### PR TITLE
Fix /mobile list appearance

### DIFF
--- a/static/js/mobile.js
+++ b/static/js/mobile.js
@@ -38,7 +38,7 @@ function updateTimes() {
     // Yes, this could be a smidge innaccurate, but not by
     // more than 1 second or so which doesn't matter.
     // And now we don't have to deal with timestamps and dates!
-    var remains = document.querySelectorAll('div.remain')
+    var remains = document.querySelectorAll('span.remain')
     for (var i = 0; i < remains.length; ++i) {
         var element = remains[i]
         var now = new Date().getTime()

--- a/templates/mobile_list.html
+++ b/templates/mobile_list.html
@@ -11,11 +11,13 @@
 	<ol>
 {% for pokemon in pokemon_list[:20] %}
 {% set img = 'icons/' ~ pokemon.id ~ '.png' -%}
-		<li style="background-image: url('{{ url_for('static', filename=img).lstrip('/') }}')"
-			href='geo:0,0?q={{pokemon.latitude}},{{pokemon.longitude}}({{pokemon.name}})'>
-			<div class="name">{{pokemon.name}}</div>
-			<div class="dir"> - {{pokemon.distance}}m ({{pokemon.card_dir}}) - </div>
-			<div class="remain" disappear="{{pokemon.disappear_sec}}">{{pokemon.time_to_disappear}}</div>
+		<li style="list-style-type: none; background-image: url('{{ url_for('static', filename=img).lstrip('/') }}');"
+				href='https://maps.google.com/?q={{pokemon.latitude}},{{pokemon.longitude}}&ll={{pokemon.latitude}},{{pokemon.longitude}}'>
+				<p>
+						<span class="name">{{pokemon.name}}</span><span class="dir"> - {{pokemon.distance}}m ({{pokemon.card_dir}})</span>
+						<br>
+						<span class="remain" disappear="{{pokemon.disappear_sec}}">{{pokemon.time_to_disappear}}</span>
+				</p>
 		</li>
 {% endfor %}
 	</ol>
@@ -26,8 +28,6 @@
 			<label><input type="checkbox" id="use-loc">Use device location</label>
 		</div>
 	</div>
-
-	<a class="origin" href='geo:0,0?q={{origin_lat}},{{origin_lng}}(origin)'>origin location</a>
 
 	<script src="{{ url_for('static', filename='dist/js/mobile.min.js').lstrip('/') }}"></script>
 </body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The /mobile feature layout is totally wrecked when I use it on my smartphone, the intended device for it. This was primary coupled to too long lines.
Additionally, I fixed the location link because ``geo:`` always directed me to Goole Earth.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my smartphone (iPhone 5) and desktop

## Screenshots (if appropriate):
**Before**

![before](https://cloud.githubusercontent.com/assets/22680515/24038682/c761813c-0b02-11e7-9b9b-c4033d6319e6.PNG)

**After**

![after](https://cloud.githubusercontent.com/assets/22680515/24038691/cdb7fa98-0b02-11e7-9295-4704a1361667.PNG)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
