### PR TITLE
Major webhook rework.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -314,6 +314,9 @@ def get_args():
                         help=('Number of webhook threads; increase if the ' +
                               'webhook queue falls behind.'),
                         type=int, default=1)
+    parser.add_argument('-whc', '--wh-concurrency',
+                        help=('Async requests pool size.'), type=int,
+                        default=10)
     parser.add_argument('-whr', '--wh-retries',
                         help=('Number of times to retry sending webhook ' +
                               'data on failure.'),

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -316,14 +316,14 @@ def get_args():
                         type=int, default=1)
     parser.add_argument('-whc', '--wh-concurrency',
                         help=('Async requests pool size.'), type=int,
-                        default=10)
+                        default=25)
     parser.add_argument('-whr', '--wh-retries',
                         help=('Number of times to retry sending webhook ' +
                               'data on failure.'),
-                        type=int, default=5)
+                        type=int, default=3)
     parser.add_argument('-wht', '--wh-timeout',
                         help='Timeout (in seconds) for webhook requests.',
-                        type=int, default=2)
+                        type=float, default=1.0)
     parser.add_argument('-whbf', '--wh-backoff-factor',
                         help=('Factor (in seconds) by which the delay ' +
                               'until next retry will increase.'),

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -136,6 +136,8 @@ def __get_requests_session(args):
                                           pool_connections=pool_size,
                                           pool_maxsize=pool_size))
 
+    return session
+
 
 def __get_key_fields(whtype):
     key_fields = {

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -97,23 +97,24 @@ def wh_updater(args, queue, key_cache):
                                   whtype, ident)
 
             # Webhook queue moving too slow.
-            if not wh_over_threshold and queue.qsize() > wh_warning_threshold:
+            if (not wh_over_threshold) and (
+                    queue.qsize() > wh_warning_threshold):
                 wh_over_threshold = True
                 wh_threshold_timer = datetime.now()
             elif wh_over_threshold:
-                timediff = datetime.now() - wh_threshold_timer
+                if queue.qsize() < wh_warning_threshold:
+                    wh_over_threshold = False
+                else:
+                    timediff = datetime.now() - wh_threshold_timer
 
-                if timediff.total_seconds() > wh_threshold_lifetime:
-                    log.warning('Webhook queue has been > %d (@%d);'
-                                + ' for over %d seconds,'
-                                + ' try increasing --wh-concurrency'
-                                + ' or --wh-threads.',
-                                wh_warning_threshold,
-                                queue.qsize(),
-                                wh_threshold_lifetime)
-            else:
-                # Not over max queue size. Reset flag.
-                wh_over_threshold = False
+                    if timediff.total_seconds() > wh_threshold_lifetime:
+                        log.warning('Webhook queue has been > %d (@%d);'
+                                    + ' for over %d seconds,'
+                                    + ' try increasing --wh-concurrency'
+                                    + ' or --wh-threads.',
+                                    wh_warning_threshold,
+                                    queue.qsize(),
+                                    wh_threshold_lifetime)
 
             queue.task_done()
         except Exception as e:

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -129,8 +129,12 @@ def __get_requests_session(args):
                     status_forcelist=[500, 502, 503, 504])
 
     # Mount handler on both HTTP & HTTPS.
-    session.mount('http://', HTTPAdapter(max_retries=retries))
-    session.mount('https://', HTTPAdapter(max_retries=retries))
+    session.mount('http://', HTTPAdapter(max_retries=retries,
+                                         pool_connections=pool_size,
+                                         pool_maxsize=pool_size))
+    session.mount('https://', HTTPAdapter(max_retries=retries,
+                                          pool_connections=pool_size,
+                                          pool_maxsize=pool_size))
 
 
 def __get_key_fields(whtype):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
 requests==2.10.0
+requests-futures==0.9.7
 PySocks==1.5.6
 git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust
 cachetools==2.0.0


### PR DESCRIPTION
## Description
Changes how webhooks work (also made them thread safe), how requests are sent, and how we determine when the queue isn't being processed fast enough and the user should increase settings.

**From now on, it is highly recommended to leave `--wh-threads` at `1` (default).** If you have some sort of crazy setup and you infinitely get the error `try increasing --wh-concurrency or --wh-threads` (i.e. the queue never goes below 100), increase `--wh-concurrency`. If you need more than `--wh-concurrency 50`, you can consider adding an additional thread.

**Seeing the error once is fine.** Please don't increase anything if you see the error once and it instantly goes away. Only when the error never goes away, you should increase concurrency (as explained above).

**Changes:**

1. Optimized default settings (1s timeout, 3 retries instead of 5).
2. Made webhooks thread safe again. This fixes infinite queuing on LFUCache error.
3. Reworked the queue size error to use time: it will only log an error if the queue size has been over the limit for at least 5 seconds.
4. Moved synchronous `requests` to asynchronous `requests_futures`.
5. We now use a single Session object instead of creating one per request. This is not only more efficient in terms of re-using objects; requests to the same hosts will re-use the same underlying TCP connection instead of requiring a new one.

## Motivation and Context
Gives major performance increase, better throughput, and rather than requiring 25 threads, the test now only needed a single thread and default settings to keep the queue empty.

## How Has This Been Tested?
Tested extensively with Barlok on a large setup (st 26, w 100) and intentionally with two receiving webhook servers rather than only one.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
