### PR TITLE
Change api_version to 0.57.4

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -353,7 +353,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     account_queue = Queue()
     threadStatus = {}
     key_scheduler = None
-    api_version = '0.57.2'
+    api_version = '0.57.4'
     api_check_time = 0
 
     '''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the error `Started with API: 0.57.2, Niantic forced to API: 0.57.4 Scanner paused due to forced Niantic API update.`

## Motivation and Context
We can scan again.

## How Has This Been Tested?
I ran it. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
