### PR TITLE
fix forgotten round in gym

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1795,7 +1795,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
                                 <div class="iv" style="width: 36px;"">
                                     <div class="type">PERFECT</div>
                                     <div class="value">
-                                        ${perfectPercent}<span style="font-size: .6em;">%</span>
+                                        ${perfectPercent.toFixed(0)}<span style="font-size: .6em;">%</span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Description
Fix for forgotten rounding in Gym-Sidebar.

## Motivation and Context
It fixes an forgotten rounding in Gym-Details

## How Has This Been Tested?
On my own Map

## Screenshots (if appropriate):
Before:
![gym_false](https://cloud.githubusercontent.com/assets/7890628/22403520/ecd69db6-e619-11e6-9275-b286f78e613b.jpg)
After:
![gym_true](https://cloud.githubusercontent.com/assets/7890628/22403535/6f6ebd76-e61a-11e6-8dbc-7164f9432e67.jpg)



## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
