### PR TITLE
Custom lure duration

### DIFF
--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -16,7 +16,7 @@
                         [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
                         [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-nsc] [-fl] -k
                         GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np] [-ng]
-                        [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH]
+                        [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH] [-ldur DURATION]
                         [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY] [-pxsc]
                         [-pxt PROXY_TIMEOUT] [-pxd PROXY_DISPLAY]
                         [-pxf PROXY_FILE] [-pxr PROXY_REFRESH]
@@ -206,6 +206,10 @@
                             scan closest spawns. [env var: POGOMAP_SPEED_SCAN]
       -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
                             [env var: POGOMAP_KPH]
+      -ldur DURATION, --lure-duration DURATION
+                            Change duration for lures set on pokestops. This is
+                            useful for events that extend lure duration.
+                            [env var: POGOMAP_LURE_DURATION]
       --dump-spawnpoints    Dump the spawnpoints from the db to json (only for use
                             with -ss). [env var: POGOMAP_DUMP_SPAWNPOINTS]
       -pd PURGE_DATA, --purge-data PURGE_DATA

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1921,7 +1921,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 if 'active_fort_modifier' in f:
                     lure_expiration = (datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0) +
-                        timedelta(minutes=30))
+                        timedelta(minutes=args.lure_duration))
                     active_fort_modifier = f['active_fort_modifier']
                     if args.webhooks and args.webhook_updates_only:
                         wh_update_queue.put(('pokestop', {

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -273,6 +273,10 @@ def get_args():
                         help=('Set a maximum speed in km/hour for scanner ' +
                               'movement.'),
                         type=int, default=35)
+    parser.add_argument('-ldur', '--lure-duration',
+                        help=('Change duration for lures set on pokestops. ' +
+                              'This is useful for events that extend lure ' +
+                              'duration'), type=int, default=30)
     parser.add_argument('--dump-spawnpoints',
                         help=('Dump the spawnpoints from the db to json ' +
                               '(only for use with -ss).'),

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -276,7 +276,7 @@ def get_args():
     parser.add_argument('-ldur', '--lure-duration',
                         help=('Change duration for lures set on pokestops. ' +
                               'This is useful for events that extend lure ' +
-                              'duration'), type=int, default=30)
+                              'duration.'), type=int, default=30)
     parser.add_argument('--dump-spawnpoints',
                         help=('Dump the spawnpoints from the db to json ' +
                               '(only for use with -ss).'),


### PR DESCRIPTION
## Description
Add possibility to customize the lure duration.

## Motivation and Context
This is useful for events like the current Valentines event that we have 6hs lure duration.
Without this during events RM's pokestop info become incorrect and lured pokestops doesn't show as lured after 30 minutes.

This happened before:
* 1 hour lure duration 
* 6 hours lure duration

<!--- ## How Has This Been Tested? --->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.