### PR TITLE
Allow encounter white/blacklist to be specified by name in a file

### DIFF
--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -8,7 +8,7 @@
                         [-st STEP_LIMIT] [-sd SCAN_DELAY]
                         [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
                         [-cds CAPTCHA_DSK] [-ed ENCOUNTER_DELAY]
-                        [-ewht ENCOUNTER_WHITELIST | -eblk ENCOUNTER_BLACKLIST]
+                        [-ewht ENCOUNTER_WHITELIST | -eblk ENCOUNTER_BLACKLIST | -ewhtf ENCOUNTER_WHITELIST_FILE | -eblkf ENCOUNTER_BLACKLIST_FILE]
                         [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
                         [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
                         [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
@@ -114,6 +114,14 @@
       -eblk ENCOUNTER_BLACKLIST, --encounter-blacklist ENCOUNTER_BLACKLIST
                             List of Pokemon to NOT encounter for more stats. [env
                             var: POGOMAP_ENCOUNTER_BLACKLIST]
+      -ewhtf ENCOUNTER_WHITELIST_FILE, --encounter-whitelist-file ENCOUNTER_WHITELIST_FILE
+                            File containing a list of Pokemon to encounter for
+                            more stats. [env var:
+                            POGOMAP_ENCOUNTER_WHITELIST_FILE]
+      -eblkf ENCOUNTER_BLACKLIST_FILE, --encounter-blacklist-file ENCOUNTER_BLACKLIST_FILE
+                            File containing a list of Pokemon to encounter for
+                            more stats. [env var:
+                            POGOMAP_ENCOUNTER_BLACKLIST_FILE]
       -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
                             Time delay between each login attempt. [env var:
                             POGOMAP_LOGIN_DELAY]

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -115,11 +115,11 @@
                             List of Pokemon to NOT encounter for more stats. [env
                             var: POGOMAP_ENCOUNTER_BLACKLIST]
       -ewhtf ENCOUNTER_WHITELIST_FILE, --encounter-whitelist-file ENCOUNTER_WHITELIST_FILE
-                            File containing a list of Pokemon to encounter for
+                            File containing a list of Pokemon to NOT encounter for
                             more stats. [env var:
                             POGOMAP_ENCOUNTER_WHITELIST_FILE]
       -eblkf ENCOUNTER_BLACKLIST_FILE, --encounter-blacklist-file ENCOUNTER_BLACKLIST_FILE
-                            File containing a list of Pokemon to encounter for
+                            File containing a list of Pokemon to NOT encounter for
                             more stats. [env var:
                             POGOMAP_ENCOUNTER_BLACKLIST_FILE]
       -ld LOGIN_DELAY, --login-delay LOGIN_DELAY

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -132,6 +132,14 @@ def get_args():
                                 action='append', default=[],
                                 help=('List of Pokemon to NOT encounter for ' +
                                       'more stats.'))
+    encounter_list.add_argument('-ewhtf', '--encounter-whitelist-file',
+                                default='', help='File containing a list of ' +
+                                                 'Pokemon to encounter for ' +
+                                                 'more stats.')
+    encounter_list.add_argument('-eblkf', '--encounter-blacklist-file',
+                                default='', help='File containing a list of ' +
+                                                 'Pokemon to encounter for ' +
+                                                 'more stats.')
     parser.add_argument('-ld', '--login-delay',
                         help='Time delay between each login attempt.',
                         type=float, default=6)
@@ -572,8 +580,19 @@ def get_args():
                   "--accountcsv to add accounts.")
             sys.exit(1)
 
-        args.encounter_blacklist = [int(i) for i in args.encounter_blacklist]
-        args.encounter_whitelist = [int(i) for i in args.encounter_whitelist]
+        if args.encounter_whitelist_file:
+            with open(args.encounter_whitelist_file) as f:
+                args.encounter_whitelist = [get_pokemon_id(name) for name in
+                                            f.read().splitlines()]
+        elif args.encounter_blacklist_file:
+            with open(args.encounter_blacklist_file) as f:
+                args.encounter_blacklist = [get_pokemon_id(name) for name in
+                                            f.read().splitlines()]
+        else:
+            args.encounter_blacklist = [int(i) for i in
+                                        args.encounter_blacklist]
+            args.encounter_whitelist = [int(i) for i in
+                                        args.encounter_whitelist]
 
         # Decide which scanning mode to use.
         if args.spawnpoint_scanning:
@@ -674,6 +693,19 @@ def get_pokemon_data(pokemon_id):
         with open(file_path, 'r') as f:
             get_pokemon_data.pokemon = json.loads(f.read())
     return get_pokemon_data.pokemon[str(pokemon_id)]
+
+
+def get_pokemon_id(pokemon_name):
+    if not hasattr(get_pokemon_id, 'ids'):
+        if not hasattr(get_pokemon_data, 'pokemon'):
+            # initialize from file
+            get_pokemon_data(1)
+
+        get_pokemon_id.ids = {}
+        for pokemon_id, data in get_pokemon_data.pokemon.iteritems():
+            get_pokemon_id.ids[data['name']] = int(pokemon_id)
+
+    return get_pokemon_id.ids.get(pokemon_name, -1)
 
 
 def get_pokemon_name(pokemon_id):

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -133,13 +133,13 @@ def get_args():
                                 help=('List of Pokemon to NOT encounter for ' +
                                       'more stats.'))
     encounter_list.add_argument('-ewhtf', '--encounter-whitelist-file',
-                                default='', help='File containing a list of ' +
-                                                 'Pokemon to encounter for ' +
-                                                 'more stats.')
+                                default='', help='File containing a list of '
+                                                 'Pokemon to NOT encounter for'
+                                                 ' more stats.')
     encounter_list.add_argument('-eblkf', '--encounter-blacklist-file',
-                                default='', help='File containing a list of ' +
-                                                 'Pokemon to encounter for ' +
-                                                 'more stats.')
+                                default='', help='File containing a list of '
+                                                 'Pokemon to NOT encounter for'
+                                                 ' more stats.')
     parser.add_argument('-ld', '--login-delay',
                         help='Time delay between each login attempt.',
                         type=float, default=6)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import unittest
+from pogom import utils
+
+
+class UtilsTest(unittest.TestCase):
+    def test_get_pokemon_id(self):
+        self.assertEqual(1, utils.get_pokemon_id("Bulbasaur"))
+        self.assertEqual(149, utils.get_pokemon_id("Dragonite"))
+
+        # Unknown name returns -1
+        self.assertEqual(-1, utils.get_pokemon_id("Unknown"))
+
+    def test_get_pokemon_name(self):
+        self.assertEqual("Bulbasaur", utils.get_pokemon_name(1))
+        self.assertEqual("Dragonite", utils.get_pokemon_name(149))
+
+        # Unknown ID raises KeyError
+        self.assertRaises(KeyError, utils.get_pokemon_name, 12367)


### PR DESCRIPTION
## Description
Allow for a file to be used for specifying encounter white/blacklist. Each line represents a pokemon.

## Motivation and Context
In order to easily organize and be able to change list of which pokemon to trigger encounters for, it'd be good to be able to specify them by name and in a separate file.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
