### PR TITLE
Webhooks whitelist and blacklist

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1897,8 +1897,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'gender': pokemon_info['pokemon_display']['gender'],
                 })
 
-            if args.webhooks:
-
+            if (args.webhooks and (p['pokemon_data']['pokemon_id']
+                                    in args.webhook_whitelist or
+                                    p['pokemon_data']['pokemon_id']
+                                    not in args.webhook_blacklist and
+                                    not args.webhook_whitelist)):
                 wh_poke = pokemon[p['encounter_id']].copy()
                 wh_poke.update({
                     'disappear_time': calendar.timegm(

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1898,10 +1898,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 })
 
             if (args.webhooks and (p['pokemon_data']['pokemon_id']
-                                    in args.webhook_whitelist or
-                                    p['pokemon_data']['pokemon_id']
-                                    not in args.webhook_blacklist and
-                                    not args.webhook_whitelist)):
+                                   in args.webhook_whitelist or
+                                   p['pokemon_data']['pokemon_id']
+                                   not in args.webhook_blacklist and
+                                   not args.webhook_whitelist)):
                 wh_poke = pokemon[p['encounter_id']].copy()
                 wh_poke.update({
                     'disappear_time': calendar.timegm(

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -169,6 +169,26 @@ def get_args():
                                 default='', help='File containing a list of '
                                                  'Pokemon to NOT encounter for'
                                                  ' more stats.')
+                                                 
+    webhook_list = parser.add_mutually_exclusive_group()
+    webhook_list.add_argument('-wwht', '--webhook-whitelist',
+                                action='append', default=[],
+                                help=('List of Pokemon to send to '
+                                ' webhooks.'))
+    webhook_list.add_argument('-wblk', '--webhook-blacklist',
+                                action='append', default=[],
+                                help=('List of Pokemon to NOT send to'
+                                ' webhooks.'))
+
+    webhook_list.add_argument('-wwhtf', '--webhook-whitelist-file',
+                                default='', help='File containing a list of '
+                                                 'Pokemon to send to'
+                                                 ' webhooks.')
+    webhook_list.add_argument('-wblkf', '--webhook-blacklist-file',
+                                default='', help='File containing a list of '
+                                                 'Pokemon to NOT send to'
+                                                 ' webhooks.')
+                                        
     parser.add_argument('-ld', '--login-delay',
                         help='Time delay between each login attempt.',
                         type=float, default=6)
@@ -640,6 +660,20 @@ def get_args():
             args.encounter_whitelist = [int(i) for i in
                                         args.encounter_whitelist]
 
+        if args.webhook_whitelist_file:
+            with open(args.webhook_whitelist_file) as f:
+                args.webhook_whitelist = [get_pokemon_id(name) for name in
+                                            f.read().splitlines()]
+        elif args.webhook_blacklist_file:
+            with open(args.webhook_blacklist_file) as f:
+                args.webhook_blacklist = [get_pokemon_id(name) for name in
+                                            f.read().splitlines()]
+        else:
+            args.webhook_blacklist = [int(i) for i in
+                                        args.webhook_blacklist]
+            args.webhook_whitelist = [int(i) for i in
+                                        args.webhook_whitelist]
+                                        
         # Decide which scanning mode to use.
         if args.spawnpoint_scanning:
             args.scheduler = 'SpawnScan'

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -169,26 +169,24 @@ def get_args():
                                 default='', help='File containing a list of '
                                                  'Pokemon to NOT encounter for'
                                                  ' more stats.')
-                                                 
     webhook_list = parser.add_mutually_exclusive_group()
     webhook_list.add_argument('-wwht', '--webhook-whitelist',
-                                action='append', default=[],
-                                help=('List of Pokemon to send to '
-                                ' webhooks.'))
+                              action='append', default=[],
+                              help=('List of Pokemon to send to '
+                                    ' webhooks.'))
     webhook_list.add_argument('-wblk', '--webhook-blacklist',
-                                action='append', default=[],
-                                help=('List of Pokemon to NOT send to'
-                                ' webhooks.'))
+                              action='append', default=[],
+                              help=('List of Pokemon to NOT send to'
+                                    ' webhooks.'))
 
     webhook_list.add_argument('-wwhtf', '--webhook-whitelist-file',
-                                default='', help='File containing a list of '
-                                                 'Pokemon to send to'
-                                                 ' webhooks.')
+                              default='', help='File containing a list of '
+                                               'Pokemon to send to'
+                                               ' webhooks.')
     webhook_list.add_argument('-wblkf', '--webhook-blacklist-file',
-                                default='', help='File containing a list of '
-                                                 'Pokemon to NOT send to'
-                                                 ' webhooks.')
-                                        
+                              default='', help='File containing a list of '
+                                               'Pokemon to NOT send to'
+                                               ' webhooks.')
     parser.add_argument('-ld', '--login-delay',
                         help='Time delay between each login attempt.',
                         type=float, default=6)
@@ -663,17 +661,16 @@ def get_args():
         if args.webhook_whitelist_file:
             with open(args.webhook_whitelist_file) as f:
                 args.webhook_whitelist = [get_pokemon_id(name) for name in
-                                            f.read().splitlines()]
+                                          f.read().splitlines()]
         elif args.webhook_blacklist_file:
             with open(args.webhook_blacklist_file) as f:
                 args.webhook_blacklist = [get_pokemon_id(name) for name in
-                                            f.read().splitlines()]
+                                          f.read().splitlines()]
         else:
             args.webhook_blacklist = [int(i) for i in
-                                        args.webhook_blacklist]
+                                      args.webhook_blacklist]
             args.webhook_whitelist = [int(i) for i in
-                                        args.webhook_whitelist]
-                                        
+                                      args.webhook_whitelist]
         # Decide which scanning mode to use.
         if args.spawnpoint_scanning:
             args.scheduler = 'SpawnScan'


### PR DESCRIPTION
Added several parameters to create a whitelist/blacklist for managing what pokemon
are sent to webhooks.  This should reduce load on webhooks, and
network traffic for things that people do not specifically want sent.
(Or if they do want specific ones)

## Description
Mirroring the encounter whitelist/blacklist concept I adjust this to create a new method for whitelist/blacklist for what to send, or not send, to your webhooks.

## Motivation and Context
When you begin to have many areas, webhooks get beat on pretty well.  Adn with proper design that can be mitigated, it doesn't mitigate the log and console output that is generated from webhook traffic.

2017-03-03 14:42:29,777 [   Manager][    INFO] Paras ignored: filter was not set
2017-03-03 14:42:29,777 [   Manager][    INFO] Paras ignored: filter was not set
2017-03-03 14:42:29,778 [   Manager][    INFO] Paras ignored: filter was not set
2017-03-03 14:42:29,778 [   Manager][    INFO] Paras ignored: filter was not set
2017-03-03 14:42:29,778 [   Manager][    INFO] Paras ignored: filter was not set
2017-03-03 14:42:29,778 [   Manager][    INFO] Paras ignored: filter was not set
2017-03-03 14:42:29,786 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:29,787 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:29,787 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:29,787 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:29,788 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:29,788 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:29,788 [   Manager][    INFO] Mankey ignored: filter was not set
2017-03-03 14:42:31,971 [   Manager][    INFO] Beedrill ignored: filter was not set
2017-03-03 14:42:31,972 [   Manager][    INFO] Beedrill ignored: filter was not set
2017-03-03 14:42:31,972 [   Manager][    INFO] Beedrill ignored: filter was not set
2017-03-03 14:42:31,973 [   Manager][    INFO] Beedrill ignored: filter was not set
2017-03-03 14:42:31,973 [   Manager][    INFO] Beedrill ignored: filter was not set
2017-03-03 14:42:31,973 [   Manager][    INFO] Beedrill ignored: filter was not set
2017-03-03 14:42:31,973 [   Manager][    INFO] Beedrill ignored: filter was not set

This is a lot of log and effort for 3 pokemon.

## How Has This Been Tested?
This was tested in my local instance using all forms of whitelist and blacklist that can be provided.

## Screenshots (if appropriate):
Using a simple whitelist of 13,69,163,220 you can see the output from RM and PokeAlert here:
![2017-03-03_15-47-21](https://cloud.githubusercontent.com/assets/7101432/23568541/e7f7172a-0028-11e7-957c-f90d28fc04b2.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
