### PR TITLE
Fix gym sidebar move type for i18n

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -788,7 +788,8 @@ def get_move_energy(move_id):
 
 
 def get_move_type(move_id):
-    return i8ln(get_moves_data(move_id)['type'])
+    move_type = get_moves_data(move_id)['type']
+    return {"type": i8ln(move_type), "type_en": move_type}
 
 
 class Timer():

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1805,7 +1805,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
                                 <div class="move">
                                     <div class="name">
                                         ${pokemon.move_1_name}
-                                        <div class="type ${pokemon.move_1_type.toLowerCase()}">${pokemon.move_1_type}</div>
+                                        <div class="type ${pokemon.move_1_type['type_en'].toLowerCase()}">${pokemon.move_1_type['type']}</div>
                                     </div>
                                     <div class="damage">
                                         ${pokemon.move_1_damage}
@@ -1815,7 +1815,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
                                 <div class="move">
                                     <div class="name">
                                         ${pokemon.move_2_name}
-                                        <div class="type ${pokemon.move_2_type.toLowerCase()}">${pokemon.move_2_type}</div>
+                                        <div class="type ${pokemon.move_2_type['type_en'].toLowerCase()}">${pokemon.move_2_type['type']}</div>
                                         <div>
                                             <i class="move-bar-sprite move-bar-sprite-${moveEnergy}"></i>
                                         </div>


### PR DESCRIPTION
## Description
- move type div in gym sidebar was using the i18n string as class attribute --> failed because css rule uses english name
- provide an array with english move type and use this one for the div class

## Motivation and Context
noticed it and I'm hoping for another 🖕 ;)

## How Has This Been Tested?
my map

## Screenshots:
**before (normal works because it's the same in ger and en)**
![before](https://cloud.githubusercontent.com/assets/453508/22995878/e8662362-f3cc-11e6-826f-a68a8fd7cacc.PNG)

**after**
![after](https://cloud.githubusercontent.com/assets/453508/22995884/eb17aa9a-f3cc-11e6-8acf-31379b902311.PNG)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.