### PR TITLE
Redirect logging messages to stderr or stdout depending on the logging level

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -33,11 +33,35 @@ from pogom.proxy import check_proxies, proxies_refresher
 # Currently supported pgoapi.
 pgoapi_version = "1.1.7"
 
+
+class LogFilter(logging.Filter):
+
+    def __init__(self, level):
+        self.level = level
+
+    def filter(self, record):
+        return record.levelno < self.level
+
+
 # Moved here so logger is configured at load time.
-logging.basicConfig(
-    format='%(asctime)s [%(threadName)18s][%(module)14s][%(levelname)8s] ' +
-    '%(message)s')
+formatter = logging.Formatter(
+    '%(asctime)s [%(threadName)18s][%(module)14s][%(levelname)8s] %(message)s')
+
+# Redirect messages lower than WARNING to stdout
+stdout_hdlr = logging.StreamHandler(sys.stdout)
+stdout_hdlr.setFormatter(formatter)
+log_filter = LogFilter(logging.WARNING)
+stdout_hdlr.addFilter(log_filter)
+stdout_hdlr.setLevel(logging.DEBUG)
+
+# Redirect messages equal or higher than WARNING to stderr
+stderr_hdlr = logging.StreamHandler(sys.stderr)
+stderr_hdlr.setFormatter(formatter)
+stderr_hdlr.setLevel(logging.WARNING)
+
 log = logging.getLogger()
+log.addHandler(stdout_hdlr)
+log.addHandler(stderr_hdlr)
 
 # Make sure pogom/pgoapi is actually removed if it is an empty directory.
 # This is a leftover directory from the time pgoapi was embedded in


### PR DESCRIPTION
Redirect logging messages to stderr or stdout depending on the logging level

## Description
Redirect messages lower than WARNING to stdout and redirect messages equal or higher than WARNING to stderr

## Motivation and Context
Currently all logging messages are redirected to stderr without take into account the logging level, so DEBUG and INFO levels are redirected to stderr. This is so annyoing when you are using some tool to run your python processes which logs stdout and stderr to distinct log files (like Docker, PM2...) and as a result all of them go to the error log file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.