### PR TITLE
Add method to SpeedScan: getscanned() returns number of scanned steps…

### DIFF
--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -525,6 +525,9 @@ class SpeedScan(HexSearch):
     def getsize(self):
         return len(self.queues[0])
 
+    def getscanned(self):
+        return self.scans_done + len(self.scans_missed_list)
+
     def get_overseer_message(self):
         n = 0
         ms = (datetime.utcnow() - self.refresh_date).total_seconds() + self.refresh_ms


### PR DESCRIPTION
Backend: add a method to speedscan object that can be used to get progress.

## Description
usage: number_processed = scheduler.getscanned()

## Motivation and Context
It's difficult to get this value otherwise: 
>>  len(search_items_queue)
AttributeError: Queue instance has no attribute 'len'

If you try: search_items_queue.qsize() you get a reference to the Queue object, that can not easily be converted to int.

## How Has This Been Tested?
Tested on local machine

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

…. Together with getsize() it can be used to print out progress.