### PR TITLE
Changed start location for Get Directions link

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -370,8 +370,7 @@ function getTypeSpan(type) {
 }
 
 function openMapDirections(lat, lng) { // eslint-disable-line no-unused-vars
-    var myLocation = locationMarker.getPosition()
-    var url = 'https://www.google.com/maps/dir/' + myLocation.lat() + ',' + myLocation.lng() + '/' + lat + ',' + lng
+    var url = 'https://www.google.com/maps/dir/Current+Location/' + lat + ',' + lng
     window.open(url, '_blank')
 }
 


### PR DESCRIPTION
## Description
Changed the starting location of the "Get Directions" map link to use the users' current location.

## Motivation and Context
The current implementation of the "Get Directions" link uses the position of the location marker; however, most users don't make use of that feature and just want directions from where they physically are.

## How Has This Been Tested?
My maps

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
