### PR TITLE
Fix issue that made TooManyLoginAttempts to never be raised

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -27,7 +27,7 @@ def check_login(args, account, api, position, proxy_url):
 
     # Try to login. Repeat a few times, but don't get stuck here.
     i = 0
-    while i < args.login_retries:
+    while i <= args.login_retries:
         try:
             if proxy_url:
                 api.set_authentication(
@@ -42,15 +42,19 @@ def check_login(args, account, api, position, proxy_url):
                     password=account['password'])
             break
         except AuthException:
-            if i >= args.login_retries:
-                raise TooManyLoginAttempts('Exceeded login attempts.')
-            else:
-                i += 1
-                log.error(
-                    ('Failed to login to Pokemon Go with account %s. ' +
-                     'Trying again in %g seconds.'),
-                    account['username'], args.login_delay)
-                time.sleep(args.login_delay)
+            i += 1
+            log.error(
+                ('Failed to login to Pokemon Go with account %s. ' +
+                 'Trying again in %g seconds.'),
+                account['username'], args.login_delay)
+            time.sleep(args.login_delay)
+
+    if i > args.login_retries:
+        log.error(
+            ('Failed to login to Pokemon Go with account %s in ' +
+             '%d tries. Giving up.'),
+            account['username'], i)
+        raise TooManyLoginAttempts('Exceeded login attempts.')
 
     log.debug('Login for account %s successful.', account['username'])
     time.sleep(20)

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -27,7 +27,8 @@ def check_login(args, account, api, position, proxy_url):
 
     # Try to login. Repeat a few times, but don't get stuck here.
     i = 0
-    while i <= args.login_retries:
+    # One initial try + login_retries.
+    while i < (args.login_retries + 1):
         try:
             if proxy_url:
                 api.set_authentication(

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -26,9 +26,9 @@ def check_login(args, account, api, position, proxy_url):
             return
 
     # Try to login. Repeat a few times, but don't get stuck here.
-    i = 0
+    num_tries = 0
     # One initial try + login_retries.
-    while i < (args.login_retries + 1):
+    while num_tries < (args.login_retries + 1):
         try:
             if proxy_url:
                 api.set_authentication(
@@ -43,18 +43,18 @@ def check_login(args, account, api, position, proxy_url):
                     password=account['password'])
             break
         except AuthException:
-            i += 1
+            num_tries += 1
             log.error(
                 ('Failed to login to Pokemon Go with account %s. ' +
                  'Trying again in %g seconds.'),
                 account['username'], args.login_delay)
             time.sleep(args.login_delay)
 
-    if i > args.login_retries:
+    if num_tries > args.login_retries:
         log.error(
             ('Failed to login to Pokemon Go with account %s in ' +
              '%d tries. Giving up.'),
-            account['username'], i)
+            account['username'], num_tries)
         raise TooManyLoginAttempts('Exceeded login attempts.')
 
     log.debug('Login for account %s successful.', account['username'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -172,8 +172,8 @@ def get_args():
                         help='Time delay between each login attempt.',
                         type=float, default=6)
     parser.add_argument('-lr', '--login-retries',
-                        help=('Number of login attempts before refreshing ' +
-                              'a thread.'),
+                        help=('Number of times to retry the login before ' +
+                              'refreshing a thread.'),
                         type=int, default=3)
     parser.add_argument('-mf', '--max-failures',
                         help=('Maximum number of failures to parse ' +


### PR DESCRIPTION
Also, make the code follow what --login-retries really means

<!--- Provide a general summary of your changes in the Title above -->

## Description
The current code is written in a way that TooManyLoginAttempts is be raised. It goes out of the while loop before the exception has a chance to be raised.

This causes the code to continue and next api call raises NotLoggedInException.

Since ---login-retries means the number of retries and not the tries (small difference, but important one) I also updated the code and arg description to respect that meaning

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
In my own map, It has beeing working fine and now TooManyLoginAttempts is raised again.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.