### PR TITLE
Add Pokémon transparency based on IV

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -973,6 +973,10 @@ var StoreOptions = {
     'zoomLevel': {
         default: 16,
         type: StoreTypes.Number
+    },
+    'showPokemonOpacity': {
+        default: false,
+        type: StoreTypes.Boolean
     }
 }
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -977,6 +977,10 @@ var StoreOptions = {
     'showPokemonOpacity': {
         default: false,
         type: StoreTypes.Boolean
+    },
+    'minPokemonOpacityPercentage': {
+        default: 33,
+        type: StoreTypes.Number
     }
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2294,7 +2294,6 @@ $(function () {
             lastpokemon = false
             wrapper.hide(options)
         }
-        Store.set('showPokemon', this.checked)
         buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon').bind(this)()
     })
     $('#pokemon-opacity-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -349,6 +349,8 @@ function initSidebar() {
     $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
     $('#last-update-gyms-switch').val(Store.get('showLastUpdatedGymsOnly'))
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'))
+    $('#pokemon-wrapper').toggle(Store.get('showPokemon'))
+    $('#pokemon-opacity-switch').prop('checked', Store.get('showPokemonOpacity'))
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
     $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'))
     $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'))
@@ -733,8 +735,11 @@ function customizePokemonMarker(marker, item, skipNotification) {
         }
     }
 
-    if (item['individual_attack'] != null) {
+    if (item['individual_attack'] != null && item['individual_defense'] != null && item['individual_stamina'] != null) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
+        if (Store.get('showPokemonOpacity')) {
+            marker.setOpacity(0.5 * (1 + perfection / 100))  // Vary opacity between 33% for 0% IV and 100 % for 100% IV.
+        }
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
                 if (Store.get('playSound')) {
@@ -746,6 +751,8 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)
             }
         }
+    } else if (Store.get('showPokemonOpacity')) {
+        marker.setOpacity(0.50)  // Default opacity if enabled
     }
 
     addListeners(marker)
@@ -2276,7 +2283,23 @@ $(function () {
         buildSwitchChangeListener(mapData, ['gyms'], 'showGyms').bind(this)()
     })
     $('#pokemon-switch').change(function () {
+        var options = {
+            'duration': 500
+        }
+        var wrapper = $('#pokemon-wrapper')
+        if (this.checked) {
+            lastpokemon = false
+            wrapper.show(options)
+        } else {
+            lastpokemon = false
+            wrapper.hide(options)
+        }
+        Store.set('showPokemon', this.checked)
         buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon').bind(this)()
+    })
+    $('#pokemon-opacity-switch').change(function () {
+        Store.set('showPokemonOpacity', this.checked)
+        redrawPokemon(mapData.pokemons)
     })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -738,7 +738,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
     if (item['individual_attack'] != null && item['individual_defense'] != null && item['individual_stamina'] != null) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (Store.get('showPokemonOpacity')) {
-            marker.setOpacity(0.5 * (1 + perfection / 100))  // Vary opacity between 33% for 0% IV and 100 % for 100% IV.
+            marker.setOpacity(0.33 + 0.67 * (perfection / 100))  // Vary opacity between 33% for 0% IV and 100 % for 100% IV.
         }
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
@@ -752,7 +752,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
             }
         }
     } else if (Store.get('showPokemonOpacity')) {
-        marker.setOpacity(0.50)  // Default opacity if enabled
+        marker.setOpacity(0.33)  // Default opacity if enabled
     }
 
     addListeners(marker)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -740,7 +740,8 @@ function customizePokemonMarker(marker, item, skipNotification) {
     if (item['individual_attack'] != null && item['individual_defense'] != null && item['individual_stamina'] != null) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (Store.get('showPokemonOpacity')) {
-            marker.setOpacity(minOpacity + (1 - minOpacity) * (perfection / 100.0))  // Vary opacity between 33% for 0% IV and 100 % for 100% IV.
+            // Vary opacity between minOpacityPercentage from map.common.js for 0% IV and 100 % for 100% IV.
+            marker.setOpacity(minOpacity + (1 - minOpacity) * (perfection / 100.0))
         }
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
@@ -754,7 +755,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
             }
         }
     } else if (Store.get('showPokemonOpacity')) {
-        marker.setOpacity(minOpacity)  // Default opacity if enabled
+        marker.setOpacity(minOpacity)  // Default opacity if toggle enabled
     }
 
     addListeners(marker)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -735,10 +735,12 @@ function customizePokemonMarker(marker, item, skipNotification) {
         }
     }
 
+
+    var minOpacity = Store.get('minPokemonOpacityPercentage') / 100.0
     if (item['individual_attack'] != null && item['individual_defense'] != null && item['individual_stamina'] != null) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (Store.get('showPokemonOpacity')) {
-            marker.setOpacity(0.33 + 0.67 * (perfection / 100))  // Vary opacity between 33% for 0% IV and 100 % for 100% IV.
+            marker.setOpacity(minOpacity + (1 - minOpacity) * (perfection / 100.0))  // Vary opacity between 33% for 0% IV and 100 % for 100% IV.
         }
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
@@ -752,7 +754,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
             }
         }
     } else if (Store.get('showPokemonOpacity')) {
-        marker.setOpacity(0.33)  // Default opacity if enabled
+        marker.setOpacity(minOpacity)  // Default opacity if enabled
     }
 
     addListeners(marker)

--- a/templates/map.html
+++ b/templates/map.html
@@ -56,6 +56,18 @@
                 </label>
               </div>
             </div>
+            <div id="pokemon-wrapper" style="display:none">
+              <div class="form-control switch-container" id="pokemon-opacity-wrapper">
+                <h3>Pokémon opacity</h3>
+                <div class="onoffswitch">
+                  <input id="pokemon-opacity-switch" type="checkbox" name="pokemon-opacity-switch" class="onoffswitch-checkbox" checked>
+                  <label class="onoffswitch-label" for="pokemon-opacity-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                  </label>
+                </div>
+              </div>
+            </div>
             <div class="form-control switch-container">
               <h3>Gyms</h3>
               <div class="onoffswitch">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR introduces the feature to distinguish Pokémon by their IVs by making the low IV-Pokémon more transparent. 
## Description
<!--- Describe your changes in detail -->
A new toggle option is available in the Map menu, wrapped below the Pokémon marker switch. When enabling (default is ``false``) marker opacity get's weighted with Pokémon IV, ranging from 33 % for no-IV Pokémon or 0% IV Pokémon to an opacity of 100% for 100% IV Pokémon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This feature is introduced through requests to better distinguish Pokémon of interest on the map. Also there was a Feature Request in #1829 as well as on [DevKat](https://feedback.userreport.com/9eec75e1-1e84-4f02-b254-5e239d896805/#idea/159800).
Instead of a toggle it was also considered to introduce this as default, when ``-enc`` is enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my personal map.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project. (Awesome JS code style)
