### PR TITLE
24h spawn history

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "centerLng": true,
     "pageLoaded": true,
     "countMarkers": true,
+	"getStats": true,
     "skel": true,
     "setupPokemonMarker": true,
 

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -63,7 +63,15 @@ class Pogom(Flask):
         self.route("/inject.js", methods=['GET'])(self.render_inject_js)
         self.route("/submit_token", methods=['POST'])(self.submit_token)
         self.route("/get_stats", methods=['GET'])(self.get_account_stats)
+        self.route("/spawn_history", methods=['GET'])(self.spawn_history)
 
+    def spawn_history(self):
+         d = {}
+         spawnpoint_id = request.args.get('spawnpoint_id')
+         d['spawn_history'] = Pokemon.get_spawn_history(spawnpoint_id)
+ 
+         return jsonify(d)
+ 
     def get_bookmarklet(self):
         args = get_args()
         return render_template('bookmarklet.html',

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -66,12 +66,12 @@ class Pogom(Flask):
         self.route("/spawn_history", methods=['GET'])(self.spawn_history)
 
     def spawn_history(self):
-         d = {}
-         spawnpoint_id = request.args.get('spawnpoint_id')
-         d['spawn_history'] = Pokemon.get_spawn_history(spawnpoint_id)
- 
-         return jsonify(d)
- 
+        d = {}
+        spawnpoint_id = request.args.get('spawnpoint_id')
+        d['spawn_history'] = Pokemon.get_spawn_history(spawnpoint_id)
+
+        return jsonify(d)
+
     def get_bookmarklet(self):
         args = get_args()
         return render_template('bookmarklet.html',

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -426,6 +426,20 @@ class Pokemon(BaseModel):
 
         return filtered
 
+    @classmethod
+    def get_spawn_history(cls, spawnpoint_id):
+         lastday = datetime.utcnow() - timedelta(hours=24)
+         query = (Pokemon
+                  .select(fn.Count(Pokemon.pokemon_id).alias('count'), Pokemon.pokemon_id)
+                  .where((Pokemon.spawnpoint_id == spawnpoint_id) &
+                         (Pokemon.disappear_time > lastday)
+                         )
+                  .group_by(Pokemon.pokemon_id)
+                  .order_by(-SQL('count'))
+                  .dicts())
+ 
+         return list(query)
+ 
 
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True, max_length=50)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -428,8 +428,8 @@ class Pokemon(BaseModel):
 
     @classmethod
     def get_spawn_history(cls, spawnpoint_id):
-         lastday = datetime.utcnow() - timedelta(hours=24)
-         query = (Pokemon
+        lastday = datetime.utcnow() - timedelta(hours=24)
+        query = (Pokemon
                   .select(fn.Count(Pokemon.pokemon_id).alias('count'), Pokemon.pokemon_id)
                   .where((Pokemon.spawnpoint_id == spawnpoint_id) &
                          (Pokemon.disappear_time > lastday)
@@ -438,8 +438,8 @@ class Pokemon(BaseModel):
                   .order_by(-SQL('count'))
                   .dicts())
  
-         return list(query)
- 
+        return list(query)
+
 
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True, max_length=50)

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -137,8 +137,8 @@
     if ($spawn) {
      // Event: Prevent clicks/taps inside the stats from bubbling.
         addEventsListener($spawn, 'click touchend', function (event) {
-         event.stopPropagation()
-     })
+            event.stopPropagation()
+        })
     }
     // Event: Hide nav on body click/tap.
     addEventsListener($body, 'click touchend', function (event) {
@@ -178,26 +178,26 @@
             event.stopPropagation()
             $stats.classList.toggle('visible')
             if ($('#stats').hasClass('visible')) {
-        if ($('#spawn').hasClass('visible')) {
-          $spawn.classList.toggle('visible')
-      }
-    }
+                if ($('#spawn').hasClass('visible')) {
+            $spawn.classList.toggle('visible')
+        }
+            }
         })
     }
 
   // Event: Toggle spawn on click.
     if ($spawnToggle) {
-      $spawnToggle.addEventListener('click', function (event) {
-        event.preventDefault()
-        event.stopPropagation()
-        $spawn.classList.toggle('visible')
-        if ($('#spawn').hasClass('visible')) {
-           if ($('#stats').hasClass('visible')) {
-             $stats.classList.toggle('visible')
-         }
-       }
-    })
-  }
+        $spawnToggle.addEventListener('click', function (event) {
+          event.preventDefault()
+          event.stopPropagation()
+          $spawn.classList.toggle('visible')
+          if ($('#spawn').hasClass('visible')) {
+            if ($('#stats').hasClass('visible')) {
+               $stats.classList.toggle('visible')
+           }
+        }
+      })
+    }
 
     // Close.
 
@@ -216,12 +216,12 @@
         $stats.appendChild($statsClose)
     }
     if ($spawn) {
-         $spawnClose = document.createElement('a')
-         $spawnClose.href = '#'
-         $spawnClose.className = 'close'
-         $spawnClose.tabIndex = 0
-         $spawn.appendChild($spawnClose)
-     }
+        $spawnClose = document.createElement('a')
+        $spawnClose.href = '#'
+        $spawnClose.className = 'close'
+        $spawnClose.tabIndex = 0
+        $spawn.appendChild($spawnClose)
+    }
     $gymSidebarClose = document.createElement('a')
     $gymSidebarClose.href = '#'
     $gymSidebarClose.className = 'close'
@@ -267,10 +267,10 @@
     }
     if ($spawnClose) {
      // Event: Hide stats on click.
-    $spawnClose.addEventListener('click', function (event) {
-            event.preventDefault()
-            event.stopPropagation()
-            $spawn.classList.remove('visible')
-        })
-}
+        $spawnClose.addEventListener('click', function (event) {
+        event.preventDefault()
+        event.stopPropagation()
+        $spawn.classList.remove('visible')
+    })
+    }
 })()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -108,10 +108,10 @@
     var $statsClose
 
 	// Spawnpoint History
-	var $spawn = document.querySelector('#spawn')
+    var $spawn = document.querySelector('#spawn')
     var $spawnToggle = document.querySelector('a[href="#spawn"]')
     var $spawnClose
- 
+
     // Gym sidebar
     var $gymSidebar = document.querySelector('#gym-details')
     var $gymSidebarClose
@@ -136,10 +136,10 @@
     }
     if ($spawn) {
      // Event: Prevent clicks/taps inside the stats from bubbling.
-     addEventsListener($spawn, 'click touchend', function (event) {
-       event.stopPropagation()
+        addEventsListener($spawn, 'click touchend', function (event) {
+         event.stopPropagation()
      })
-   }
+    }
     // Event: Hide nav on body click/tap.
     addEventsListener($body, 'click touchend', function (event) {
         // on ios safari, when navToggle is clicked,
@@ -153,7 +153,7 @@
         }
         if ($spawn && event.target.matches('a[href="#spawn]')) {
             return
-     }
+        }
         $nav.classList.remove('visible')
         if ($stats) {
             $stats.classList.remove('visible')
@@ -177,27 +177,27 @@
             event.preventDefault()
             event.stopPropagation()
             $stats.classList.toggle('visible')
-    if ($('#stats').hasClass('visible')) {
-      if ($('#spawn').hasClass('visible')) {
-           $spawn.classList.toggle('visible')
-         }
-       }
-     })
-   }
- 
-  // Event: Toggle spawn on click.
-  if ($spawnToggle) {
-    $spawnToggle.addEventListener('click', function (event) {
-      event.preventDefault()
-       event.stopPropagation()
-       $spawn.classList.toggle('visible')
-       if ($('#spawn').hasClass('visible')) {
-         if ($('#stats').hasClass('visible')) {
-           $stats.classList.toggle('visible')
-         }
-       }
+            if ($('#stats').hasClass('visible')) {
+        if ($('#spawn').hasClass('visible')) {
+          $spawn.classList.toggle('visible')
+      }
+    }
         })
     }
+
+  // Event: Toggle spawn on click.
+    if ($spawnToggle) {
+      $spawnToggle.addEventListener('click', function (event) {
+        event.preventDefault()
+        event.stopPropagation()
+        $spawn.classList.toggle('visible')
+        if ($('#spawn').hasClass('visible')) {
+           if ($('#stats').hasClass('visible')) {
+             $stats.classList.toggle('visible')
+         }
+       }
+    })
+  }
 
     // Close.
 
@@ -215,13 +215,13 @@
         $statsClose.tabIndex = 0
         $stats.appendChild($statsClose)
     }
-     if ($spawn) {
-     $spawnClose = document.createElement('a')
-     $spawnClose.href = '#'
-     $spawnClose.className = 'close'
-     $spawnClose.tabIndex = 0
-     $spawn.appendChild($spawnClose)
-    }
+    if ($spawn) {
+         $spawnClose = document.createElement('a')
+         $spawnClose.href = '#'
+         $spawnClose.className = 'close'
+         $spawnClose.tabIndex = 0
+         $spawn.appendChild($spawnClose)
+     }
     $gymSidebarClose = document.createElement('a')
     $gymSidebarClose.href = '#'
     $gymSidebarClose.className = 'close'
@@ -265,12 +265,12 @@
             $gymSidebar.classList.remove('visible')
         })
     }
-	if ($spawnClose) {
+    if ($spawnClose) {
      // Event: Hide stats on click.
-        $spawnClose.addEventListener('click', function (event) {
-        event.preventDefault()
-        event.stopPropagation()
-        $spawn.classList.remove('visible')
-     })
-   }
+    $spawnClose.addEventListener('click', function (event) {
+            event.preventDefault()
+            event.stopPropagation()
+            $spawn.classList.remove('visible')
+        })
+}
 })()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -179,8 +179,8 @@
             $stats.classList.toggle('visible')
             if ($('#stats').hasClass('visible')) {
                 if ($('#spawn').hasClass('visible')) {
-            $spawn.classList.toggle('visible')
-        }
+                    $spawn.classList.toggle('visible')
+                }
             }
         })
     }
@@ -188,15 +188,15 @@
   // Event: Toggle spawn on click.
     if ($spawnToggle) {
         $spawnToggle.addEventListener('click', function (event) {
-          event.preventDefault()
-          event.stopPropagation()
-          $spawn.classList.toggle('visible')
-          if ($('#spawn').hasClass('visible')) {
-            if ($('#stats').hasClass('visible')) {
-               $stats.classList.toggle('visible')
-           }
-        }
-      })
+            event.preventDefault()
+            event.stopPropagation()
+            $spawn.classList.toggle('visible')
+            if ($('#spawn').hasClass('visible')) {
+              if ($('#stats').hasClass('visible')) {
+                $stats.classList.toggle('visible')
+            }
+          }
+        })
     }
 
     // Close.
@@ -268,9 +268,9 @@
     if ($spawnClose) {
      // Event: Hide stats on click.
         $spawnClose.addEventListener('click', function (event) {
-        event.preventDefault()
-        event.stopPropagation()
-        $spawn.classList.remove('visible')
-    })
+            event.preventDefault()
+            event.stopPropagation()
+            $spawn.classList.remove('visible')
+        })
     }
 })()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -107,6 +107,11 @@
     var $statsToggle = document.querySelector('a[href="#stats"]')
     var $statsClose
 
+	// Spawnpoint History
+	var $spawn = document.querySelector('#spawn')
+    var $spawnToggle = document.querySelector('a[href="#spawn"]')
+    var $spawnClose
+ 
     // Gym sidebar
     var $gymSidebar = document.querySelector('#gym-details')
     var $gymSidebarClose
@@ -129,7 +134,12 @@
             event.stopPropagation()
         })
     }
-
+    if ($spawn) {
+     // Event: Prevent clicks/taps inside the stats from bubbling.
+     addEventsListener($spawn, 'click touchend', function (event) {
+       event.stopPropagation()
+     })
+   }
     // Event: Hide nav on body click/tap.
     addEventsListener($body, 'click touchend', function (event) {
         // on ios safari, when navToggle is clicked,
@@ -141,9 +151,15 @@
         if ($stats && event.target.matches('a[href="#stats"]')) {
             return
         }
+        if ($spawn && event.target.matches('a[href="#spawn]')) {
+            return
+     }
         $nav.classList.remove('visible')
         if ($stats) {
             $stats.classList.remove('visible')
+        }
+        if ($spawn) {
+            $spawn.classList.remove('visible')
         }
     })
     // Toggle.
@@ -161,6 +177,25 @@
             event.preventDefault()
             event.stopPropagation()
             $stats.classList.toggle('visible')
+    if ($('#stats').hasClass('visible')) {
+      if ($('#spawn').hasClass('visible')) {
+           $spawn.classList.toggle('visible')
+         }
+       }
+     })
+   }
+ 
+  // Event: Toggle spawn on click.
+  if ($spawnToggle) {
+    $spawnToggle.addEventListener('click', function (event) {
+      event.preventDefault()
+       event.stopPropagation()
+       $spawn.classList.toggle('visible')
+       if ($('#spawn').hasClass('visible')) {
+         if ($('#stats').hasClass('visible')) {
+           $stats.classList.toggle('visible')
+         }
+       }
         })
     }
 
@@ -180,7 +215,13 @@
         $statsClose.tabIndex = 0
         $stats.appendChild($statsClose)
     }
-
+     if ($spawn) {
+     $spawnClose = document.createElement('a')
+     $spawnClose.href = '#'
+     $spawnClose.className = 'close'
+     $spawnClose.tabIndex = 0
+     $spawn.appendChild($spawnClose)
+    }
     $gymSidebarClose = document.createElement('a')
     $gymSidebarClose.href = '#'
     $gymSidebarClose.className = 'close'
@@ -224,4 +265,12 @@
             $gymSidebar.classList.remove('visible')
         })
     }
+	if ($spawnClose) {
+     // Event: Hide stats on click.
+        $spawnClose.addEventListener('click', function (event) {
+        event.preventDefault()
+        event.stopPropagation()
+        $spawn.classList.remove('visible')
+     })
+   }
 })()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -90,7 +90,6 @@ var notifyText = 'disappears at <dist> (<udist>)'
 //
 // Functions
 //
-
 function excludePokemon(id) { // eslint-disable-line no-unused-vars
     $selectExclude.val(
         $selectExclude.val().concat(id)
@@ -596,6 +595,11 @@ function spawnpointLabel(item) {
                 May appear as early as ${formatSpawnTime(item.time - 1800)}
             </div>`
     }
+
+  str += `
+      <div>
+      <a href="javascript:getStats('${item.spawnpoint_id}')">Show 24 hour history</a>&nbsp;&nbsp;
+    </div>`
     return str
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -596,7 +596,7 @@ function spawnpointLabel(item) {
             </div>`
     }
 
-  str += `
+    str += `
       <div>
       <a href="javascript:getStats('${item.spawnpoint_id}')">Show 24 hour history</a>&nbsp;&nbsp;
     </div>`

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -146,29 +146,29 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
     }
 }
 
-function getStats (spawnpointId){ // eslint-disable-line no-unused-vars
+function getStats(spawnpointId) { // eslint-disable-line no-unused-vars
     $('ul[name=spawnpointnest]').empty()
     $('ul[name=spawnpointrest]').empty()
     $('div[id=spacer]').empty()
     $.ajax({
-       url: 'spawn_history?spawnpoint_id=' + spawnpointId,
-       dataType: 'json',
-       async: true,
-       success: function (data) {
-         document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
-         document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
+        url: 'spawn_history?spawnpoint_id=' + spawnpointId,
+        dataType: 'json',
+        async: true,
+        success: function (data) {
+           document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
+           document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
 
-         $.each(data.spawn_history, function (count, id) {
-      if (id.count > 5)
-      $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
-	  $('div[id=spacer]').append('<br><br>')
-          else
+           $.each(data.spawn_history, function (count, id) {
+             if (id.count > 5)
+      $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') &
+      $('div[id=spacer]').append('<br><br>')
+             else
         $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')
-      })
-         document.getElementById('spawn').classList.add('visible')
+         })
+           document.getElementById('spawn').classList.add('visible')
        },
-       error: function (jqXHR, status, error) {
-         console.log('Error loading stats: ' + error)
-     }
-   })
+        error: function (jqXHR, status, error) {
+           console.log('Error loading stats: ' + error)
+       }
+    })
 }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -145,3 +145,30 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
         document.getElementById('pokestopList').innerHTML = 'PokéStops markers are disabled'
     }
 }
+
+function getStats (spawnpointId) { // eslint-disable-line no-unused-vars
+   $('ul[name=spawnpointnest]').empty()
+   $('ul[name=spawnpointrest]').empty()
+   $('div[id=spacer]').empty()
+   $.ajax({
+     url: 'spawn_history?spawnpoint_id=' + spawnpointId,
+     dataType: 'json',
+     async: true,
+     success: function (data) {
+       document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
+	   document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
+
+      $.each(data.spawn_history, function (count, id) {
+		  if (id.count > 5)
+        $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
+	    $('div[id=spacer]').append('<br><br>')
+          else 
+        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')			  
+	  })
+       document.getElementById('spawn').classList.add('visible')
+     },
+     error: function (jqXHR, status, error) {
+       console.log('Error loading stats: ' + error)
+     }
+   })
+ }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -146,29 +146,29 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
     }
 }
 
-function getStats (spawnpointId) { // eslint-disable-line no-unused-vars
-   $('ul[name=spawnpointnest]').empty()
-   $('ul[name=spawnpointrest]').empty()
-   $('div[id=spacer]').empty()
-   $.ajax({
-     url: 'spawn_history?spawnpoint_id=' + spawnpointId,
-     dataType: 'json',
-     async: true,
-     success: function (data) {
-       document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
-	   document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
+function getStats(spawnpointId) { // eslint-disable-line no-unused-vars
+    $('ul[name=spawnpointnest]').empty()
+    $('ul[name=spawnpointrest]').empty()
+    $('div[id=spacer]').empty()
+    $.ajax({
+       url: 'spawn_history?spawnpoint_id=' + spawnpointId,
+       dataType: 'json',
+       async: true,
+       success: function (data) {
+         document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
+         document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
 
-      $.each(data.spawn_history, function (count, id) {
-		  if (id.count > 5)
-        $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
-	    $('div[id=spacer]').append('<br><br>')
-          else 
-        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')			  
-	  })
-       document.getElementById('spawn').classList.add('visible')
+         $.each(data.spawn_history, function (count, id) {
+        if (id.count > 5){
+      $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
+      $('div[id=spacer]').append('<br><br>')
+        else {
+        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')
+     })
+         document.getElementById('spawn').classList.add('visible')
      },
-     error: function (jqXHR, status, error) {
-       console.log('Error loading stats: ' + error)
+       error: function (jqXHR, status, error) {
+         console.log('Error loading stats: ' + error)
      }
    })
- }
+}

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -146,29 +146,29 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
     }
 }
 
-function getStats(spawnpointId) { // eslint-disable-line no-unused-vars
-    $('ul[name=spawnpointnest]').empty()
-    $('ul[name=spawnpointrest]').empty()
-    $('div[id=spacer]').empty()
-    $.ajax({
-       url: 'spawn_history?spawnpoint_id=' + spawnpointId,
-       dataType: 'json',
-       async: true,
-       success: function (data) {
-         document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
-         document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
+function getStats (spawnpointId) { // eslint-disable-line no-unused-vars
+   $('ul[name=spawnpointnest]').empty()
+   $('ul[name=spawnpointrest]').empty()
+   $('div[id=spacer]').empty()
+   $.ajax({
+     url: 'spawn_history?spawnpoint_id=' + spawnpointId,
+     dataType: 'json',
+     async: true,
+     success: function (data) {
+       document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
+	   document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
 
-         $.each(data.spawn_history, function (count, id) {
-        if (id.count > 5){
-      $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
-      $('div[id=spacer]').append('<br><br>')
-        else {
-        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')
-     })
-         document.getElementById('spawn').classList.add('visible')
+      $.each(data.spawn_history, function (count, id) {
+		  if (id.count > 5)
+        $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
+	    $('div[id=spacer]').append('<br><br>')
+          else 
+        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')			  
+	  })
+       document.getElementById('spawn').classList.add('visible')
      },
-       error: function (jqXHR, status, error) {
-         console.log('Error loading stats: ' + error)
+     error: function (jqXHR, status, error) {
+       console.log('Error loading stats: ' + error)
      }
    })
-}
+ }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -146,29 +146,29 @@ function countMarkers(map) { // eslint-disable-line no-unused-vars
     }
 }
 
-function getStats (spawnpointId) { // eslint-disable-line no-unused-vars
-   $('ul[name=spawnpointnest]').empty()
-   $('ul[name=spawnpointrest]').empty()
-   $('div[id=spacer]').empty()
-   $.ajax({
-     url: 'spawn_history?spawnpoint_id=' + spawnpointId,
-     dataType: 'json',
-     async: true,
-     success: function (data) {
-       document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
-	   document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
+function getStats (spawnpointId){ // eslint-disable-line no-unused-vars
+    $('ul[name=spawnpointnest]').empty()
+    $('ul[name=spawnpointrest]').empty()
+    $('div[id=spacer]').empty()
+    $.ajax({
+       url: 'spawn_history?spawnpoint_id=' + spawnpointId,
+       dataType: 'json',
+       async: true,
+       success: function (data) {
+         document.getElementById('stats-nest-label').innerHTML = 'Nesting or Frequent'
+         document.getElementById('stats-spawn-label').innerHTML = 'Spawns'
 
-      $.each(data.spawn_history, function (count, id) {
-		  if (id.count > 5)
-        $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
-	    $('div[id=spacer]').append('<br><br>')
-          else 
-        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')			  
-	  })
-       document.getElementById('spawn').classList.add('visible')
-     },
-     error: function (jqXHR, status, error) {
-       console.log('Error loading stats: ' + error)
+         $.each(data.spawn_history, function (count, id) {
+      if (id.count > 5)
+      $('ul[name=spawnpointnest]').append('<li style="float: left; list-style: none; height: 36px; margin-bottom: 50px; margin-right: 5px;"><i class="pokemon-large-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li><br>') & 
+	  $('div[id=spacer]').append('<br><br>')
+          else
+        $('ul[name=spawnpointrest]').append('<li style="float: left; list-style: none; height: 36px; margin-right: 5px;"><i class="pokemon-sprite n' + id.pokemon_id + '"></i><span style="font-weight: bold;">   Spawned ' + id.count + ' Times</span></li>')
+      })
+         document.getElementById('spawn').classList.add('visible')
+       },
+       error: function (jqXHR, status, error) {
+         console.log('Error loading stats: ' + error)
      }
    })
- }
+}

--- a/static/sass/layout/_stats.scss
+++ b/static/sass/layout/_stats.scss
@@ -1,6 +1,6 @@
 /* Stats */
 
-  #stats {
+  #stats, #spawn {
     @include vendor('transform', 'translateX(25em)');
     @include vendor('transition', ('transform #{_duration(stats)} ease', 'box-shadow #{_duration(stats)} ease', 'visibility #{_duration(stats)}'));
     -webkit-overflow-scrolling: touch;

--- a/templates/map.html
+++ b/templates/map.html
@@ -40,6 +40,8 @@
         <a href="#nav"><span class="label">Options</span></a>
         <h1><a href="#">Rocket Map</a></h1>
         <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
+
+
       </header>
       <!-- NAV -->
       <nav id="nav">
@@ -365,6 +367,26 @@
           <div id="pokestopList" style="color: black;"></div>
         </div>
       </nav>
+       <nav id="spawn">
+		<div class="switch-container">
+          <div class="switch-container">
+            <center><h1 id="spawn-ldg-label">24 Hour History For SpawnPoint</h1></center>
+          </div>
+		  <div class="stats-label-container">
+            <center><h1 id="stats-nest-label"></h1></center>
+          </div>
+            <div id="spawnList" style="color: black;">
+			 <ul class="statsHolder " name="spawnpointnest" style="max-width: 240px; list-style: none"></ul>
+		    </div>
+		  <div id="spacer"><br></div>
+		  <div class="stats-label-container">
+            <center><h1 id="stats-spawn-label"></h1></center>
+          </div>
+            <div id="spawnList" style="color: black;">
+			 <ul class="statsHolder " name="spawnpointrest" style="max-width: 240px; list-style: none"></ul>
+          </div>
+ 		</div>
+	  </nav>
       <nav id="gym-details">
         <center><h1>Loading...</h1></center>
       </nav>


### PR DESCRIPTION
## Description
Adds a link to spawn points and when clicked it opens 24 hour history in the side bar

## Motivation and Context
It is designed to help find what spawns at specific spawn points and help identify nests

## How Has This Been Tested?
Tested on a windows set up and my main setup on raspberry pi

## Screenshots (if appropriate):
![sh](https://cloud.githubusercontent.com/assets/8204684/23899651/ec5803f0-08ad-11e7-98c7-99e8e5eaa669.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
