### PR TITLE
add time to popup notification

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -866,27 +866,6 @@ var StoreOptions = {
         default: '',
         type: StoreTypes.Number
     },
-    /*
-        text place holders:
-        <pkm> - pokemon name
-        <prc> - iv in percent without percent symbol
-        <atk> - attack as number
-        <def> - defense as number
-        <sta> - stamnia as number
-    */
-    'notify_title': {
-        default: '<pkm> <prc>% (<atk>/<def>/<sta>)',
-        type: StoreTypes.String
-    },
-    /*
-        text place holders:
-        <dist>  - disappear time
-        <udist> - time until disappear
-    */
-    'notify_text': {
-        default: 'disappear at <dist> (<udist>)',
-        type: StoreTypes.String
-    },
     'showGyms': {
         default: false,
         type: StoreTypes.Boolean

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -866,6 +866,27 @@ var StoreOptions = {
         default: '',
         type: StoreTypes.Number
     },
+    /*
+        text place holders:
+        <pkm> - pokemon name
+        <prc> - iv in percent without percent symbol
+        <atk> - attack as number
+        <def> - defense as number
+        <sta> - stamnia as number
+    */
+    'notify_title': {
+        default: '<pkm> <prc>% (<atk>/<def>/<sta>)',
+        type: StoreTypes.String
+    },
+    /*
+        text place holders:
+        <dist>  - disappear time
+        <udist> - time until disappear
+    */
+    'notify_text': {
+        default: 'disappear at <dist> (<udist>)',
+        type: StoreTypes.String
+    },
     'showGyms': {
         default: false,
         type: StoreTypes.Boolean

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -617,6 +617,50 @@ function isRangeActive(map) {
     return Store.get('showRanges')
 }
 
+function getIv (item) {
+    if (item['individual_attack'] !== null) {
+        return 100.0 * (item['individual_attack'] + item['individual_defense'] + item['individual_stamina']) / 45
+    }
+
+    return 0
+}
+
+function getTimeUntil (time) {
+    var now = +new Date()
+    var tdiff = time - now
+
+    var sec = Math.floor((tdiff / 1000) % 60)
+    var min = Math.floor((tdiff / 1000 / 60) % 60)
+    var hour = Math.floor((tdiff / (1000 * 60 * 60)) % 24)
+
+    return {
+        'total': tdiff,
+        'hour': hour,
+        'min': min,
+        'sec': sec
+    }
+}
+
+function notifyText (item) {
+    var perfection = getIv(item)
+    var ivtext = perfection.toFixed(1) + '% (' + item['individual_attack'] + '/' + item['individual_defense'] + '/' + item['individual_stamina'] + ')'
+    var dtime = new Date(item['disappear_time'])
+    var distext = ('0' + dtime.getHours()).slice(-2)
+    distext += ':'
+    distext += ('0' + dtime.getMinutes()).slice(-2)
+    distext += ':'
+    distext += ('0' + dtime.getSeconds()).slice(-2)
+    var until = getTimeUntil(item['disappear_time'])
+    var untiltext = '('
+    untiltext += (until.hour > 0) ? until.hour + ':' : ''
+    untiltext += ('0' + until.min).slice(-2) + 'm' + ('0' + until.sec).slice(-2) + 's' + ')'
+
+    return {
+        'fav_title': item['pokemon_name'] + ' ' + ivtext,
+        'fav_text': 'available until ' + distext + ' ' + untiltext
+    }
+}
+
 function customizePokemonMarker(marker, item, skipNotification) {
     marker.addListener('click', function () {
         this.setAnimation(null)
@@ -645,13 +689,13 @@ function customizePokemonMarker(marker, item, skipNotification) {
     }
 
     if (item['individual_attack'] != null) {
-        var perfection = 100.0 * (item['individual_attack'] + item['individual_defense'] + item['individual_stamina']) / 45
+        var perfection = getIv(item)
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
                 if (Store.get('playSound')) {
                     audio.play()
                 }
-                sendNotification('A ' + perfection.toFixed(1) + '% perfect ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+                sendNotification(notifyText(item).fav_title, notifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
             }
             if (marker.animationDisabled !== true) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -67,6 +67,24 @@ var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
 var gymPrestige = [2000, 4000, 8000, 12000, 16000, 20000, 30000, 40000, 50000]
 var audio = new Audio('static/sounds/ding.mp3')
 
+/*
+  text place holders:
+  <pkm> - pokemon name
+  <prc> - iv in percent without percent symbol
+  <atk> - attack as number
+  <def> - defense as number
+  <sta> - stamnia as number
+*/
+var notifyIvTitle = '<pkm> <prc>% (<atk>/<def>/<sta>)'
+var notifyNoIvTitle = '<pkm>'
+
+/*
+  text place holders:
+  <dist>  - disappear time
+  <udist> - time until disappear
+*/
+var notifyText = 'disappear at <dist> (<udist>)'
+
 //
 // Functions
 //
@@ -617,16 +635,19 @@ function isRangeActive(map) {
     return Store.get('showRanges')
 }
 
-function getIv (item) {
-    if (item['individual_attack'] !== null) {
-        return 100.0 * (item['individual_attack'] + item['individual_defense'] + item['individual_stamina']) / 45
+function getIv(atk, def, stm) {
+    if (atk !== null) {
+        return 100.0 * (atk + def + stm) / 45
+    }
+
+    return false
 }
 
-function lpad (str, len, padstr) {
+function lpad(str, len, padstr) {
     return Array(Math.max(len - String(str).length + 1, 0)).join(padstr) + str
 }
 
-function repArray (text, find, replace) {
+function repArray(text, find, replace) {
     for (var i = 0; i < find.length; i++) {
         text = text.replace(find[i], replace[i])
     }
@@ -634,32 +655,7 @@ function repArray (text, find, replace) {
     return text
 }
 
-function notifyText (item) {
-    var iv = getIv(item)
-    var find = ['<prc>', '<pkm>', '<atk>', '<def>', '<sta>']
-    var replace = [iv.toFixed(1), item['pokemon_name'], item['individual_attack'],
-        item['individual_defense'], item['individual_stamina']]
-    var ntitle = repArray(Store.get('notify_title'), find, replace)
-    var dtime = new Date(item['disappear_time'])
-    var dist = lpad(dtime.getHours(), 2, 0)
-    dist += ':'
-    dist += lpad(dtime.getMinutes(), 2, 0)
-    dist += ':'
-    dist += lpad(dtime.getSeconds(), 2, 0)
-    var until = getTimeUntil(item['disappear_time'])
-    var udist = (until.hour > 0) ? until.hour + ':' : ''
-    udist += lpad(until.min, 2, 0) + 'm' + lpad(until.sec, 2, 0) + 's'
-    find = ['<dist>', '<udist>']
-    replace = [dist, udist]
-    var ntext = repArray(Store.get('notify_text'), find, replace)
-
-    return {
-        'fav_title': ntitle,
-        'fav_text': ntext
-    }
-}
-
-function getTimeUntil (time) {
+function getTimeUntil(time) {
     var now = +new Date()
     var tdiff = time - now
 
@@ -671,7 +667,31 @@ function getTimeUntil (time) {
         'total': tdiff,
         'hour': hour,
         'min': min,
-        'sec': sec
+        'sec': sec,
+        'now': now,
+        'ttime': time
+    }
+}
+
+function getNotifyText(item) {
+    var iv = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
+    var find = ['<prc>', '<pkm>', '<atk>', '<def>', '<sta>']
+    var replace = [((iv) ? iv.toFixed(1) : ''), item['pokemon_name'], item['individual_attack'],
+        item['individual_defense'], item['individual_stamina']]
+    var ntitle = repArray(((iv) ? notifyIvTitle : notifyNoIvTitle), find, replace)
+    var dist = (new Date(item['disappear_time'])).toLocaleString([], {
+        hour: '2-digit', minute: '2-digit',
+        second: '2-digit', hour12: false})
+    var until = getTimeUntil(item['disappear_time'])
+    var udist = (until.hour > 0) ? until.hour + ':' : ''
+    udist += lpad(until.min, 2, 0) + 'm' + lpad(until.sec, 2, 0) + 's'
+    find = ['<dist>', '<udist>']
+    replace = [dist, udist]
+    var ntext = repArray(notifyText, find, replace)
+
+    return {
+        'fav_title': ntitle,
+        'fav_text': ntext
     }
 }
 
@@ -695,7 +715,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
             if (Store.get('playSound')) {
                 audio.play()
             }
-            sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+            sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
         }
         if (marker.animationDisabled !== true) {
             marker.setAnimation(google.maps.Animation.BOUNCE)
@@ -703,13 +723,13 @@ function customizePokemonMarker(marker, item, skipNotification) {
     }
 
     if (item['individual_attack'] != null) {
-        var perfection = getIv(item)
+        var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
                 if (Store.get('playSound')) {
                     audio.play()
                 }
-                sendNotification(notifyText(item).fav_title, notifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+                sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
             }
             if (marker.animationDisabled !== true) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
@@ -1441,16 +1461,14 @@ function redrawPokemon(pokemonList) {
 
 var updateLabelDiffTime = function () {
     $('.label-countdown').each(function (index, element) {
-        var disappearsAt = new Date(parseInt(element.getAttribute('disappears-at')))
-        var now = new Date()
+        var disappearsAt = getTimeUntil(parseInt(element.getAttribute('disappears-at')))
 
-        var difference = Math.abs(disappearsAt - now)
-        var hours = Math.floor(difference / 36e5)
-        var minutes = Math.floor((difference - (hours * 36e5)) / 6e4)
-        var seconds = Math.floor((difference - (hours * 36e5) - (minutes * 6e4)) / 1e3)
+        var hours = disappearsAt.hour
+        var minutes = disappearsAt.min
+        var seconds = disappearsAt.sec
         var timestring = ''
 
-        if (disappearsAt < now) {
+        if (disappearsAt.ttime < disappearsAt.now) {
             timestring = '(expired)'
         } else {
             timestring = '('
@@ -1458,8 +1476,8 @@ var updateLabelDiffTime = function () {
                 timestring = hours + 'h'
             }
 
-            timestring += ('0' + minutes).slice(-2) + 'm'
-            timestring += ('0' + seconds).slice(-2) + 's'
+            timestring += lpad(minutes, 2, 0) + 'm'
+            timestring += lpad(seconds, 2, 0) + 's'
             timestring += ')'
         }
 
@@ -1732,7 +1750,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
 
         if (result.pokemon.length) {
             $.each(result.pokemon, function (i, pokemon) {
-                var perfectPercent = Math.round((pokemon.iv_defense + pokemon.iv_attack + pokemon.iv_stamina) * 100 / 45)
+                var perfectPercent = getIv(pokemon.iv_attack, pokemon.iv_defense, pokemon.iv_stamina)
                 var moveEnergy = Math.round(100 / pokemon.move_2_energy)
 
                 pokemonHtml += `

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -620,9 +620,43 @@ function isRangeActive(map) {
 function getIv (item) {
     if (item['individual_attack'] !== null) {
         return 100.0 * (item['individual_attack'] + item['individual_defense'] + item['individual_stamina']) / 45
+}
+
+function lpad (str, len, padstr) {
+    return Array(Math.max(len - String(str).length + 1, 0)).join(padstr) + str
+}
+
+function repArray (text, find, replace) {
+    for (var i = 0; i < find.length; i++) {
+        text = text.replace(find[i], replace[i])
     }
 
-    return 0
+    return text
+}
+
+function notifyText (item) {
+    var iv = getIv(item)
+    var find = ['<prc>', '<pkm>', '<atk>', '<def>', '<sta>']
+    var replace = [iv.toFixed(1), item['pokemon_name'], item['individual_attack'],
+        item['individual_defense'], item['individual_stamina']]
+    var ntitle = repArray(Store.get('notify_title'), find, replace)
+    var dtime = new Date(item['disappear_time'])
+    var dist = lpad(dtime.getHours(), 2, 0)
+    dist += ':'
+    dist += lpad(dtime.getMinutes(), 2, 0)
+    dist += ':'
+    dist += lpad(dtime.getSeconds(), 2, 0)
+    var until = getTimeUntil(item['disappear_time'])
+    var udist = (until.hour > 0) ? until.hour + ':' : ''
+    udist += lpad(until.min, 2, 0) + 'm' + lpad(until.sec, 2, 0) + 's'
+    find = ['<dist>', '<udist>']
+    replace = [dist, udist]
+    var ntext = repArray(Store.get('notify_text'), find, replace)
+
+    return {
+        'fav_title': ntitle,
+        'fav_text': ntext
+    }
 }
 
 function getTimeUntil (time) {
@@ -638,26 +672,6 @@ function getTimeUntil (time) {
         'hour': hour,
         'min': min,
         'sec': sec
-    }
-}
-
-function notifyText (item) {
-    var perfection = getIv(item)
-    var ivtext = perfection.toFixed(1) + '% (' + item['individual_attack'] + '/' + item['individual_defense'] + '/' + item['individual_stamina'] + ')'
-    var dtime = new Date(item['disappear_time'])
-    var distext = ('0' + dtime.getHours()).slice(-2)
-    distext += ':'
-    distext += ('0' + dtime.getMinutes()).slice(-2)
-    distext += ':'
-    distext += ('0' + dtime.getSeconds()).slice(-2)
-    var until = getTimeUntil(item['disappear_time'])
-    var untiltext = '('
-    untiltext += (until.hour > 0) ? until.hour + ':' : ''
-    untiltext += ('0' + until.min).slice(-2) + 'm' + ('0' + until.sec).slice(-2) + 's' + ')'
-
-    return {
-        'fav_title': item['pokemon_name'] + ' ' + ivtext,
-        'fav_text': 'available until ' + distext + ' ' + untiltext
     }
 }
 


### PR DESCRIPTION
## Description
This PR improve the popup-notification with IV, disappear-time and time until disappear.

## Motivation and Context
I've saw a lot this popup notification but had always to click on it to get information about this pokemon.
to improve this behaivoir i added the useful information directly to the popup-notification

## How Has This Been Tested?
This PR i've tested on my own Map in different cities. Running since day one of my own Map without any issue.

```
4.4.26-gentoo
Python 2.7.12
pip 7.1.2 from /usr/lib64/python2.7/site-packages (python 2.7)
```

## Screenshots (if appropriate):
![popupnoty](https://cloud.githubusercontent.com/assets/7890628/21462124/96dd093c-c958-11e6-8c90-35e63378b12e.jpg)
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ `x`] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ `x`] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
