### PR TITLE
Optimize mysql data types for pokemon and gympokemon table

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -14,6 +14,7 @@ from pogom.utils import get_args
 from datetime import timedelta
 from collections import OrderedDict
 from bisect import bisect_left
+from decimal import Decimal
 
 from . import config
 from .models import (Pokemon, Gym, Pokestop, ScannedLocation,
@@ -563,6 +564,8 @@ class CustomJSONEncoder(JSONEncoder):
                     obj.microsecond / 1000
                 )
                 return millis
+            if isinstance(obj, Decimal):
+                return float(obj)
             iterable = iter(obj)
         except TypeError:
             pass

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -14,7 +14,6 @@ from pogom.utils import get_args
 from datetime import timedelta
 from collections import OrderedDict
 from bisect import bisect_left
-from decimal import Decimal
 
 from . import config
 from .models import (Pokemon, Gym, Pokestop, ScannedLocation,
@@ -564,8 +563,6 @@ class CustomJSONEncoder(JSONEncoder):
                     obj.microsecond / 1000
                 )
                 return millis
-            if isinstance(obj, Decimal):
-                return float(obj)
             iterable = iter(obj)
         except TypeError:
             pass

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2505,7 +2505,3 @@ def database_migrate(db, old_ver):
                            'MODIFY COLUMN `height` FLOAT NULL DEFAULT NULL,'
                            'MODIFY COLUMN `gender` SMALLINT NULL DEFAULT NULL'
                            ';')
-            db.execute_sql('ALTER TABLE `gympokemon` '
-                           'MODIFY COLUMN `weight` FLOAT NULL DEFAULT NULL,'
-                           'MODIFY COLUMN `height` FLOAT NULL DEFAULT NULL'
-                           ';')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2505,9 +2505,14 @@ def database_migrate(db, old_ver):
         # we don't have to touch sqlite because it has REAL and INTEGER only
         if args.db_type == 'mysql':
             db.execute_sql('ALTER TABLE `pokemon` '
-                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT NULL,'
-                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT NULL,'
-                           'MODIFY COLUMN `gender` SMALLINT NULL DEFAULT NULL;')
+                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT '
+                           ' NULL,'
+                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT '
+                           'NULL,'
+                           'MODIFY COLUMN `gender` SMALLINT NULL DEFAULT '
+                           ' NULL;')
             db.execute_sql('ALTER TABLE `gympokemon` '
-                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT NULL,'
-                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT NULL;')
+                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT '
+                           'NULL,'
+                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT '
+                           ' NULL;')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -38,7 +38,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 14
+db_schema_version = 15
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -102,8 +102,8 @@ class Pokemon(BaseModel):
     individual_stamina = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    weight = DoubleField(null=True)
-    height = DoubleField(null=True)
+    weight = FloatField(null=True)
+    height = FloatField(null=True)
     gender = IntegerField(null=True)
     last_modified = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
@@ -2496,3 +2496,11 @@ def database_migrate(db, old_ver):
             migrator.add_column('pokemon', 'gender',
                                 IntegerField(null=True, default=0))
         )
+
+    if old_ver < 15:
+        # change pokemon.weight and pokemon.height to float
+        # we don't have to touch sqlite because it has REAL only
+        if args.db_type == 'mysql':
+            db.execute_sql('ALTER TABLE `pokemon` '
+                           'MODIFY COLUMN `weight` FLOAT NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `height` FLOAT NULL DEFAULT NULL;')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -13,8 +13,8 @@ import math
 from peewee import InsertQuery, \
     Check, CompositeKey, ForeignKeyField, \
     SmallIntegerField, IntegerField, CharField, DoubleField, BooleanField, \
-    DateTimeField, DecimalField, fn, DeleteQuery, FloatField, SQL, TextField, \
-    JOIN, OperationalError
+    DateTimeField, fn, DeleteQuery, FloatField, SQL, TextField, JOIN, \
+    OperationalError
 from playhouse.flask_utils import FlaskDB
 from playhouse.pool import PooledMySQLDatabase
 from playhouse.shortcuts import RetryOperationalError, case
@@ -102,10 +102,8 @@ class Pokemon(BaseModel):
     individual_stamina = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    weight = DecimalField(
-        null=True, max_digits=6, decimal_places=2, auto_round=True)
-    height = DecimalField(
-        null=True, max_digits=5, decimal_places=2, auto_round=True)
+    weight = FloatField(null=True)
+    height = FloatField(null=True)
     gender = SmallIntegerField(null=True)
     last_modified = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
@@ -1610,10 +1608,8 @@ class GymPokemon(BaseModel):
     num_upgrades = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    height = DecimalField(
-        null=True, max_digits=5, decimal_places=2, auto_round=True)
-    weight = DecimalField(
-        null=True, max_digits=6, decimal_places=2, auto_round=True)
+    height = FloatField(null=True)
+    weight = FloatField(null=True)
     stamina = IntegerField(null=True)
     stamina_max = IntegerField(null=True)
     cp_multiplier = FloatField(null=True)
@@ -2505,14 +2501,11 @@ def database_migrate(db, old_ver):
         # we don't have to touch sqlite because it has REAL and INTEGER only
         if args.db_type == 'mysql':
             db.execute_sql('ALTER TABLE `pokemon` '
-                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT '
-                           ' NULL,'
-                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT '
-                           'NULL,'
-                           'MODIFY COLUMN `gender` SMALLINT NULL DEFAULT '
-                           ' NULL;')
+                           'MODIFY COLUMN `weight` FLOAT NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `height` FLOAT NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `gender` SMALLINT NULL DEFAULT NULL'
+                           ';')
             db.execute_sql('ALTER TABLE `gympokemon` '
-                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT '
-                           'NULL,'
-                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT '
-                           ' NULL;')
+                           'MODIFY COLUMN `weight` FLOAT NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `height` FLOAT NULL DEFAULT NULL'
+                           ';')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -12,9 +12,9 @@ import geopy
 import math
 from peewee import InsertQuery, \
     Check, CompositeKey, ForeignKeyField, \
-    IntegerField, CharField, DoubleField, BooleanField, \
-    DateTimeField, fn, DeleteQuery, FloatField, SQL, TextField, JOIN, \
-    OperationalError
+    SmallIntegerField, IntegerField, CharField, DoubleField, BooleanField, \
+    DateTimeField, DecimalField, fn, DeleteQuery, FloatField, SQL, TextField, \
+    JOIN, OperationalError
 from playhouse.flask_utils import FlaskDB
 from playhouse.pool import PooledMySQLDatabase
 from playhouse.shortcuts import RetryOperationalError, case
@@ -102,9 +102,9 @@ class Pokemon(BaseModel):
     individual_stamina = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    weight = FloatField(null=True)
-    height = FloatField(null=True)
-    gender = IntegerField(null=True)
+    weight = DecimalField(null=True, max_digits=6, decimal_places=2)
+    height = DecimalField(null=True, max_digits=5, decimal_places=2)
+    gender = SmallIntegerField(null=True)
     last_modified = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
 
@@ -1608,8 +1608,8 @@ class GymPokemon(BaseModel):
     num_upgrades = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    height = FloatField(null=True)
-    weight = FloatField(null=True)
+    height = DecimalField(null=True, max_digits=5, decimal_places=2)
+    weight = DecimalField(null=True, max_digits=6, decimal_places=2)
     stamina = IntegerField(null=True)
     stamina_max = IntegerField(null=True)
     cp_multiplier = FloatField(null=True)
@@ -2498,9 +2498,12 @@ def database_migrate(db, old_ver):
         )
 
     if old_ver < 15:
-        # change pokemon.weight and pokemon.height to float
-        # we don't have to touch sqlite because it has REAL only
+        # we don't have to touch sqlite because it has REAL and INTEGER only
         if args.db_type == 'mysql':
             db.execute_sql('ALTER TABLE `pokemon` '
-                           'MODIFY COLUMN `weight` FLOAT NULL DEFAULT NULL,'
-                           'MODIFY COLUMN `height` FLOAT NULL DEFAULT NULL;')
+                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `gender` SMALLINT NULL DEFAULT NULL;')
+            db.execute_sql('ALTER TABLE `gympokemon` '
+                           'MODIFY COLUMN `weight` DECIMAL(6,2) NULL DEFAULT NULL,'
+                           'MODIFY COLUMN `height` DECIMAL(5,2) NULL DEFAULT NULL;')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -102,8 +102,10 @@ class Pokemon(BaseModel):
     individual_stamina = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    weight = DecimalField(null=True, max_digits=6, decimal_places=2)
-    height = DecimalField(null=True, max_digits=5, decimal_places=2)
+    weight = DecimalField(
+        null=True, max_digits=6, decimal_places=2, auto_round=True)
+    height = DecimalField(
+        null=True, max_digits=5, decimal_places=2, auto_round=True)
     gender = SmallIntegerField(null=True)
     last_modified = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
@@ -1608,8 +1610,10 @@ class GymPokemon(BaseModel):
     num_upgrades = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
-    height = DecimalField(null=True, max_digits=5, decimal_places=2)
-    weight = DecimalField(null=True, max_digits=6, decimal_places=2)
+    height = DecimalField(
+        null=True, max_digits=5, decimal_places=2, auto_round=True)
+    weight = DecimalField(
+        null=True, max_digits=6, decimal_places=2, auto_round=True)
     stamina = IntegerField(null=True)
     stamina_max = IntegerField(null=True)
     cp_multiplier = FloatField(null=True)


### PR DESCRIPTION
## Description
- let's not waste space for each pokemon
- Use float for height and weight instead of double
  - API uses float as well
  - App displays only 2 digits after dot
- Use smallint for gender
  - no need for integer for such a few genders
  - we can't use tinyint because peewee doesn't support it

## Motivation and Context
- it makes some difference for huge pokemon tables

## How Has This Been Tested?
- tested with mysql and sqlite but please test before merge

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.