### PR TITLE
Display hash key expiration date on hash key status page (-PS)

### DIFF
--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -1076,7 +1076,8 @@ class KeyScheduler(object):
             self.keys[key] = {
                 'remaining': 0,
                 'maximum': 0,
-                'peak': 0
+                'peak': 0,
+                'expires': 'N/A'
             }
 
         self.key_cycle = itertools.cycle(keys)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -27,6 +27,7 @@ import time
 import copy
 
 from datetime import datetime
+from dateutil import tz
 from threading import Thread, Lock
 from queue import Queue, Empty
 from sets import Set
@@ -243,14 +244,16 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
 
         elif display_type[0] == 'hashstatus':
             status_text.append(
-                '----------------------------------------------------------')
+                '----------------------------------------------------------' + 
+                '---------------------')
             status_text.append('Hash key status:')
             status_text.append(
-                '----------------------------------------------------------')
+                '----------------------------------------------------------' + 
+                '---------------------')
 
-            status = '{:21} | {:9} | {:9} | {:9}'
+            status = '{:21} | {:9} | {:9} | {:9} | {:20}'
             status_text.append(status.format('Key', 'Remaining', 'Maximum',
-                                             'Peak'))
+                                             'Peak', 'Expires'))
 
             for key in hash_key:
                 key_instance = key_scheduler.keys[key]
@@ -263,7 +266,8 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
                     key_text,
                     key_instance['remaining'],
                     key_instance['maximum'],
-                    key_instance['peak']))
+                    key_instance['peak'],
+                    key_instance['expires']))
 
         # Print the status_text for the current screen.
         status_text.append((
@@ -1103,6 +1107,23 @@ def search_worker_thread(args, account_queue, account_failures,
 
                     if key_instance['peak'] < peak:
                         key_instance['peak'] = peak
+
+                    if key_instance['expires'] == 'N/A':
+                        expires = HashServer.status.get(
+                            'expiration', 'N/A')
+
+                        if expires <> 'N/A':
+                            expires = datetime.utcfromtimestamp(
+                                int(expires))
+                                
+                            from_zone = tz.tzutc()
+                            to_zone = tz.tzlocal()
+                            
+                            expires = expires.replace(tzinfo=from_zone)
+                            expires = expires.astimezone(to_zone)
+                            expires = expires.strftime('%Y-%m-%d %H:%M:%S')
+                            
+                        key_instance['expires'] = expires
 
                 # Delay the desired amount after "scan" completion.
                 delay = scheduler.delay(status['last_scan_date'])

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -244,11 +244,11 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
 
         elif display_type[0] == 'hashstatus':
             status_text.append(
-                '----------------------------------------------------------' + 
+                '----------------------------------------------------------' +
                 '---------------------')
             status_text.append('Hash key status:')
             status_text.append(
-                '----------------------------------------------------------' + 
+                '----------------------------------------------------------' +
                 '---------------------')
 
             status = '{:21} | {:9} | {:9} | {:9} | {:20}'
@@ -1112,17 +1112,17 @@ def search_worker_thread(args, account_queue, account_failures,
                         expires = HashServer.status.get(
                             'expiration', 'N/A')
 
-                        if expires <> 'N/A':
+                        if expires != 'N/A':
                             expires = datetime.utcfromtimestamp(
                                 int(expires))
-                                
+
                             from_zone = tz.tzutc()
                             to_zone = tz.tzlocal()
-                            
+
                             expires = expires.replace(tzinfo=from_zone)
                             expires = expires.astimezone(to_zone)
                             expires = expires.strftime('%Y-%m-%d %H:%M:%S')
-                            
+
                         key_instance['expires'] = expires
 
                 # Delay the desired amount after "scan" completion.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1095,7 +1095,7 @@ def search_worker_thread(args, account_queue, account_failures,
                                        whq, dbq)
 
                 if args.hash_key:
-                    key_instance = key_scheduler.keys[key_scheduler.current()]
+                    key_instance = key_scheduler.keys[key]
                     key_instance['remaining'] = HashServer.status.get(
                         'remaining', 0)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ requests-futures==0.9.7
 PySocks==1.5.6
 git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust
 cachetools==2.0.0
+python-dateutil==1.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With the release 0.55 pgoapi, a new status was included to show the expiration of hash keys.  This will add a new column called "Expires" to the hash key status page on -PS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Show when keys expire in local time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local maps.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
