### PR TITLE
Make title customizable

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -56,6 +56,7 @@
 #ssl-privatekey:        # path to ssl private key
 #encrypt-lib:           # path to encrypt lib to be used instead of the shipped ones
 #status-page-password:  # enables and protects the /status page to view status of all workers
+#title:                 # title to use (default Rocket Map)
 
 # Uncomment a line when you want to change its default value (Remove # at the beginning)
 # Please ensure to leave a space after the colon (:) (example setting: value)

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -35,6 +35,7 @@
                         [-spp STATUS_PAGE_PASSWORD] [-hk HASH_KEY] [-tut]
                         [-el ENCRYPT_LIB] [-odt ON_DEMAND_TIMEOUT]
                         [-v [filename.log] | -vv [filename.log]]
+                        [--title TITLE]
 
     Args that start with '--' (eg. -a) can also be set in a config file
     (default: <RocketMap Project Root>/config/config.ini or specified
@@ -321,3 +322,6 @@
                             Like verbose, but show debug messages from all modules
                             as well. Optionally specify file to log to. [env var:
                             POGOMAP_VERY_VERBOSE]
+      --title TITLE
+                            Changes the application title from 'Rocket Map'. [env
+                            var: POGOMAP_TITLE]

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -517,11 +517,13 @@ class Pogom(Flask):
         return valid_input
 
     def get_stats(self):
+        args = get_args()
         return render_template('statistics.html',
                                lat=self.current_location[0],
                                lng=self.current_location[1],
                                gmaps_key=config['GMAPS_KEY'],
-                               valid_input=self.get_valid_stat_input()
+                               valid_input=self.get_valid_stat_input(),
+                               title=args.title
                                )
 
     def get_gymdata(self):
@@ -535,7 +537,9 @@ class Pogom(Flask):
         if args.status_page_password is None:
             abort(404)
 
-        return render_template('status.html')
+        return render_template('status.html',
+                               title=args.title
+                               )
 
     def post_status(self):
         args = get_args()

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -67,7 +67,8 @@ class Pogom(Flask):
     def get_bookmarklet(self):
         args = get_args()
         return render_template('bookmarklet.html',
-                               domain=args.manual_captcha_domain)
+                               domain=args.manual_captcha_domain,
+                               title=args.title)
 
     def render_inject_js(self):
         args = get_args()

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -164,7 +164,8 @@ class Pogom(Flask):
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,
                                search_control=search_display,
-                               show_scan=scan_display
+                               show_scan=scan_display,
+                               title=args.title
                                )
 
     def raw_data(self):

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -406,6 +406,9 @@ def get_args():
     parser.add_argument('--disable-blacklist',
                         help=('Disable the global anti-scraper IP blacklist.'),
                         action='store_true', default=False)
+    parser.add_argument('--title',
+                        help=('Set title'),
+                        type=str, default='Rocket Map')
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose',
                            help=('Show debug messages from RocketMap ' +

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -407,7 +407,7 @@ def get_args():
                         help=('Disable the global anti-scraper IP blacklist.'),
                         action='store_true', default=False)
     parser.add_argument('--title',
-                        help=('Set title'),
+                        help=('Set the map title'),
                         type=str, default='Rocket Map')
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose',

--- a/templates/bookmarklet.html
+++ b/templates/bookmarklet.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>RocketMap - Bookmarklet</title>
+    <title>{{title}} - Bookmarklet</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/app.min.css').lstrip('/') }}">
 </head>
   <body style="width:660px; margin:40px auto;">

--- a/templates/map.html
+++ b/templates/map.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <meta name="apple-mobile-web-app-title" content="PokeMap">
+    <meta name="apple-mobile-web-app-title" content="{{title}}">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="theme-color" content="#3b3b3b">
     <!-- Fav- & Apple-Touch-Icons -->

--- a/templates/map.html
+++ b/templates/map.html
@@ -2,7 +2,7 @@
 <html lang="{{lang}}">
   <head>
     <meta charset="utf-8">
-    <title>Rocket Map</title>
+    <title>{{title}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -38,7 +38,7 @@
       <!-- Header -->
       <header id="header">
         <a href="#nav"><span class="label">Options</span></a>
-        <h1><a href="#">Rocket Map</a></h1>
+        <h1><a href="#">{{title}}</a></h1>
         <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
       </header>
       <!-- NAV -->

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Rocket Map - Statistics</title>
+    <title>{{title}} - Statistics</title>
 
     <!-- Fav- & Apple-Touch-Icons -->
     <!-- Favicon -->
@@ -41,7 +41,7 @@
         <!-- Header -->
         <header id="header">
             <a href="#nav">Options</a>
-            <h1><a href="./">Rocket Map</a></h1>
+            <h1><a href="./">{{title}}</a></h1>
         </header>
         <nav id="nav">
           <div class="ui-accordion-content">

--- a/templates/status.html
+++ b/templates/status.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Rocket Map - Status</title>
+    <title>{{title}} - Status</title>
 
     <!-- Fav- & Apple-Touch-Icons -->
     <!-- Favicon -->
@@ -35,7 +35,7 @@
 <!-- Header -->
 <header id="header">
     <a href="#nav"><span class="label">Options</span></a>
-    <h1><a href="./">Rocket Map</a></h1>
+    <h1><a href="./">{{title}}</a></h1>
 </header>
 <nav id="nav">
   <div id="nav-accordion">


### PR DESCRIPTION
## Description
Adds a `--title` argument and a `title` template variable to override the default 'Rocket Map' title.

## Motivation and Context
I wanted to change the title from 'Rocket Map' to 'Pokemon Go map of $cityname', to make it more clear to my users.

## How Has This Been Tested?
1. Made changes
2. Use no config.ini with only req params (gmap key, location, username, password)
3. Observe title 'Rocket Map'
4. Cp config.ini.example config.ini
5. Change title in config.ini
6. Observe my custom title

## Screenshots (if appropriate):
![rocketmap-title-pr-1](https://cloud.githubusercontent.com/assets/1611537/23656715/1caeaac2-033b-11e7-8b7a-fd3f7e9d742b.png)
Without using title

![rocketmap-title-pr-2](https://cloud.githubusercontent.com/assets/1611537/23656718/1f9109c4-033b-11e7-9940-dc888972e1ed.png)
WIth using config: `title: My custom title`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
