### PR TITLE
Add spawnpoint type to pokemon webhook data.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1574,7 +1574,7 @@ def hex_bounds(center, steps=None, radius=None):
 
 # todo: this probably shouldn't _really_ be in "models" anymore, but w/e.
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
-              api, now_date):
+              api, now_date, tth_found_pct):
     pokemon = {}
     pokestops = {}
     gyms = {}
@@ -1789,7 +1789,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'disappear_time': calendar.timegm(
                         disappear_time.timetuple()),
                     'last_modified_time': p['last_modified_timestamp_ms'],
-                    'time_until_hidden_ms': p['time_till_hidden_ms']
+                    'time_until_hidden_ms': p['time_till_hidden_ms'],
+                    'tth_found': tth_found_pct
                 })
                 wh_update_queue.put(('pokemon', wh_poke))
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1574,7 +1574,7 @@ def hex_bounds(center, steps=None, radius=None):
 
 # todo: this probably shouldn't _really_ be in "models" anymore, but w/e.
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
-              api, now_date, tth_found_pct):
+              api, now_date):
     pokemon = {}
     pokestops = {}
     gyms = {}
@@ -1790,7 +1790,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         disappear_time.timetuple()),
                     'last_modified_time': p['last_modified_timestamp_ms'],
                     'time_until_hidden_ms': p['time_till_hidden_ms'],
-                    'tth_found': tth_found_pct
+                    'verified': SpawnPoint.tth_found(sp)
                 })
                 wh_update_queue.put(('pokemon', wh_poke))
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -514,15 +514,23 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         time.sleep(1)
 
 
+def get_scheduler_tth_found_pct(scheduler):
+    tth_found_pct = getattr(scheduler, 'tth_found', 0)
+
+    if tth_found_pct > 0:
+        # Avoid division by zero. Keep 0.0 default for consistency.
+        active_sp = max(getattr(scheduler, 'active_sp', 0.0), 1.0)
+        tth_found_pct = tth_found_pct * 100.0 / float(active_sp)
+
+    return tth_found_pct
+
+
 def wh_status_update(args, status, wh_queue, scheduler):
     scheduler_name = status['scheduler']
+
     if args.speed_scan:
-        tth_found = getattr(scheduler, 'tth_found', -1)
+        tth_found = get_scheduler_tth_found_pct(scheduler)
         spawns_found = getattr(scheduler, 'spawns_found', 0)
-        if tth_found > -1:
-            # Avoid division by zero. Keep 0.0 default for consistency.
-            active_sp = max(getattr(scheduler, 'active_sp', 0.0), 1.0)
-            tth_found = tth_found * 100.0 / float(active_sp)
 
         if (tth_found - status['scheduler_status']['tth_found']) > 0.01:
             log.debug("Scheduler update is due, sending webhook message.")
@@ -979,7 +987,8 @@ def search_worker_thread(args, account_queue, account_failures,
                             break
 
                     parsed = parse_map(args, response_dict, step_location,
-                                       dbq, whq, api, scan_date)
+                                       dbq, whq, api, scan_date,
+                                       get_scheduler_tth_found_pct(scheduler))
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -987,8 +987,7 @@ def search_worker_thread(args, account_queue, account_failures,
                             break
 
                     parsed = parse_map(args, response_dict, step_location,
-                                       dbq, whq, api, scan_date,
-                                       get_scheduler_tth_found_pct(scheduler))
+                                       dbq, whq, api, scan_date)
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1


### PR DESCRIPTION
## Description
Moved some duplicate code out to its own function, and included spawnpoint type in the pokémon data being sent.

## Motivation and Context
Sending tth_found only in `scheduler` webhook messages isn't enough: timing doesn't always match, and we can't guarantee we can match pokémon spawn data with `scheduler` messages, so we can't retrieve the exact type (spawnpoint status).

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
