### PR TITLE
Added exception handler for update_total_stats in search.py

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -537,7 +537,15 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
                     i].get_overseer_message()
 
         # Let's update the total stats and add that info to message
-        update_total_stats(threadStatus, last_account_status)
+        # Added exception handler as dict items change
+        try:
+            update_total_stats(threadStatus, last_account_status)
+        except Exception as e:
+            log.error(
+                'Update total stats had an Exception: {}.'.format(
+                    repr(e)))
+            traceback.print_exc(file=sys.stdout)
+            time.sleep(10)
         threadStatus['Overseer']['message'] += '\n' + get_stats_message(
             threadStatus)
 


### PR DESCRIPTION
This is a patch pulled out of #1900 that adds an exception handler for update_total_stats when size of dict changes. Detailed in that PR as ISSUE4

## Description
RocketMap can stop with an uncaught exception:

Current behavior:
![](https://cloud.githubusercontent.com/assets/24545326/23830876/912bc43c-070c-11e7-976c-2dced8453150.png)

Changes:
In the seach.py, add an exception handler to catch any problems while copying the queue items.
![](https://cloud.githubusercontent.com/assets/24545326/23830885/d6592f18-070c-11e7-98da-80c8cbadb3a9.png)

New behavior:
![](https://cloud.githubusercontent.com/assets/24545326/23832751/63e839b6-0733-11e7-8a08-74d9578a4015.png)
The exception is caught and the Map continues.

## Motivation and Context
I've plucked this patch from #1900 and am submitting it as it's own PR, as it has been a fairly commonly reported problem in help chat on Discord recently and it may be a while before the original larger PR is fully vetted/tested/approved. This smaller issue was bundled with that PR and is probably more appropriate as a smaller patch.
This fixes ISSUE 4 outlined in #1900 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed on 3 VM's for past 3 days with no issues found aside from catching the previously uncaught exception and allowing the script to continue without a hard failure.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
