### PR TITLE
Retry failed scans

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -759,10 +759,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
     forts = None
     wild_pokemon = None
     pokesfound = False
+    nearbyfound = False
     fortsfound = False
 
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     for cell in cells:
+        if len(cell.get('nearby_pokemons', [])) > 0:
+            nearbyfound = True
         if config['parse_pokemon']:
             if len(cell.get('wild_pokemons', [])) > 0:
                 pokesfound = True
@@ -961,6 +964,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
     return {
         'count': skipped + stopsskipped + len(pokemons) + len(pokestops) + len(gyms),
         'gyms': gyms,
+        'nearby': nearbyfound,
+        'neargym': fortsfound,
     }
 
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -629,15 +629,16 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                         break
 
                         parsed = parse_map(args, response_dict, step_location, dbq, whq, api)
-                        search_items_queue.task_done()
                         if parsed['count'] > 0:
                             status['success'] += 1
                             consecutive_empties = 0
+                            search_items_queue.task_done()
                             break  # Break out of the retry loop, we got a good scan
                         else:
                             if parsed['nearby']:  # If we spot a nearby pokemon, we're not speed limited
                                 status['success'] += 1
                                 consecutive_empties = 0
+                                search_items_queue.task_done()
                                 break  # Break out of retry loop, good scan, just nothing here
                             else:
                                 retries += 1
@@ -646,7 +647,6 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                     consecutive_empties += 1
                                 if parsed['neargym']:
                                     status['message'] = 'Found a fort, but no pokemon. Either nothing around, or speed limited'
-                                    log.warning(status['message'])
                                 else:
                                     status['message'] = 'No nearby pokemon or forts. Either nothing around, or softbanned'
                                 log.warning(status['message'])

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -587,7 +587,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.info(status['message'])
 
                 retries = 0  # reset the retry counter
-                While retries <= 2:
+                While (retries < 3):
                     # Make the actual request. (finally!)
                     response_dict = map_request(api, step_location, args.jitter)
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -587,7 +587,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.info(status['message'])
 
                 retries = 0  # reset the retry counter
-                While retries < 3:
+                While retries <= 2:
                     # Make the actual request. (finally!)
                     response_dict = map_request(api, step_location, args.jitter)
 
@@ -652,7 +652,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                 log.warning(status['message'])
                                 time.sleep(args.scan_delay * retries)  # Wait a little longer on each retry to try and beat limiter
                                 continue  # Wait, then try scanning again
-                                
+
                         consecutive_fails = 0
                         status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], parsed['count'])
                         log.debug(status['message'])

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -587,7 +587,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.info(status['message'])
 
                 retries = 0  # reset the retry counter
-                While (retries < 3):
+                while retries < 3:
                     # Make the actual request. (finally!)
                     response_dict = map_request(api, step_location, args.jitter)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As per the speed limitation, we tend to encounter lots of failed or empty scans. This attempts to fix that by simply waiting (up to 30 seconds) to scan again. Typically gets it on the second try when the speed limiter releases but the 30 second wait is for the longer speed bans. Does not reduce captcha's though, just reduces empty scans!

Noticed 1501 checks nearby to determine an empty scan vs a speed limited scan. Decided to use them and gyms to get better empty detection. Of course if a worker is far from any stops/gyms and no pokemon around, it'll count an empty.

## Motivation and Context
Tired of hundreds of empty scans. My best worker was at 50% good scans, 50% failed. With this, you can get thousands of good scans in, and only one fail.

## How Has This Been Tested?
My personal map.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

**PS: how do you change more than one file???**