### PR TITLE
Added a method to force quit the server

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -96,7 +96,8 @@ def switch_status_printer(display_type, current_page, mainlog,
         elif command.lower() == 'h':
             mainlog.handlers[0].setLevel(logging.CRITICAL)
             display_type[0] = 'hashstatus'
-
+        elif command.lower() == 'q':
+            os._exit(0)
 
 # Thread to print out the status of each worker.
 def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
@@ -272,7 +273,7 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
         status_text.append((
             'Page {}/{}. Page number to switch pages. F to show on hold ' +
             'accounts. H to show hash status. <ENTER> alone to switch ' +
-            'between status and log view').format(current_page[0],
+            'between status and log view. Q to force quit the server.').format(current_page[0],
                                                   total_pages))
         # Clear the screen.
         os.system('cls' if os.name == 'nt' else 'clear')

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -99,6 +99,7 @@ def switch_status_printer(display_type, current_page, mainlog,
         elif command.lower() == 'q':
             os._exit(0)
 
+
 # Thread to print out the status of each worker.
 def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
                    wh_queue, account_queue, account_failures, account_captchas,
@@ -273,8 +274,8 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue,
         status_text.append((
             'Page {}/{}. Page number to switch pages. F to show on hold ' +
             'accounts. H to show hash status. <ENTER> alone to switch ' +
-            'between status and log view. Q to force quit the server.').format(current_page[0],
-                                                  total_pages))
+            'between status and log view. Q to force quit the server.'
+            ).format(current_page[0], total_pages))
         # Clear the screen.
         os.system('cls' if os.name == 'nt' else 'clear')
         # Print status.


### PR DESCRIPTION
## Description
Added a trigger for 'Q' to force quit the server.

## Motivation and Context
This change adds a method to (force) quit the server.  This solves the problem of having to spam Ctrl+C to quit the server, which in turn can cause things to be aborted mid-routines.

## How Has This Been Tested?
Ran the server, confirmed text formatted correctly on screen, confirmed pressing 'q<enter>' caused the server to quit.
This method _is_ unclean (should really signal from thread to process and have the process react appropriately with e.g. quit), yet many times cleaner than spamming Ctrl+C.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

( I actually couldn't find where e.g. 'h' is documented!  If this hasn't been documented, I'd be happy to add documentation or otherwise modify the existing documentation. )