### PR TITLE
Fixes Issue 1941, negative seconds

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -578,7 +578,7 @@ function pokestopLabel(expireTime, latitude, longitude) {
 function formatSpawnTime(seconds) {
     // the addition and modulo are required here because the db stores when a spawn disappears
     // the subtraction to get the appearance time will knock seconds under 0 if the spawn happens in the previous hour
-    return ('0' + Math.floor(((seconds + 3600) % 3600) / 60)).substr(-2) + ':' + ('0' + seconds % 60).substr(-2)
+    return ('0' + Math.floor(((seconds + 3600) % 3600) / 60)).substr(-2) + ':' + ('0' + (seconds >= 0 ? seconds % 60 : 60 + (seconds % 60))).substr(-2)
 }
 
 function spawnpointLabel(item) {


### PR DESCRIPTION
Spawn point details can currently show negative seconds.  These should
be substracted from 60 to get the correct second count.
Note: This only fixes a formatting issue, not any issues with regard to
actual spawn times.  For discussion on the latter, see Issue #1944

## Description
Adds a ternary operator to subtract negative seconds from 60 to correct the negative seconds issue.

## Motivation and Context
Negative seconds don't make sense in display formats, especially not when they're only negative if they're single-digit.  
This fixes Issue #1941  
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Three-fold: In-map, using Calc, and using a javascript iteration over a range of numbers.  
This change only affects displayed times in the spawn point details on the map.

## Screenshots (if appropriate):
https://cloud.githubusercontent.com/assets/3775662/24132943/989aeda0-0dcf-11e7-9335-42e971672d6a.png

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The last two points are just a reminder to self that the front-end needs documentation, period :)