### PR TITLE
Fix sprites extract

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -879,6 +879,6 @@ def generate_device_info():
 
 def extract_sprites():
     log.debug("Extracting sprites...")
-    zip = zipfile('static01.zip', 'r')
+    zip = zipfile.ZipFile('static01.zip', 'r')
     zip.extractall('static')
     zip.close()


### PR DESCRIPTION
Fixes `TypeError: 'module' object is not callable`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.