### PR TITLE
Making api check work when we are ahead of forced api

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -353,7 +353,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     account_queue = Queue()
     threadStatus = {}
     key_scheduler = None
-    api_version = '0.57.2'
+    api_version = '0.57.3'
     api_check_time = 0
 
     '''
@@ -1233,7 +1233,7 @@ def check_forced_version(args, api_version, api_check_time, pause_bit):
         api_check_time = int(time.time()) + args.version_check_interval
         forced_api = get_api_version(args)
 
-        if (api_version != forced_api and forced_api != 0):
+        if (api_version < forced_api and forced_api != 0):
             pause_bit.set()
             log.info(('Started with API: {}, ' +
                       'Niantic forced to API: {}').format(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update api check to make it possible to be ahead of forced api.
## Description
<!--- Describe your changes in detail -->
Check if forced api is newer than the api currently using rather than checking if they are different.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we are ahead of forced api and when we change the api version, the scanner will pause.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on personal computer with window 7
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
