### PR TITLE
Minor documentation fix and additional documentation

### DIFF
--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -32,7 +32,7 @@ The default configuration file is *config/config.ini* underneath the project hom
   location: seattle, wa
   step-limit: 5
   gmaps-key: MyGmapsKeyGoesHereSomeLongString
-  print-status: True
+  print-status: "status"
   -- end of file --
   </pre>
 

--- a/docs/extras/hashing.md
+++ b/docs/extras/hashing.md
@@ -14,6 +14,16 @@ Please don't ask *"What if my step size is _x_, and I have encounters for _y_ Po
 We still don't know.  Get a key, turn on your map and see if it works.
 If you are getting rate limited then either get more keys, or lower your calls (disabling/reducing encounters, disabling gym details, and decreasing step size are a few ways to reduce calls)
 
+You can get a more detailed view of how many Hash key calls are being used by enabling the status view `-ps` / `--print-status` and typing `h` followed by the enter key.  
+
+## Where do I enter my hash key?
+Use `-hk YourHashKeyHere` / `--hash-key YourHashKeyHere`.  
+If you use a configuration file, add the line `hash-key: YourHashKeyHere` to that file.
+
+## What if I have more than one hash key?
+Specify `-hk YourHashKeyHere -hk YourSecondHashKeyHere ...`.  
+If you use a configuration file, use `hash-key: [YourHashKeyHere, YourSecondHashKeyHere, ...]` in the file.
+
 ## What does HashingQuotaExceededException('429: Request limited, error: ',) mean?
 Any variant of this means you've exceeded the Requests Per Minute that your key allows.
 


### PR DESCRIPTION
## Description
Fixed a configuration file example that was using an invalid value.  
Added command line and configuration file documentation for the Hash key.

## Motivation and Context
The invalid value caused the example, if used 'as is', to fail.  
The cl/config documentation for hash key makes it easier for new users to find where the hash key should be specified, similar to the captcha key documentation.

## How Has This Been Tested?
n/a - presumably this formats correctly on readthedocs, although I noticed that other documentation the double-space for newlines may not be working, or readthedocs has outdated files.