### PR TITLE
Add changes to the verbosity of pokemon cleaning.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2288,12 +2288,19 @@ def clean_db_loop(args):
 
             # If desired, clear old Pokemon spawns.
             if args.purge_data > 0:
+                log.info("Beginning purge of old Pokemon spawns.")
+                start = datetime.utcnow()
                 query = (Pokemon
                          .delete()
                          .where((Pokemon.disappear_time <
                                  (datetime.utcnow() -
                                   timedelta(hours=args.purge_data)))))
-                query.execute()
+                rows = query.execute()
+                end = datetime.utcnow()
+                diff = end-start
+                log.info("Completed purge of old Pokemon spawns. "
+                         "%i deleted in %f seconds.",
+                         rows, diff.total_seconds())
 
             log.info('Regular database cleaning complete.')
             time.sleep(60)


### PR DESCRIPTION
Added some basic verbosity when -pd (--purge-data) is added to the command line/config file.

## Description
Added a message that purging pokemon data is beginning.
Gathered row count, and time functions.
Report on deleted pokemon and duration in the completion message.


## Motivation and Context
I've seen several people wonder about this process in #help.  
Questions arise:
How long does it take?
How do I know it's complete?
What does it do?

Additionally, people add -pd after running for a very long time and it creates lock timeouts.
This verbosity will help pinpoint that the lock timeouts are happening during this phase and once the purges are over they should go away.


## How Has This Been Tested?
This was tested on a copy of my local database multiple times.

## Screenshots (if appropriate):
2017-03-14 09:29:16,731 [        MainThread][        models][    INFO] Connecting to MySQL database on localhost:3306...
2017-03-14 09:29:16,861 [        db-cleaner][        models][    INFO] Beginning purge of old Pokemon spawns.
2017-03-14 09:29:27,572 [        db-cleaner][        models][    INFO] Completed purge of old Pokemon spawns. 366120 deleted in 10.710843 seconds.
2017-03-14 09:29:27,572 [        db-cleaner][        models][    INFO] Regular database cleaning complete.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
