### PR TITLE
Fixed an error in the -tut where the buddy pokemon was not being set.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -819,18 +819,14 @@ def complete_tutorial(api, account, tutorial_state):
 
         time.sleep(random.uniform(0.5, 0.6))
         request = api.create_request()
-        request.get_player(
-            player_locale={
-                'country': 'US',
-                'language': 'en',
-                'timezone': 'America/Denver'})
+        request.get_inventory()
         responses = request.call().get('responses', {})
 
         inventory = responses.get('GET_INVENTORY', {}).get(
             'inventory_delta', {}).get('inventory_items', [])
         for item in inventory:
             pokemon = item.get('inventory_item_data', {}).get('pokemon_data')
-            if pokemon:
+            if pokemon and pokemon.get('move_1'):
                 starter_id = pokemon.get('id')
 
     if 4 not in tutorial_state:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed an error where -tut was not setting the buddy pokemon.
## Description
<!--- Describe your changes in detail -->
In the -tut phase, when the starter pokemon is caught, this change will set the starter to be the buddy.  I've also modified so that the logic only looks for pokemon.  The id field is in several different pieces of the inventory object.   As such, I added it so that the logic specifically looks for the "move_1" to make sure that we are only grabbing the id from an actual pokemon.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This logic was in the code already, but was not working correctly.   As such, I am fixing it to set the buddy pokemon correctly.   This was determined by using many different accounts both new and previously used in mapping created by ptc-acc-gen and pikaptcha.   All mechanisms were exhibiting the same bug.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested this locally, running -tut on my fork to make sure the buddy is correctly set.  I've loaded the accounts on a test device to verify that the buddy is set correctly now.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
