### PR TITLE
Fix issue with negative average delays

### DIFF
--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -1040,9 +1040,9 @@ class SpeedScan(HexSearch):
             seconds_within_band = (
                 int((datetime.utcnow() - self.refresh_date).total_seconds()) +
                 self.refresh_ms)
-            start_delay = (
-                seconds_within_band - item['start'] -
-                (self.args.spawn_delay if item['kind'] == 'spawn' else 0))
+            enforced_delay = (self.args.spawn_delay if item['kind'] == 'spawn'
+                              else 0)
+            start_delay = seconds_within_band - item['start'] + enforced_delay
             safety_buffer = item['end'] - seconds_within_band
 
             if safety_buffer < 0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The problem was with negative start_delays.
Enforced start_delay should be subtracted just from
item['start'] but not from the seconds_within_band
In the whole expression it should be an addition.

The original author may made a mistake when removing the
parentheses.

## Motivation and Context
Negative average delays should not happen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.