### PR TITLE
Completing tutorial with a final Pokéstop spin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,0 @@
-Initial

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,1 @@
+Initial

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -8,10 +8,16 @@ Pokestop due to the "First Pokestop of the Day" bonus.
 * We assume you are running a basic RocketMap installation. It is best to run
 the tutorial with hashing service on newest API to not get your fresh accounts
 becoming flagged.
-* Set up an instance with a config file and make some changes to it which let
+* Set up an instance with the following flags
+	* ``--complete-tutorial`` or just ``-tut``
+	* ``--config config/config.tutorial.ini`` or just
+	``-cf config/config.tutorial.ini`` to use a designated config file.
+	* ``accountcsv: PATH/accounts.csv`` or just ``-ac PATH/accounts.csv``
+* Create the ``config/config.tutorial.ini`` file by copying and renaming the
+``config/config.ini.example`` and make some changes to it afterwards which let
 the tutorial run smooth and fast enough to go through a batch of accounts.
 * Config changes are:
-	* Location next to at least one known Pokestop, a cluster ist better.
+	* Location next to at least one known Pokestop, a cluster is preferred.
 	* Set step distance to ``st: 1``.
 	* Set scan delay ``sd`` to a value which provides enough calls during the
 	following set search time (a good value is around ``sd: 15`` or lower).
@@ -19,9 +25,8 @@ the tutorial run smooth and fast enough to go through a batch of accounts.
 	* Set the account rest interval as high as possible that all accounts get
 	cycled and none returns, a safe value is ``ari: 36000``.
 	* Set login delay at least to ``login_delay: 1`` to avoid throttling.
-* Put your accounts into a ``accounts.csv`` file and refer to it in your
-process with ``-ac PATH/accounts.csv`` or in the config file with
-``accountcsv: PATH/accounts.csv``.
+* Put your accounts, which need to run the tutorial and need to level up, into
+your ``accounts.csv`` file.
 * Set your simultaneously working accounts, with ``-w`` as process flag, to a
 reasonable number, considering hash key limit and throttling. You can at least
 have 10 accounts running at the same time.

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -1,19 +1,27 @@
 # RocketMap tutorial completion for accounts (up to Level 2)
 
-This is documentation to complete the Pokemon GO Tutorial for a number of accounts while simultaneously become level 2 when completing it next to a Pokestop due to the "First Pokestop of the Day" bonus.
+This is documentation to complete the Pokemon GO Tutorial for a number of
+accounts while simultaneously become level 2 when completing it next to a
+Pokestop due to the "First Pokestop of the Day" bonus.
 
 ## Instruction
-* We assume you are running a basic RocketMap installation. It is best to run the tutorial with hashing service on newest API to not get your fresh accounts becoming flagged
-* Set up an instance with a config file and make some changes to it which let the tutorial run smooth and fast enough to go through a batch of accounts.
+* We assume you are running a basic RocketMap installation. It is best to run
+the tutorial with hashing service on newest API to not get your fresh accounts
+becoming flagged
+* Set up an instance with a config file and make some changes to it which let
+the tutorial run smooth and fast enough to go through a batch of accounts.
 * Config changes are:
 	* location next to at least one known Pokestop, a cluster ist better.
 	* set step distance to ``st: 1``
-	* set scan delay ``sd`` to a value which provides enough calls during the following set search time (a good value is around ``sd: 15`` or lower)
+	* set scan delay ``sd`` to a value which provides enough calls during the
+	following set search time (a good value is around ``sd: 15`` or lower)
 	* set the account search interval to around ``-asi: 120``
-	* set the account rest interval as high as possible that all accounts get cycled and none returns, a safe value is ``-ari: 36000``
-* put your accounts for the tutorial and level up into a ``accounts.csv`` file and refer to it in your process with ``-ac PATH/accounts.csv`` or in the config file with ``accountcsv: PATH/accounts.csv``.
-* if you are not using fresh accounts and you are not running has service, prepare for occuring captchas. Set up your RocketMap accordingly.
-* Let it run and watch it complete the tutorials as well as getting your accounts up to Level 2
-
-
-
+	* set the account rest interval as high as possible that all accounts get
+	cycled and none returns, a safe value is ``-ari: 36000``
+* put your accounts for the tutorial and level up into a ``accounts.csv`` file
+and refer to it in your process with ``-ac PATH/accounts.csv`` or in the config
+file with ``accountcsv: PATH/accounts.csv``.
+* if you are not using fresh accounts and you are not running has service,
+prepare for occuring captchas. Set up your RocketMap accordingly.
+* Let it run and watch it complete the tutorials as well as getting your
+accounts up to Level 2

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -8,7 +8,6 @@ Pokestop due to the "First Pokestop of the Day" bonus.
 * We assume you are running a basic RocketMap installation. It is best to run
 the tutorial with hashing service on newest API to not get your fresh accounts
 becoming flagged.
-
 * Create a ``config/config.tutorial.ini`` file by copying and renaming the
 ``config/config.ini.example`` and make some changes to it afterwards which let
 the tutorial run smooth and fast enough to go through a batch of accounts.

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -1,6 +1,6 @@
 # RocketMap tutorial completion for accounts (up to Level 2)
 
-This is documentation to complete the Pokemon GO Tutorial for a number of
+This is a documentation to complete the Pokemon GO Tutorial for a number of
 accounts while simultaneously become level 2 when completing it next to a
 Pokestop due to the "First Pokestop of the Day" bonus.
 

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -1,36 +1,33 @@
 # RocketMap tutorial completion for accounts (up to Level 2)
-
-This is a documentation to complete the Pokemon GO Tutorial for a number of
-accounts while simultaneously become level 2 when completing it next to a
-Pokestop due to the "First Pokestop of the Day" bonus.
+This is a guide on how to complete the Pokémon Go tutorial steps and becoming
+level 2 on your accounts as fast as possible, so you can use `-tut` once
+on all accounts and disable it again afterwards.
 
 ## Instruction
-* We assume you are running a basic RocketMap installation. It is best to run
-the tutorial with hashing service on newest API to not get your fresh accounts
-becoming flagged.
-* Create a ``config/config.tutorial.ini`` file by copying and renaming the
-``config/config.ini.example`` and make some changes to it afterwards which let
-the tutorial run smooth and fast enough to go through a batch of accounts.
+* We assume you are running a basic RocketMap installation. Using the hashing
+service with the latest API version will avoid accounts being flagged.
+* Create a ``config/config.tutorial.ini`` file by copying and renaming
+``config/config.ini.example`` and make the following changes:
 * Config changes are:
-	* Location next to at least one known Pokestop, a cluster is preferred.
+	* Set location next to at least one known Pokestop, a cluster is preferred.
 	* Set step distance to ``st: 1``.
 	* Set scan delay ``sd`` to a value which provides enough calls during the
 	following set search time (a good value is around ``sd: 15`` or lower).
-	* Set the account search interval to around ``asi: 120``.
-	* Set the account rest interval as high as possible that all accounts get
-	cycled and none returns, a safe value is ``ari: 36000``.
-	* Set login delay at least to ``login_delay: 1`` to avoid throttling.
-* Put your accounts, which need to run the tutorial and need to level up, into
-your ``accounts.csv`` file.
-* Set up an instance with the following flags
+	* Set the account search interval to approx. ``asi: 120``.
+	* Set the account rest interval as high as possible so all accounts get
+	cycled and none return, a safe value is ``ari: 36000``.
+	* Set login delay to at least ``login_delay: 1`` to avoid throttling.
+* Put the accounts that need to complete the tutorial and need to level up 
+into your ``accounts.csv`` file.
+* Set up an instance with the following flags:
 	* ``--complete-tutorial`` or just ``-tut``
 	* ``--config config/config.tutorial.ini`` or just
 	``-cf config/config.tutorial.ini`` to use a designated config file.
 	* ``--accountcsv PATH/accounts.csv`` or just ``-ac PATH/accounts.csv``
 	* ``-w WORKER`` to set your simultaneously working accounts to a reasonable
-	number, considering hash key limit and throttling. You can at least have 10
+	number, considering hash key limit and throttling. You can have at least 10
 	accounts running at the same time without any problems.
-* If you are not using fresh accounts and you are not running hash service,
-prepare for occuring captchas. Set up your RocketMap accordingly.
-* Enable ``-v`` in process if you want to see it working in log.
+* If you are not using fresh accounts and you are not using the hashing service,
+prepare for captchas. Set up your RocketMap accordingly.
+* Enable ``-v`` in process if you want to see the debug logs.
 * Let it run and your accounts will complete the tutorial and rise to level 2.

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -1,0 +1,19 @@
+# RocketMap tutorial completion for accounts (up to Level 2)
+
+This is documentation to complete the Pokemon GO Tutorial for a number of accounts while simultaneously become level 2 when completing it next to a Pokestop due to the "First Pokestop of the Day" bonus.
+
+## Instruction
+* We assume you are running a basic RocketMap installation. It is best to run the tutorial with hashing service on newest API to not get your fresh accounts becoming flagged
+* Set up an instance with a config file and make some changes to it which let the tutorial run smooth and fast enough to go through a batch of accounts.
+* Config changes are:
+	* location next to at least one known Pokestop, a cluster ist better.
+	* set step distance to ``st: 1``
+	* set scan delay ``sd`` to a value which provides enough calls during the following set search time (a good value is around ``sd: 15`` or lower)
+	* set the account search interval to around ``-asi: 120``
+	* set the account rest interval as high as possible that all accounts get cycled and none returns, a safe value is ``-ari: 36000``
+* put your accounts for the tutorial and level up into a ``accounts.csv`` file and refer to it in your process with ``-ac PATH/accounts.csv`` or in the config file with ``accountcsv: PATH/accounts.csv``.
+* if you are not using fresh accounts and you are not running has service, prepare for occuring captchas. Set up your RocketMap accordingly.
+* Let it run and watch it complete the tutorials as well as getting your accounts up to Level 2
+
+
+

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -28,4 +28,4 @@ have 10 accounts running at the same time.
 * If you are not using fresh accounts and you are not running hash service,
 prepare for occuring captchas. Set up your RocketMap accordingly.
 * Enable ``-v`` in process if you want to see it working in log.
-* Let it run and your accounts will complete the tutorial and rise to Level 2.
+* Let it run and your accounts will complete the tutorial and rise to level 2.

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -8,12 +8,8 @@ Pokestop due to the "First Pokestop of the Day" bonus.
 * We assume you are running a basic RocketMap installation. It is best to run
 the tutorial with hashing service on newest API to not get your fresh accounts
 becoming flagged.
-* Set up an instance with the following flags
-	* ``--complete-tutorial`` or just ``-tut``
-	* ``--config config/config.tutorial.ini`` or just
-	``-cf config/config.tutorial.ini`` to use a designated config file.
-	* ``accountcsv: PATH/accounts.csv`` or just ``-ac PATH/accounts.csv``
-* Create the ``config/config.tutorial.ini`` file by copying and renaming the
+
+* Create a ``config/config.tutorial.ini`` file by copying and renaming the
 ``config/config.ini.example`` and make some changes to it afterwards which let
 the tutorial run smooth and fast enough to go through a batch of accounts.
 * Config changes are:
@@ -27,9 +23,14 @@ the tutorial run smooth and fast enough to go through a batch of accounts.
 	* Set login delay at least to ``login_delay: 1`` to avoid throttling.
 * Put your accounts, which need to run the tutorial and need to level up, into
 your ``accounts.csv`` file.
-* Set your simultaneously working accounts, with ``-w`` as process flag, to a
-reasonable number, considering hash key limit and throttling. You can at least
-have 10 accounts running at the same time.
+* Set up an instance with the following flags
+	* ``--complete-tutorial`` or just ``-tut``
+	* ``--config config/config.tutorial.ini`` or just
+	``-cf config/config.tutorial.ini`` to use a designated config file.
+	* ``--accountcsv PATH/accounts.csv`` or just ``-ac PATH/accounts.csv``
+	* ``-w WORKER`` to set your simultaneously working accounts to a reasonable
+	number, considering hash key limit and throttling. You can at least have 10
+	accounts running at the same time without any problems.
 * If you are not using fresh accounts and you are not running hash service,
 prepare for occuring captchas. Set up your RocketMap accordingly.
 * Enable ``-v`` in process if you want to see it working in log.

--- a/docs/extras/tutorial.md
+++ b/docs/extras/tutorial.md
@@ -7,21 +7,25 @@ Pokestop due to the "First Pokestop of the Day" bonus.
 ## Instruction
 * We assume you are running a basic RocketMap installation. It is best to run
 the tutorial with hashing service on newest API to not get your fresh accounts
-becoming flagged
+becoming flagged.
 * Set up an instance with a config file and make some changes to it which let
 the tutorial run smooth and fast enough to go through a batch of accounts.
 * Config changes are:
-	* location next to at least one known Pokestop, a cluster ist better.
-	* set step distance to ``st: 1``
-	* set scan delay ``sd`` to a value which provides enough calls during the
-	following set search time (a good value is around ``sd: 15`` or lower)
-	* set the account search interval to around ``-asi: 120``
-	* set the account rest interval as high as possible that all accounts get
-	cycled and none returns, a safe value is ``-ari: 36000``
-* put your accounts for the tutorial and level up into a ``accounts.csv`` file
-and refer to it in your process with ``-ac PATH/accounts.csv`` or in the config
-file with ``accountcsv: PATH/accounts.csv``.
-* if you are not using fresh accounts and you are not running has service,
+	* Location next to at least one known Pokestop, a cluster ist better.
+	* Set step distance to ``st: 1``.
+	* Set scan delay ``sd`` to a value which provides enough calls during the
+	following set search time (a good value is around ``sd: 15`` or lower).
+	* Set the account search interval to around ``asi: 120``.
+	* Set the account rest interval as high as possible that all accounts get
+	cycled and none returns, a safe value is ``ari: 36000``.
+	* Set login delay at least to ``login_delay: 1`` to avoid throttling.
+* Put your accounts into a ``accounts.csv`` file and refer to it in your
+process with ``-ac PATH/accounts.csv`` or in the config file with
+``accountcsv: PATH/accounts.csv``.
+* Set your simultaneously working accounts, with ``-w`` as process flag, to a
+reasonable number, considering hash key limit and throttling. You can at least
+have 10 accounts running at the same time.
+* If you are not using fresh accounts and you are not running hash service,
 prepare for occuring captchas. Set up your RocketMap accordingly.
-* Let it run and watch it complete the tutorials as well as getting your
-accounts up to Level 2
+* Enable ``-v`` in process if you want to see it working in log.
+* Let it run and your accounts will complete the tutorial and rise to Level 2.

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -212,6 +212,7 @@ def spin_pokestop(api, account, fort, step_location):
         req = api.create_request()
         log.debug('Pokestop ID: %s', fort['id'])
         while (spin_result is None) and spin_try < 3:
+            time.sleep(random.uniform(0.8, 1.8))  # Do not let Niantic throttle
             spin_response = req.fort_search(
                 fort_id=fort['id'],
                 fort_latitude=fort['latitude'],
@@ -228,9 +229,7 @@ def spin_pokestop(api, account, fort, step_location):
             spin_response = req.download_settings()
             spin_response = req.get_buddy_walked()
             spin_response = req.call()
-
-            # Sleep shortly before another call to avoid throttling by Niantic.
-            time.sleep(random.uniform(1, 3))
+            time.sleep(random.uniform(2, 4))
 
             # Check for reCaptcha
             captcha_url = spin_response['responses'][

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -6,6 +6,7 @@ import time
 import random
 
 from pgoapi.exceptions import AuthException
+from .utils import .in_radius
 
 log = logging.getLogger(__name__)
 
@@ -201,23 +202,20 @@ def complete_tutorial(api, account, tutorial_state):
     time.sleep(random.uniform(2, 4))
     return True
 
-# Spinning a Pokestop to level account up to level 2.
-# API argument needs to be a logged in API instance.
-
 
 def spin_pokestop(api, account, fort, step_location):
     spinning_radius = 0.04
-    if in_radius((f['latitude'], f['longitude']), step_location,
+    if in_radius((fort['latitude'], fort['longitude']), step_location,
                  spinning_radius):
         spin_try = 0
         spin_result = None
         req = api.create_request()
-        log.debug('Pokestop ID: %s', f['id'])
+        log.debug('Pokestop ID: %s', fort['id'])
         while (spin_result is None) and spin_try < 3:
             spin_response = req.fort_search(
-                fort_id=f['id'],
-                fort_latitude=f['latitude'],
-                fort_longitude=f['longitude'],
+                fort_id=fort['id'],
+                fort_latitude=fort['latitude'],
+                fort_longitude=fort['longitude'],
                 player_latitude=step_location[
                     0],
                 player_longitude=step_location[

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -251,38 +251,34 @@ def spin_pokestop(api, fort, step_location):
     if in_radius((fort['latitude'], fort['longitude']), step_location,
                  spinning_radius):
         log.debug('Attempt to spin Pokestop (ID %s)', fort['id'])
-        spin_try = 0
-        while spin_try < 3:
-            spin_try += 1
-            time.sleep(random.uniform(0.8, 1.8))  # Do not let Niantic throttle
-            spin_response = spin_pokestop_request(api, fort, step_location)
-            time.sleep(random.uniform(2, 4))  # Do not let Niantic throttle
 
-            # Check for reCaptcha
-            captcha_url = spin_response['responses'][
-                'CHECK_CHALLENGE']['challenge_url']
-            if len(captcha_url) > 1:
-                log.debug('Account encountered a reCaptcha.')
-                return False
+        time.sleep(random.uniform(0.8, 1.8))  # Do not let Niantic throttle
+        spin_response = spin_pokestop_request(api, fort, step_location)
+        time.sleep(random.uniform(2, 4))  # Do not let Niantic throttle
 
-            spin_result = spin_response['responses']['FORT_SEARCH']['result']
-            if spin_result is 1:
-                log.debug('Successful Pokestop spin.')
-                return True
-            elif spin_result is 2:
-                log.debug('Pokestop was not in range to spin.')
-            elif spin_result is 3:
-                log.debug('Pokestop has already been recently spun.')
-            elif spin_result is 4:
-                log.debug('Failed to spin Pokestop. Inventory is full.')
-            elif spin_result is 5:
-                log.debug(
-                    'Pokestop is not spinable. ' +
-                    'Already spun maximum number for this day, bot?')
-            else:
-                log.warning(
-                    'Failed to spin a Pokestop. Unknown result %d.',
-                    spin_result)
+        # Check for reCaptcha
+        captcha_url = spin_response['responses'][
+            'CHECK_CHALLENGE']['challenge_url']
+        if len(captcha_url) > 1:
+            log.debug('Account encountered a reCaptcha.')
+            return False
+
+        spin_result = spin_response['responses']['FORT_SEARCH']['result']
+        if spin_result is 1:
+            log.debug('Successful Pokestop spin.')
+            return True
+        elif spin_result is 2:
+            log.debug('Pokestop was not in range to spin.')
+        elif spin_result is 3:
+            log.debug('Failedto spin Pokestop. Has recently been spun.')
+        elif spin_result is 4:
+            log.debug('Failed to spin Pokestop. Inventory is full.')
+        elif spin_result is 5:
+            log.debug('Maximum number of Pokestops spun for this day.')
+        else:
+            log.debug(
+                'Failed to spin a Pokestop. Unknown result %d.',
+                spin_result)
 
     return False
 

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -4,9 +4,9 @@
 import logging
 import time
 import random
+import math
 
 from pgoapi.exceptions import AuthException
-from .utils import .in_radius
 
 log = logging.getLogger(__name__)
 
@@ -263,3 +263,19 @@ def spin_pokestop(api, account, fort, step_location):
                 log.warning('Failed to spin a Pokestop for unknown reason.')
 
     return False
+
+
+# Return equirectangular approximation distance in km.
+def equi_rect_distance(loc1, loc2):
+    R = 6371  # Radius of the earth in km.
+    lat1 = math.radians(loc1[0])
+    lat2 = math.radians(loc2[0])
+    x = (math.radians(loc2[1]) - math.radians(loc1[1])
+         ) * math.cos(0.5 * (lat2 + lat1))
+    y = lat2 - lat1
+    return R * math.sqrt(x * x + y * y)
+
+
+# Return True if distance between two locs is less than distance in km.
+def in_radius(loc1, loc2, distance):
+    return equi_rect_distance(loc1, loc2) < distance

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -239,7 +239,7 @@ def spin_pokestop(api, fort, step_location):
             captcha_url = spin_response['responses'][
                 'CHECK_CHALLENGE']['challenge_url']
             if len(captcha_url) > 1:
-                log.debug('Worker encountered a reCaptcha.')
+                log.debug('Account encountered a reCaptcha.')
                 return False
 
             spin_result = spin_response['responses']['FORT_SEARCH']['result']

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -204,6 +204,32 @@ def complete_tutorial(api, account, tutorial_state):
     return True
 
 
+# Complete tutorial with a level up by a Pokestop spin.
+# API argument needs to be a logged in API instance.
+# Called during fort parsing in models.py
+def tutorial_pokestop_spin(api, map_dict, forts, step_location, account):
+    player_level = get_player_level(map_dict)
+    if player_level > 1:
+        log.debug(
+            'No need to spin a Pokestop. ' +
+            'Account %s is already level %d.',
+            account['username'], player_level)
+    else:  # Account needs to spin a Pokestop for level 2.
+        for fort in forts:
+            if fort.get('type') == 1:
+                log.debug(
+                    'Spinning Pokestop for account %s.',
+                    account['username'])
+                if spin_pokestop(api, fort, step_location):
+                    log.debug(
+                        'Account %s successfully spun a Pokestop' +
+                        'after completed tutorial.',
+                        account['username'])
+                    return True
+
+    return False
+
+
 def get_player_level(map_dict):
     inventory_items = map_dict['responses'].get(
         'GET_INVENTORY', {}).get(

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -215,11 +215,11 @@ def tutorial_pokestop_spin(api, map_dict, forts, step_location, account):
             'Account %s is already level %d.',
             account['username'], player_level)
     else:  # Account needs to spin a Pokestop for level 2.
+        log.debug(
+            'Spinning Pokestop for account %s.',
+            account['username'])
         for fort in forts:
             if fort.get('type') == 1:
-                log.debug(
-                    'Spinning Pokestop for account %s.',
-                    account['username'])
                 if spin_pokestop(api, fort, step_location):
                     log.debug(
                         'Account %s successfully spun a Pokestop' +

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -229,10 +229,7 @@ def spin_pokestop(api, fort, step_location):
         while spin_try < 3:
             spin_try += 1
             time.sleep(random.uniform(0.8, 1.8))  # Do not let Niantic throttle
-            spin_response = spin_pokestop_request(
-                    api, fort['id'],
-                    fort['latitude'], fort['longitude'],
-                    step_location[0], step_location[1])
+            spin_response = spin_pokestop_request(api, fort, step_location)
             time.sleep(random.uniform(2, 4))  # Do not let Niantic throttle
 
             # Check for reCaptcha
@@ -264,22 +261,25 @@ def spin_pokestop(api, fort, step_location):
     return False
 
 
-def spin_pokestop_request(
-        api, fort_id, fort_latitude, fort_longitude,
-        player_latitude, player_longitude):
-    req = api.create_request()
-    spin_pokestop_response = req.fort_search(
-        fort_id,
-        fort_latitude,
-        fort_longitude,
-        player_latitude,
-        player_longitude)
-    spin_pokestop_response = req.check_challenge()
-    spin_pokestop_response = req.get_hatched_eggs()
-    spin_pokestop_response = req.get_inventory()
-    spin_pokestop_response = req.check_awarded_badges()
-    spin_pokestop_response = req.download_settings()
-    spin_pokestop_response = req.get_buddy_walked()
-    spin_pokestop_response = req.call()
+def spin_pokestop_request(api, fort, step_location):
+    try:
+        req = api.create_request()
+        spin_pokestop_response = req.fort_search(
+            fort_id=fort['id'],
+            fort_latitude=fort['latitude'],
+            fort_longitude=fort['longitude'],
+            player_latitude=step_location[0],
+            player_longitude=step_location[1])
+        spin_pokestop_response = req.check_challenge()
+        spin_pokestop_response = req.get_hatched_eggs()
+        spin_pokestop_response = req.get_inventory()
+        spin_pokestop_response = req.check_awarded_badges()
+        spin_pokestop_response = req.download_settings()
+        spin_pokestop_response = req.get_buddy_walked()
+        spin_pokestop_response = req.call()
 
-    return spin_pokestop_response
+        return spin_pokestop_response
+
+    except Exception as e:
+        log.warning('Exception while spinning Pokestop: %s', repr(e))
+        return False

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -222,7 +222,7 @@ def tutorial_pokestop_spin(api, map_dict, forts, step_location, account):
             if fort.get('type') == 1:
                 if spin_pokestop(api, fort, step_location):
                     log.debug(
-                        'Account %s successfully spun a Pokestop' +
+                        'Account %s successfully spun a Pokestop ' +
                         'after completed tutorial.',
                         account['username'])
                     return True
@@ -270,7 +270,7 @@ def spin_pokestop(api, fort, step_location):
         elif spin_result is 2:
             log.debug('Pokestop was not in range to spin.')
         elif spin_result is 3:
-            log.debug('Failedto spin Pokestop. Has recently been spun.')
+            log.debug('Failed to spin Pokestop. Has recently been spun.')
         elif spin_result is 4:
             log.debug('Failed to spin Pokestop. Inventory is full.')
         elif spin_result is 5:

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -200,3 +200,74 @@ def complete_tutorial(api, account, tutorial_state):
               account['username'])
     time.sleep(random.uniform(2, 4))
     return True
+
+# Spinning a Pokestop to level account up to level 2.
+# API argument needs to be a logged in API instance.
+
+
+def spin_pokestop(api, account, fort, step_location):
+    spinning_radius = 0.04
+    if in_radius((f['latitude'], f['longitude']), step_location,
+                 spinning_radius):
+        spin_try = 0
+        spin_result = None
+        req = api.create_request()
+        log.warning('Pokestop ID: %s', f['id'])
+        while (spin_result is None) and spin_try < 3:
+            spin_response = req.fort_search(
+                fort_id=f['id'],
+                fort_latitude=f['latitude'],
+                fort_longitude=f['longitude'],
+                player_latitude=step_location[
+                    0],
+                player_longitude=step_location[
+                    1]
+            )
+
+            # Sleep shortly before another call to avoid throttling by Niantic. 
+            time.sleep(random.uniform(1, 3))
+            spin_response = req.check_challenge()
+            spin_response = req.get_hatched_eggs()
+            spin_response = req.get_inventory()
+            spin_response = req.check_awarded_badges()
+            spin_response = req.download_settings()
+            spin_response = req.get_buddy_walked()
+            spin_response = req.call()
+            # Check for reCaptcha
+            captcha_url = spin_response['responses']
+                ['CHECK_CHALLENGE']['challenge_url']
+            if len(captcha_url) > 1:
+                log.debug('Account encountered a reCaptcha.')
+                return False
+
+            if (spin_response['responses']['FORT_SEARCH']['result'] is 1):
+                spin_result = 'Succeeded'
+                log.debug(
+                    'Worker successfuly spinned Pokestop')
+                return True
+            elif (spin_response['responses']['FORT_SEARCH']['result'] is 2):
+                spin_result = 'Failed'
+                log.debug(
+                    'Pokestop was not in range to spin.')
+            elif (spin_response['responses']['FORT_SEARCH']['result'] is 3):
+                spin_result = 'Failed'
+                log.debug(
+                    'Pokestop has already been recently spun.')
+            elif (spin_response['responses']['FORT_SEARCH']['result'] is 4):
+                spin_result = 'Failed'
+                log.debug(
+                    'Failed to spin Pokestop. ' +
+                    'Inventory is full.')
+            elif (spin_response['responses']['FORT_SEARCH']['result'] is 5):
+                spin_result = 'Failed'
+                log.debug(
+                    'Pokestop is not spinable. ' +
+                    'Maximum number for this day ' +
+                    'already spun, bot?')
+            else:
+                spin_result = 'Failed'
+                log.warning(
+                    'Failed to spin a Pokestop ' +
+                    'for unknown reason.')
+
+    return False

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1925,28 +1925,24 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         # Check level as part of account tutorial completion
         if args.complete_tutorial:
             player_level = get_player_level(map_dict)
-            pokestop_spinning = False
-            if player_level == 1:
-                pokestop_spinning = True
-                log.debug(
-                    'Spinning Pokestop for account %s.', account['username'])
-            else:
-                log.debug(
-                    'No need to spin a Pokestop. ' +
-                    'Account %s is already level %d.',
-                    account['username'], player_level)
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 # Spinning Pokestop as a part of account tutorial completion
-                if args.complete_tutorial and pokestop_spinning:
-                    # Set to False when True is returned
-                    pokestop_spinning = not spin_pokestop(
-                        api, f, step_location)
-                    if not pokestop_spinning:
+                if args.complete_tutorial and player_level == 1:
+                    log.debug(
+                        'Spinning Pokestop for account %s.',
+                        account['username'])
+                    if spin_pokestop(api, f, step_location):
+                        player_level = 0  # Should be 2, but this can change
                         log.debug(
                             'Account %s successfully spun a Pokestop' +
-                            'after completed tutorial.')
+                            'after completed tutorial.', account['username'])
+                elif args.complete_tutorial and player_level != 1:
+                    log.debug(
+                        'No need to spin a Pokestop. ' +
+                        'Account %s is already level %d.',
+                        account['username'], player_level)
 
                 if 'active_fort_modifier' in f:
                     lure_expiration = (datetime.utcfromtimestamp(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1918,7 +1918,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     (f['last_modified'] -
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
 
-        if args.complete_tutorial:  # Complete tutorial with a Pokestop spin
+        # Complete tutorial with a Pokestop spin
+        captcha_url = map_dict['responses'][
+                'CHECK_CHALLENGE']['challenge_url']  # Just to be sure
+        if args.complete_tutorial and not len(captcha_url) > 1:
             if config['parse_pokestops']:
                 tutorial_pokestop_spin(
                     api, map_dict, forts, step_location, account)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1921,7 +1921,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         # Complete tutorial with a Pokestop spin
         captcha_url = map_dict['responses'][
                 'CHECK_CHALLENGE']['challenge_url']  # Just to be sure
-        if args.complete_tutorial and not len(captcha_url) > 1:
+        if args.complete_tutorial and not (len(captcha_url) > 1):
             if config['parse_pokestops']:
                 tutorial_pokestop_spin(
                     api, map_dict, forts, step_location, account)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1948,8 +1948,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 if args.complete_tutorial and pokestop_spinning:
                     distance = 0.04
-                    if in_radius((f['latitude'], f['longitude']),
-                                    step_location, distance):
+                    if in_radius(
+                                (f['latitude'], f['longitude']),
+                                step_location,
+                                distance):
                         spin_try = 0
                         spin_result = None
                         req = api.create_request()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1919,7 +1919,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         # Check level as part of account tutorial completion
-        # if it is needed to spin a Pokestop for level 2 
+        # if it is needed to spin a Pokestop for level 2
         if args.complete_tutorial:
             player_level = 0
             pokestop_spinning = False
@@ -1945,11 +1945,12 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         account['username'], player_level)
             else:
                 except Exception as e:
-                    log.error('Exception in parse_map retrieving ' +
-                        'player_stats under account %s. '
+                    log.error(
+                        'Exception in parse_map retrieving ' +
+                        'player_stats under account %s. ' +
                         'Exception message: %s',
                         account['username'], repr(e)))
-                    traceback.print_exc(file=sys.stdout)
+                    traceback.print_exc(file = sys.stdout)
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
@@ -1957,14 +1958,14 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 if args.complete_tutorial and pokestop_spinning:
                     # spin_pokestop returns True if succeeded
                     # pokestop_spinning should then be set to False
-                    pokestop_spinning = not spin_pokestop(api, account, f,
-                        step_location)
+                    pokestop_spinning=not spin_pokestop(
+                        api, account, f, step_location)
 
                 if 'active_fort_modifier' in f:
-                    lure_expiration = (datetime.utcfromtimestamp(
+                    lure_expiration=(datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0) +
                         timedelta(minutes=args.lure_duration))
-                    active_fort_modifier = f['active_fort_modifier']
+                    active_fort_modifier=f['active_fort_modifier']
                     if args.webhooks and args.webhook_updates_only:
                         wh_update_queue.put(('pokestop', {
                             'pokestop_id': b64encode(str(f['id'])),
@@ -1978,17 +1979,17 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                             'active_fort_modifier': active_fort_modifier
                         }))
                 else:
-                    lure_expiration, active_fort_modifier = None, None
+                    lure_expiration, active_fort_modifier=None, None
 
                 # Send all pokestops to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change
                     # the information pushed to webhooks.  Similar to above and
                     # previous commits.
-                    l_e = None
+                    l_e=None
 
                     if lure_expiration is not None:
-                        l_e = calendar.timegm(lure_expiration.timetuple())
+                        l_e=calendar.timegm(lure_expiration.timetuple())
 
                     wh_update_queue.put(('pokestop', {
                         'pokestop_id': b64encode(str(f['id'])),
@@ -2007,7 +2008,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     stopsskipped += 1
                     continue
 
-                pokestops[f['id']] = {
+                pokestops[f['id']]={
                     'pokestop_id': f['id'],
                     'enabled': f['enabled'],
                     'latitude': f['latitude'],

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1925,8 +1925,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         # Check level as part of account tutorial completion
         if args.complete_tutorial:
             player_level = get_player_level(map_dict)
-            log.debug(
-                'Account %s is level %d.', account['username'], player_level)
             pokestop_spinning = False
             if player_level == 1:
                 pokestop_spinning = True
@@ -1948,7 +1946,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     if not pokestop_spinning:
                         log.debug(
                             'Account %s successfully spun a Pokestop' +
-                            'and after completed tutorial.')
+                            'after completed tutorial.')
 
                 if 'active_fort_modifier' in f:
                     lure_expiration = (datetime.utcfromtimestamp(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1931,8 +1931,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     api, map_dict, forts, step_location, account)
             else:
                 log.error(
-                    'Pokestop can not be spun since parsing Pokestops is not' +
-                    'active. Check if \'-nk\' flag is accidently set.')
+                    'Pokestop can not be spun since parsing Pokestops is ' +
+                    'not active. Check if \'-nk\' flag is accidently set.')
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1925,7 +1925,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             else:
                 log.error(
                     'Pokestop can not be spun since parsing Pokestops is not' +
-                    'active. Check if \'-nk\' flag is accidently set .')
+                    'active. Check if \'-nk\' flag is accidently set.')
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1661,7 +1661,7 @@ class Token(flaskDb.Model):
                 if tokens:
                     log.debug('Retrived Token IDs: {}'.format(token_ids))
                     result = DeleteQuery(Token).where(
-                                 Token.id << token_ids).execute()
+                        Token.id << token_ids).execute()
                     log.debug('Deleted {} tokens.'.format(result))
         except OperationalError as e:
             log.error('Failed captcha token transactional query: {}'.format(e))
@@ -1925,33 +1925,41 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'inventory_delta', {}).get(
                 'inventory_items', [])
             player_stats = [item['inventory_item_data']['player_stats']
-            for item in inventory_items
-                if 'player_stats' in item.get(
-                        'inventory_item_data', {})]
+                            for item in inventory_items
+                            if 'player_stats' in item.get(
+                'inventory_item_data', {})]
                 if len(player_stats) > 0:
                 player_level = player_stats[0].get('level', 1)
                 if player_level < 2:
                     pokestop_spinning = True
-                    log.info('Pokestop-Spinning - Account is level %d. Continuing ...', player_level)
+                    log.debug(
+                        'Pokestop-Spinning - Account is level %d. ' +
+                        'Continuing ...', player_level)
                 else:
-                    log.info('Pokestop-Spinning - Not needed. Account is already level %d.', player_level)
+                    log.debug(
+                        'Pokestop-Spinning - Not needed. ' +
+                        'Account is already level %d.', player_level)
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 if args.complete_tutorial and pokestop_spinning:
                     distance = 0.04
-                    if in_radius((f['latitude'], f['longitude']), step_location, distance):
+                    if in_radius((f['latitude'], f['longitude']),
+                            step_location, distance):
                         spin_try = 0
                         spin_result = None
                         req = api.create_request()
                         log.warning('Pokestop ID: %s', f['id'])
                         while (spin_result is None) and spin_try < 3:
-                            spin_response = req.fort_search(fort_id=f['id'],
-                                                            fort_latitude=f['latitude'],
-                                                            fort_longitude=f['longitude'],
-                                                            player_latitude=step_location[0],
-                                                            player_longitude=step_location[1]
-                                                            )
+                            spin_response = req.fort_search(
+                                                fort_id=f['id'],
+                                                fort_latitude=f['latitude'],
+                                                fort_longitude=f['longitude'],
+                                                player_latitude=step_location[
+                                                    0],
+                                                player_longitude=step_location[
+                                                    1]
+                                                )
                             spin_response = req.check_challenge()
                             spin_response = req.get_hatched_eggs()
                             spin_response = req.get_inventory()
@@ -1961,31 +1969,46 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                             time.sleep(10)
                             spin_response = req.call()
                             # Check for reCaptcha
-                            captcha_url = spin_response['responses']['CHECK_CHALLENGE']['challenge_url']
+                            captcha_url = spin_response['responses'][
+                                'CHECK_CHALLENGE']['challenge_url']
                             if len(captcha_url) > 1:
-                                log.info('Account encountered a reCaptcha')
+                                log.debug('Account encountered a reCaptcha')
                                 return
 
-                            if spin_response['responses']['FORT_SEARCH']['result'] is 1:
+                            if (spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 1):
                                 spin_result = 'Succeeded'
-                                log.info('Pokestop-Spinning - Spinning attempt succeeded')
+                                log.debug(
+                                    'Pokestop-Spinning - ' +
+                                    'Spinning attempt succeeded')
                                 pokestop_spinning = False
-                            elif spin_response['responses']['FORT_SEARCH']['result'] is 2:
+                            elif spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 2:
                                 spin_result = 'Failed'
-                                log.info('Pokestop-Spinning - Pokestop already spun')
-                            elif spin_response['responses']['FORT_SEARCH']['result'] is 3:
+                                log.debug('Pokestop-Spinning - ' +
+                                    'Pokestop out of range')
+                            elif spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 3:
                                 spin_result = 'Failed'
-                                log.info('Pokestop-Spinning - Inventory full')
-                            elif spin_response['responses']['FORT_SEARCH']['result'] is 4:
+                                log.debug('Pokestop-Spinning - ' +
+                                    'Pokestop already spun')
+                            elif spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 4:
                                 spin_result = 'Failed'
-                                log.info('Pokestop-Spinning - Pokestop not spinable (maybe maximum number already spun)')
-                            elif spin_response['responses']['FORT_SEARCH']['result'] is 5:
+                                log.debug(
+                                    'Pokestop-Spinning - ' +
+                                    'Inventory is full')
+                            elif spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 5:
                                 spin_result = 'Failed'
-                                log.info('Pokestop-Spinning - Maximum spun stops for the day - idk how you managed this either')
+                                log.debug(
+                                    'Pokestop-Spinning - ' +
+                                    'Pokestop not spinable' +
+                                    '(maybe maximum number already spun)')
                             else:
                                 spin_result = 'Failed'
-                                log.info('Pokestop-Spinning - No result, aborted')
-
+                                log.debug(
+                                    'Pokestop-Spinning - No result, aborted')
 
                 if 'active_fort_modifier' in f:
                     lure_expiration = (datetime.utcfromtimestamp(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1940,15 +1940,16 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'Pokestop-Spinning - Not needed. ' +
                         'Account is already level %d.', player_level)
             else:
-                log.warning('Pokestop-Spinning - ' +
-                    'Account level could not be determined')
+                log.warning(
+                        'Pokestop-Spinning - ' +
+                        'Account level could not be determined')
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 if args.complete_tutorial and pokestop_spinning:
                     distance = 0.04
                     if in_radius((f['latitude'], f['longitude']),
-                                step_location, distance):
+                                    step_location, distance):
                         spin_try = 0
                         spin_result = None
                         req = api.create_request()
@@ -1988,12 +1989,14 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                             elif (spin_response['responses']
                                     ['FORT_SEARCH']['result'] is 2):
                                 spin_result = 'Failed'
-                                log.debug('Pokestop-Spinning - ' +
+                                log.debug(
+                                    'Pokestop-Spinning - ' +
                                     'Pokestop out of range')
                             elif (spin_response['responses']
                                     ['FORT_SEARCH']['result'] is 3):
                                 spin_result = 'Failed'
-                                log.debug('Pokestop-Spinning - ' +
+                                log.debug(
+                                    'Pokestop-Spinning - ' +
                                     'Pokestop already spun')
                             elif (spin_response['responses']
                                     ['FORT_SEARCH']['result'] is 4):
@@ -2010,7 +2013,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                                     '(maybe maximum number already spun)')
                             else:
                                 spin_result = 'Failed'
-                                log.debug(
+                                log.warning(
                                     'Pokestop-Spinning - No result, aborted')
 
                 if 'active_fort_modifier' in f:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1924,7 +1924,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
         # Check level as part of account tutorial completion
         if args.complete_tutorial:
-            player_level = get_player_level(map_dict, account)
+            player_level = get_player_level(map_dict)
+            log.debug(
+                'Account %s is level %d.', account['username'], player_level)
             pokestop_spinning = False
             if player_level == 1:
                 pokestop_spinning = True
@@ -1942,7 +1944,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 if args.complete_tutorial and pokestop_spinning:
                     # Set to False when True is returned
                     pokestop_spinning = not spin_pokestop(
-                        api, account, f, step_location)
+                        api, f, step_location)
+                    if not pokestop_spinning:
+                        log.debug(
+                            'Account %s successfully spun a Pokestop' +
+                            'and after completed tutorial.')
 
                 if 'active_fort_modifier' in f:
                     lure_expiration = (datetime.utcfromtimestamp(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1917,6 +1917,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 encountered_pokestops = [(f['pokestop_id'], int(
                     (f['last_modified'] -
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
+        elif (not config['parse_pokestops'] and args.complete_tutorial):
+            log.error(
+                'Pokestop can not be spun since parsing Pokestops is not' +
+                'active. You should check if you accidently set \'-nk\' flag.')
 
         # Check level as part of account tutorial completion
         if args.complete_tutorial:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1925,6 +1925,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         # Check level as part of account tutorial completion
         if args.complete_tutorial:
             player_level = get_player_level(map_dict)
+            if player_level > 1:
+                log.debug(
+                    'No need to spin a Pokestop. ' +
+                    'Account %s is already level %d.',
+                    account['username'], player_level)
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
@@ -1934,15 +1939,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'Spinning Pokestop for account %s.',
                         account['username'])
                     if spin_pokestop(api, f, step_location):
-                        player_level = 0  # Should be 2, but this can change
+                        player_level = 2  # Should be, now, but this can change
                         log.debug(
                             'Account %s successfully spun a Pokestop' +
                             'after completed tutorial.', account['username'])
-                elif args.complete_tutorial and player_level != 1:
-                    log.debug(
-                        'No need to spin a Pokestop. ' +
-                        'Account %s is already level %d.',
-                        account['username'], player_level)
 
                 if 'active_fort_modifier' in f:
                     lure_expiration = (datetime.utcfromtimestamp(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1919,7 +1919,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         # Check level as part of account tutorial completion
-        # if it is needed to spin a Pokestop for level 2
         if args.complete_tutorial:
             player_level = 0
             pokestop_spinning = False
@@ -1927,10 +1926,19 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'GET_INVENTORY', {}).get(
                 'inventory_delta', {}).get(
                 'inventory_items', [])
-            player_stats = [item['inventory_item_data']['player_stats']
-                            for item in inventory_items
-                            if 'player_stats' in item.get(
-                            'inventory_item_data', {})]
+            try:
+                player_stats = [item['inventory_item_data']['player_stats']
+                                for item in inventory_items
+                                if 'player_stats' in item.get(
+                                'inventory_item_data', {})]
+            except Exception as e:
+                log.error(
+                    'Exception in parse_map retrieving ' +
+                    'player_stats under account %s. ' +
+                    'Exception message: %s',
+                    account['username'], repr(e))
+                traceback.print_exc(file=sys.stdout)
+
             if len(player_stats) > 0:
                 player_level = player_stats[0].get('level', 1)
                 if player_level < 2:
@@ -1943,29 +1951,20 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'No need to spin a Pokestop. ' +
                         'Account %s is already level %d.',
                         account['username'], player_level)
-            else:
-                except Exception as e:
-                    log.error(
-                        'Exception in parse_map retrieving ' +
-                        'player_stats under account %s. ' +
-                        'Exception message: %s',
-                        account['username'], repr(e)))
-                    traceback.print_exc(file = sys.stdout)
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 # Spinning Pokestop as a part of account tutorial completion
                 if args.complete_tutorial and pokestop_spinning:
-                    # spin_pokestop returns True if succeeded
-                    # pokestop_spinning should then be set to False
-                    pokestop_spinning=not spin_pokestop(
+                    # Set to False when True is returned
+                    pokestop_spinning = not spin_pokestop(
                         api, account, f, step_location)
 
                 if 'active_fort_modifier' in f:
-                    lure_expiration=(datetime.utcfromtimestamp(
+                    lure_expiration = (datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0) +
                         timedelta(minutes=args.lure_duration))
-                    active_fort_modifier=f['active_fort_modifier']
+                    active_fort_modifier = f['active_fort_modifier']
                     if args.webhooks and args.webhook_updates_only:
                         wh_update_queue.put(('pokestop', {
                             'pokestop_id': b64encode(str(f['id'])),
@@ -1979,17 +1978,17 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                             'active_fort_modifier': active_fort_modifier
                         }))
                 else:
-                    lure_expiration, active_fort_modifier=None, None
+                    lure_expiration, active_fort_modifier = None, None
 
                 # Send all pokestops to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change
                     # the information pushed to webhooks.  Similar to above and
                     # previous commits.
-                    l_e=None
+                    l_e = None
 
                     if lure_expiration is not None:
-                        l_e=calendar.timegm(lure_expiration.timetuple())
+                        l_e = calendar.timegm(lure_expiration.timetuple())
 
                     wh_update_queue.put(('pokestop', {
                         'pokestop_id': b64encode(str(f['id'])),
@@ -2008,7 +2007,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     stopsskipped += 1
                     continue
 
-                pokestops[f['id']]={
+                pokestops[f['id']] = {
                     'pokestop_id': f['id'],
                     'enabled': f['enabled'],
                     'latitude': f['latitude'],

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1927,8 +1927,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             player_stats = [item['inventory_item_data']['player_stats']
                             for item in inventory_items
                             if 'player_stats' in item.get(
-                'inventory_item_data', {})]
-                if len(player_stats) > 0:
+                            'inventory_item_data', {})]
+            if len(player_stats) > 0:
                 player_level = player_stats[0].get('level', 1)
                 if player_level < 2:
                     pokestop_spinning = True
@@ -1939,13 +1939,16 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     log.debug(
                         'Pokestop-Spinning - Not needed. ' +
                         'Account is already level %d.', player_level)
+            else:
+                log.warning('Pokestop-Spinning - ' +
+                    'Account level could not be determined')
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 if args.complete_tutorial and pokestop_spinning:
                     distance = 0.04
                     if in_radius((f['latitude'], f['longitude']),
-                            step_location, distance):
+                                step_location, distance):
                         spin_try = 0
                         spin_result = None
                         req = api.create_request()
@@ -1982,24 +1985,24 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                                     'Pokestop-Spinning - ' +
                                     'Spinning attempt succeeded')
                                 pokestop_spinning = False
-                            elif spin_response['responses']
-                                    ['FORT_SEARCH']['result'] is 2:
+                            elif (spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 2):
                                 spin_result = 'Failed'
                                 log.debug('Pokestop-Spinning - ' +
                                     'Pokestop out of range')
-                            elif spin_response['responses']
-                                    ['FORT_SEARCH']['result'] is 3:
+                            elif (spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 3):
                                 spin_result = 'Failed'
                                 log.debug('Pokestop-Spinning - ' +
                                     'Pokestop already spun')
-                            elif spin_response['responses']
-                                    ['FORT_SEARCH']['result'] is 4:
+                            elif (spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 4):
                                 spin_result = 'Failed'
                                 log.debug(
                                     'Pokestop-Spinning - ' +
                                     'Inventory is full')
-                            elif spin_response['responses']
-                                    ['FORT_SEARCH']['result'] is 5:
+                            elif (spin_response['responses']
+                                    ['FORT_SEARCH']['result'] is 5):
                                 spin_result = 'Failed'
                                 log.debug(
                                     'Pokestop-Spinning - ' +

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1698,6 +1698,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     new_spawn_points = []
     sp_id_list = []
     now_secs = date_secs(now_date)
+    captcha_url = ''
 
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
@@ -1862,6 +1863,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 encounter_result = req.get_buddy_walked()
                 encounter_result = req.call()
 
+                captcha_url = encounter_result['responses']['CHECK_CHALLENGE'][
+                        'challenge_url']  # Check for captcha
+                if len(captcha_url) > 1:  # Throw warning but finish parsing
+                    log.debug('Account encountered a reCaptcha.')
+
             pokemon[p['encounter_id']] = {
                 'encounter_id': b64encode(str(p['encounter_id'])),
                 'spawnpoint_id': p['spawn_point_id'],
@@ -1919,8 +1925,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         # Complete tutorial with a Pokestop spin
-        captcha_url = encounter_result['responses'][
-                'CHECK_CHALLENGE']['challenge_url']  # Just to be sure
         if args.complete_tutorial and not (len(captcha_url) > 1):
             if config['parse_pokestops']:
                 tutorial_pokestop_spin(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1919,7 +1919,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         # Complete tutorial with a Pokestop spin
-        captcha_url = map_dict['responses'][
+        captcha_url = encounter_result['responses'][
                 'CHECK_CHALLENGE']['challenge_url']  # Just to be sure
         if args.complete_tutorial and not (len(captcha_url) > 1):
             if config['parse_pokestops']:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -988,7 +988,7 @@ def search_worker_thread(args, account_queue, account_failures,
                         break
 
                     parsed = parse_map(args, response_dict, step_location,
-                                       dbq, whq, api, scan_date)
+                                       dbq, whq, api, scan_date, account)
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR focuses on implementing a single spin of a Pokéstop in the end of the RocketMap account tutorial, resulting in a level 2 *ding* of the worker. 
## Description
<!--- Describe your changes in detail -->
The PR adds functionality to the ``--complete-tutorial`` flag. After the basic tutorial, the worker is checked with the first map-call if it is still level 1, if that is the case a nearby Pokéstop is spun. With this single Pokéstop spin, the Pokéstop-of-the-day bonus will result in an immediate rise to level 2 beucause of the the basic tutorial before. With the correct settings a big number of workers can complete the tutorial and level up to level 2 fast. How it works is detailed in the ``docs/extras/tutorial.md`` documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the introduction of reCaptcha to Pokémon GO a new goal was set, to minimize those occurrences on your workers. While this is achievable with a good scanning method, timing and speed-limit, you won't get rid or almost rid of them. Running the newest API together with a not described hashing service and slightly level accounts (level 2) will result in almost no reCaptcha for your worker.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By myself and various Discord users, leveling up their new accounts. Here, a fresh installation was used together with a pre-configured ``config.ini``. Here, we were able to excel in more than 25 accounts per 90 seconds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project. (we will see, dear flake8)
- [x] My change requires a change to the documentation. 
- [x] I have updated the documentation accordingly. (I set up a basic documentation already)
