### PR TITLE
Niantic API version watchdog

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -560,7 +560,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
 
         # API Watchdog - Check if Niantic forces a new API.
         if not args.no_version_check:
-            api_check_time = check_forced_version(args, curr_api_version,
+            api_check_time = check_forced_version(args, api_version,
                                                   api_check_time, pause_bit)
 
         # Now we just give a little pause here.
@@ -1227,18 +1227,18 @@ def stat_delta(current_status, last_status, stat_name):
     return current_status.get(stat_name, 0) - last_status.get(stat_name, 0)
 
 
-def check_forced_version(args, curr_api_version, api_check_time, pause_bit):
+def check_forced_version(args, api_version, api_check_time, pause_bit):
     if int(time.time()) > api_check_time:
         api_check_time = int(time.time()) + args.version_check_interval
         forced_api = get_api_version(args)
-        if (curr_api_version != forced_api and
-                forced_api != 0):
+
+        if (api_version != forced_api and forced_api != 0):
             pause_bit.set()
             log.info(('Started with API: {}, ' +
                       'Niantic forced to API: {}').format(
-                curr_api_version,
+                api_version,
                 forced_api))
-            log.info('Scanner paused due Niantic API foce.')
+            log.info('Scanner paused due to forced Niantic API update.')
             log.info('Stop the scanner process until RocketMap ' +
                      'has updated.')
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -25,12 +25,15 @@ import traceback
 import random
 import time
 import copy
+import requests
 
 from datetime import datetime
 from threading import Thread, Lock
 from queue import Queue, Empty
 from sets import Set
 from collections import deque
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 from pgoapi import PGoApi
 from pgoapi.utilities import f2i
@@ -350,6 +353,8 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     account_queue = Queue()
     threadStatus = {}
     key_scheduler = None
+    api_version = '0.55.0'
+    api_check_time = 0
 
     '''
     Create a queue of accounts for workers to pull from. When a worker has
@@ -465,6 +470,9 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         t.daemon = True
         t.start()
 
+    if not args.no_version_check:
+        log.info('Enabling new API force Watchdog.')
+
     # A place to track the current location.
     current_location = False
 
@@ -549,6 +557,11 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         if args.webhook_scheduler_updates:
             wh_status_update(args, threadStatus['Overseer'], wh_queue,
                              scheduler_array[0])
+
+        # API Watchdog - Check if Niantic forces a new API.
+        if not args.no_version_check:
+            api_check_time = check_forced_version(args, curr_api_version,
+                                                  api_check_time, pause_bit)
 
         # Now we just give a little pause here.
         time.sleep(1)
@@ -1212,3 +1225,48 @@ def stagger_thread(args):
 # The delta from last stat to current stat
 def stat_delta(current_status, last_status, stat_name):
     return current_status.get(stat_name, 0) - last_status.get(stat_name, 0)
+
+
+def check_forced_version(args, curr_api_version, api_check_time, pause_bit):
+    if int(time.time()) > api_check_time:
+        api_check_time = int(time.time()) + args.version_check_interval
+        forced_api = get_api_version(args)
+        if (curr_api_version != forced_api and
+                forced_api != 0):
+            pause_bit.set()
+            log.info(('Started with API: {}, ' +
+                      'Niantic forced to API: {}').format(
+                curr_api_version,
+                forced_api))
+            log.info('Scanner paused due Niantic API foce.')
+            log.info('Stop the scanner process until RocketMap ' +
+                     'has updated.')
+
+    return api_check_time
+
+
+def get_api_version(args):
+    proxies = {}
+
+    if args.proxy:
+        num, proxy = get_new_proxy(args)
+        proxies = {
+            'http': proxy,
+            'https': proxy
+        }
+
+    try:
+        s = requests.Session()
+        s.mount('https://',
+                HTTPAdapter(max_retries=Retry(total=3,
+                                              backoff_factor=0.1,
+                                              status_forcelist=[500, 502,
+                                                                503, 504])))
+        r = s.get(
+            'https://pgorelease.nianticlabs.com/plfe/version',
+            proxies=proxies,
+            verify=False)
+        return r.text[2:] if r.status_code == requests.codes.ok else 0
+    except Exception as e:
+        log.warning('error on API check: %s', repr(e))
+        return 0

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -384,12 +384,19 @@ def get_args():
                         help=("Complete ToS and tutorial steps on accounts " +
                               "if they haven't already."),
                         default=False)
+    parser.add_argument('-novc', '--no-version-check', action='store_true',
+                        help='Disable API version check.',
+                        default=False)
+    parser.add_argument('-vci', '--version-check-interval', type=int,
+                        help='Interval to check API version in seconds ' +
+                        '(Default: in [60, 300]).',
+                        default=random.randint(60, 300))
     parser.add_argument('-el', '--encrypt-lib',
                         help=('Path to encrypt lib to be used instead of ' +
                               'the shipped ones.'))
     parser.add_argument('-odt', '--on-demand_timeout',
                         help=('Pause searching while web UI is inactive ' +
-                              'for this timeout(in seconds).'),
+                              'for this timeout (in seconds).'),
                         type=int, default=0)
     parser.add_argument('--disable-blacklist',
                         help=('Disable the global anti-scraper IP blacklist.'),


### PR DESCRIPTION
## Description
Checks every `-vci` (default in [60, 300]) seconds whether the required Niantic API version has been updated. If it has, a pgoapi update is required and the expected API's version should be edited in search.py.

`-novc` disables this functionality.

## Motivation and Context
Avoids unnecessary account flags/bans/captchas.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
