### PR TITLE
24Hour spawnpoint history

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "centerLng": true,
     "pageLoaded": true,
     "countMarkers": true,
-	"getStats": true,
+    "getStats": true,
     "skel": true,
     "setupPokemonMarker": true,
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,12 @@ Live visualization of all the pokemon (with option to show gyms and pokestops) i
 
 ## Installation
 
-For instructions on how to setup and run the tool, please refer to the project [documentation](https://rocketmap.readthedocs.io) or the ~~[video guide](https://www.youtube.com/watch?v=2ACJHCNZ3ow)~~ Video guide to be replaced
+For instructions on how to setup and run the tool, please refer to the project [documentation](https://rocketmap.readthedocs.io).
 
 ## Deployment
 
-**Please note, deployments are not supported officially.**
+**Please note, deployments are not supported officially. You are using these deployment links at your own risk.**
 [![Deploy](https://raw.githubusercontent.com/RocketMap/PokemonGo-Map-in-Cloud/master/images/deploy-to-jelastic.png)](https://jelastic.com/install-application/?manifest=https://raw.githubusercontent.com/RocketMap/PokemonGo-Map-in-Cloud/master/manifest.jps) [![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/RocketMap/RocketMap#develop)
-
-## iOS Version
-
-There is an [iOS port](https://github.com/istornz/iPokeGo) in the works. All iOS related prs and issues please refer to this [repo](https://github.com/istornz/iPokeGo).
 
 ## Contributions
 

--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -32,7 +32,7 @@ The default configuration file is *config/config.ini* underneath the project hom
   location: seattle, wa
   step-limit: 5
   gmaps-key: MyGmapsKeyGoesHereSomeLongString
-  print-status: True
+  print-status: "status"
   -- end of file --
   </pre>
 

--- a/docs/extras/hashing.md
+++ b/docs/extras/hashing.md
@@ -14,6 +14,16 @@ Please don't ask *"What if my step size is _x_, and I have encounters for _y_ Po
 We still don't know.  Get a key, turn on your map and see if it works.
 If you are getting rate limited then either get more keys, or lower your calls (disabling/reducing encounters, disabling gym details, and decreasing step size are a few ways to reduce calls)
 
+You can get a more detailed view of how many Hash key calls are being used by enabling the status view `-ps` / `--print-status` and typing `h` followed by the enter key.  
+
+## Where do I enter my hash key?
+Use `-hk YourHashKeyHere` / `--hash-key YourHashKeyHere`.  
+If you use a configuration file, add the line `hash-key: YourHashKeyHere` to that file.
+
+## What if I have more than one hash key?
+Specify `-hk YourHashKeyHere -hk YourSecondHashKeyHere ...`.  
+If you use a configuration file, use `hash-key: [YourHashKeyHere, YourSecondHashKeyHere, ...]` in the file.
+
 ## What does HashingQuotaExceededException('429: Request limited, error: ',) mean?
 Any variant of this means you've exceeded the Requests Per Minute that your key allows.
 

--- a/docs/extras/mysql.md
+++ b/docs/extras/mysql.md
@@ -6,7 +6,7 @@
 
 ## I. Prerequisites
 1. Have already ran/operated the RocketMap using the default database setup.
-2. Have the "develop" build of RocketMap. [Available here.](https://github.com/RocketMap/RocketMap/archive/develop.zip)
+2. Have the "develop" build of RocketMap. [Available here.](https://rocketmap.readthedocs.io/en/develop/basic-install/index.html)
 3. Downloaded [MariaDB](https://downloads.mariadb.org/)
 
 ## II. Installing MariaDB

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -64,7 +64,11 @@ class Pogom(Flask):
         self.route("/submit_token", methods=['POST'])(self.submit_token)
         self.route("/get_stats", methods=['GET'])(self.get_account_stats)
         self.route("/spawn_history", methods=['GET'])(self.spawn_history)
+        self.route("/robots.txt", methods=['GET'])(self.render_robots_txt)
 
+    def render_robots_txt(self):
+        return render_template('robots.txt')
+    
     def spawn_history(self):
         d = {}
         spawnpoint_id = request.args.get('spawnpoint_id')

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -69,14 +69,12 @@ class Pogom(Flask):
     def render_robots_txt(self):
         return render_template('robots.txt')
 
-   
     def spawn_history(self):
         d = {}
         spawnpoint_id = request.args.get('spawnpoint_id')
         d['spawn_history'] = Pokemon.get_spawn_history(spawnpoint_id)
 
         return jsonify(d)
-
 
     def get_bookmarklet(self):
         args = get_args()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2597,3 +2597,4 @@ def database_migrate(db, old_ver):
             migrate(
                 migrator.add_index('pokestop', ('last_updated',), False)
             )
+        log.info('Schema upgrade complete.')

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -353,7 +353,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     account_queue = Queue()
     threadStatus = {}
     key_scheduler = None
-    api_version = '0.57.2'
+    api_version = '0.57.4'
     api_check_time = 0
 
     '''

--- a/static/js/status.js
+++ b/static/js/status.js
@@ -170,6 +170,8 @@ function compare(index) {
 }
 
 function updateStatus() {
+    lastRawUpdateTime = new Date()
+
     loadRawData().done(function (result) {
         // Parse result on success.
         parseResult(result)


### PR DESCRIPTION
## Description
Adds a link to spawn points and when clicked it opens 24 hour history in the side bar.
## Motivation and Context
It is designed to help find what spawns at specific spawn points and help identify nests

## How Has This Been Tested?
Tested on a windows set up and my main setup on raspberry pi
Arengo made treavis happy :)

## Screenshots (if appropriate):
![sh](https://cloud.githubusercontent.com/assets/8204684/23899651/ec5803f0-08ad-11e7-98c7-99e8e5eaa669.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
