### PR TITLE
Quick fix for reCaptcha page stats refresh

### DIFF
--- a/templates/inject.js
+++ b/templates/inject.js
@@ -72,6 +72,6 @@ setInterval(function() {
         setTimeout(refreshStats, 1000);
     } else {
         $('#timer').html('<strong>' + timer.toString() + '</strong> seconds until refresh.');
-        setTimeout(refreshStats, 1000);
+        setTimeout(refreshStats, 2500);
     }
 }, 1000);

--- a/templates/inject.js
+++ b/templates/inject.js
@@ -72,5 +72,6 @@ setInterval(function() {
         setTimeout(refreshStats, 1000);
     } else {
         $('#timer').html('<strong>' + timer.toString() + '</strong> seconds until refresh.');
+        setTimeout(refreshStats, 1000);
     }
 }, 1000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a quick fix until @neskk full fix of #1796 is ready.

## Description
<!--- Describe your changes in detail -->
Updates stats every second. Increase the updating by changing ``2500`` (2.5 s) to an higher number yourself, this number reflects the interval in milliseconds.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
reCaptcha page stats failed to update and turned to zero.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my local machine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
