### PR TITLE
Fix sprite image

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2149,8 +2149,7 @@ $(function () {
         })
         $selectRarityNotify.select2({
             placeholder: i8ln('Select Rarity'),
-            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare')],
-            templateResult: formatState
+            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare')]
         })
 
         // setup list change behavior now that we have the list to work from


### PR DESCRIPTION
Sprite images was removed from "Notify of Rarity" option.

## Description
Bulbasaur appears in front of Common, Uncommon, Rare, Very Rare and Ultra Rare when proposals are shown for "Notify of Rarity". I have removed Sprite images from those options as it seemed wrong to me.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
