### PR TITLE
Account database lock exception fixed

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -60,7 +60,12 @@ def init_database(app):
             stale_timeout=300)
     else:
         log.info('Connecting to local SQLite database')
-        db = SqliteExtDatabase(args.db, pragmas=(('journal_mode', 'WAL'), ('mmap_size', 1024 * 1024 * 32), ('cache_size', 10000), ('journal_size_limit', 1024 * 1024 * 4),))
+        db = SqliteExtDatabase(args.db,
+                               pragmas=(
+                                   ('journal_mode', 'WAL'),
+                                   ('mmap_size', 1024 * 1024 * 32),
+                                   ('cache_size', 10000),
+                                   ('journal_size_limit', 1024 * 1024 * 4),))
 
     app.config['DATABASE'] = db
     flaskDb.init_app(app)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -10,7 +10,7 @@ import gc
 import time
 import geopy
 import math
-from peewee import SqliteDatabase, InsertQuery, \
+from peewee import InsertQuery, \
     Check, CompositeKey, ForeignKeyField, \
     IntegerField, CharField, DoubleField, BooleanField, \
     DateTimeField, fn, DeleteQuery, FloatField, SQL, TextField, JOIN
@@ -18,6 +18,7 @@ from playhouse.flask_utils import FlaskDB
 from playhouse.pool import PooledMySQLDatabase
 from playhouse.shortcuts import RetryOperationalError
 from playhouse.migrate import migrate, MySQLMigrator, SqliteMigrator
+from playhouse.sqlite_ext import SqliteExtDatabase
 from datetime import datetime, timedelta
 from base64 import b64encode
 from cachetools import TTLCache
@@ -58,8 +59,8 @@ def init_database(app):
             max_connections=connections,
             stale_timeout=300)
     else:
-        log.info('Connecting to local SQLite database...')
-        db = SqliteDatabase(args.db)
+        log.info('Connecting to local SQLite database')
+        db = SqliteExtDatabase(args.db, journal_mode='WAL')
 
     app.config['DATABASE'] = db
     flaskDb.init_app(app)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -60,7 +60,7 @@ def init_database(app):
             stale_timeout=300)
     else:
         log.info('Connecting to local SQLite database')
-        db = SqliteExtDatabase(args.db, journal_mode='WAL')
+        db = SqliteExtDatabase(args.db, , pragmas=(('journal_mode', 'WAL'), ('mmap_size', 1024 * 1024 * 32), ('cache_size', 10000), ('journal_size_limit', 1024 * 1024 * 4),))
 
     app.config['DATABASE'] = db
     flaskDb.init_app(app)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -60,7 +60,7 @@ def init_database(app):
             stale_timeout=300)
     else:
         log.info('Connecting to local SQLite database')
-        db = SqliteExtDatabase(args.db, , pragmas=(('journal_mode', 'WAL'), ('mmap_size', 1024 * 1024 * 32), ('cache_size', 10000), ('journal_size_limit', 1024 * 1024 * 4),))
+        db = SqliteExtDatabase(args.db, pragmas=(('journal_mode', 'WAL'), ('mmap_size', 1024 * 1024 * 32), ('cache_size', 10000), ('journal_size_limit', 1024 * 1024 * 4),))
 
     app.config['DATABASE'] = db
     flaskDb.init_app(app)


### PR DESCRIPTION
## Description

This fix resolves the problem with SQLite and multi threading which put the accounts in cool down mode due to database lock.
## Motivation and Context

The problem arose when the function search_worker_thread could not read from the database because of the writing process. The solution was using "Write-Ahead Logging", so that the read and write process do not influence each other  - https://www.sqlite.org/wal.html
This fix also resolves the issues #1232
## How Has This Been Tested?

This has been tested with 77 workers.
`runserver.py -ns -st 100 -ss --jitter -w 77 -asi 3900 -ari 3500 -msl 875 -ac usernames.csv -l "55.402360, 10.386895" -k [gmaps-key]`
The accounts stopped going into cool down due to database lock.
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
