### PR TITLE
API Watchdog HTTP instead of HTTPS

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1257,15 +1257,14 @@ def get_api_version(args):
 
     try:
         s = requests.Session()
-        s.mount('https://',
+        s.mount('http://',
                 HTTPAdapter(max_retries=Retry(total=3,
                                               backoff_factor=0.1,
                                               status_forcelist=[500, 502,
                                                                 503, 504])))
         r = s.get(
-            'https://pgorelease.nianticlabs.com/plfe/version',
-            proxies=proxies,
-            verify=False)
+            'http://pgorelease.nianticlabs.com/plfe/version',
+            proxies=proxies)
         return r.text[2:] if r.status_code == requests.codes.ok else 0
     except Exception as e:
         log.warning('error on API check: %s', repr(e))


### PR DESCRIPTION
changed https to http to avoid any SSL Errors

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR change the version check website to use http instead of https to avoid any ssl error
<!--- Describe your changes in detail -->

## Motivation and Context
I think is an overhead for a check to use SSL. To avoid any SSL change it HTTP only
`SSLError(SSLError(SSLEOFError(8, u'EOF occurred in violation of protocol (_ssl.c:661)'),),)`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
