### PR TITLE
Reformat dates to ensure correct sorting of dates

### DIFF
--- a/static/js/status.js
+++ b/static/js/status.js
@@ -1,6 +1,3 @@
-/* Shared */
-var monthArray = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-
 /* Main stats page */
 var rawDataIsLoading = false
 var statusPagePassword = false
@@ -76,12 +73,14 @@ function processWorker(i, worker) {
     }
 
     var lastModified = new Date(worker['last_modified'])
-    lastModified = lastModified.getHours() + ':' +
+
+    // Use YYYY-MM-DD HH:MM:SS formatted dates to enable simple sorting
+    lastModified = lastModified.getFullYear() + '-' +
+        ('0' + (lastModified.getMonth() + 1)).slice(-2) + '-' +
+        ('0' + lastModified.getDate()).slice(-2) + ' ' +
+        ('0' + lastModified.getHours()).slice(-2) + ':' +
         ('0' + lastModified.getMinutes()).slice(-2) + ':' +
-        ('0' + lastModified.getSeconds()).slice(-2) + ' ' +
-        lastModified.getDate() + ' ' +
-        monthArray[lastModified.getMonth()] + ' ' +
-        lastModified.getFullYear()
+        ('0' + lastModified.getSeconds()).slice(-2)
 
     $('#username_' + hash).html(worker['username'])
     $('#success_' + hash).html(worker['success'])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
My change alters the date format on the status page to a YY-MM-DD HH:MM:SS style format.

## Motivation and Context
Currently the when sorting the table we sort alphabetically / numerically. This works for all columns except date where alphabetic sort results in the incorrect order. This mostly happens when there are two entries in different months but can happen in other edge cases as well.

## How Has This Been Tested?
On my local machine

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
