### PR TITLE
Fix no nearby pokemon warning if --no-pokemon is used

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1720,10 +1720,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             log.info('Common causes: captchas or IP bans.')
             abandon_loc = True
         else:
-            # No wild or nearby Pokemon but there are forts.  It's probably
-            # a speed violation.
-            log.warning('No nearby or wild Pokemon but there are visible gyms '
-                        'or pokestops. Possible speed violation.')
+            if not args.no_pokemon:
+                # No wild or nearby Pokemon but there are forts.  It's probably
+                # a speed violation.
+                log.warning('No nearby or wild Pokemon but there are visible '
+                            'gyms or pokestops. Possible speed violation.')
             if not (config['parse_pokestops'] or config['parse_gyms']):
                 # If we're not going to parse the forts, then we'll just
                 # exit here.


### PR DESCRIPTION
## Description
Reopen of #1708 
- If you scan with --no-pokemon option you don't care for pokemon and there is no speed limit for gyms/stops
  - suppress the warning (`No nearby or wild Pokemon but there are visible gyms or pokestops. Possible speed violation.`) if scanning with --no-pokemon

## Motivation and Context
Annoying message which is incorrect in case of no_pokemon

## How Has This Been Tested?
my map gym/stop scanner

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.