### PR TITLE
Improve memory usage

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -207,8 +207,7 @@ def complete_tutorial(api, account, tutorial_state):
 # Complete tutorial with a level up by a Pokestop spin.
 # API argument needs to be a logged in API instance.
 # Called during fort parsing in models.py
-def tutorial_pokestop_spin(api, map_dict, forts, step_location, account):
-    player_level = get_player_level(map_dict)
+def tutorial_pokestop_spin(api, player_level, forts, step_location, account):
     if player_level > 1:
         log.debug(
             'No need to spin a Pokestop. ' +

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -29,10 +29,11 @@ from timeit import default_timer
 from . import config
 from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, \
     get_args, cellid, in_radius, date_secs, clock_between, secs_between, \
-    get_move_name, get_move_damage, get_move_energy, get_move_type
+    get_move_name, get_move_damage, get_move_energy, get_move_type, \
+    clear_dict_response
 from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
-from .account import tutorial_pokestop_spin
+from .account import tutorial_pokestop_spin, get_player_level
 log = logging.getLogger(__name__)
 
 args = get_args()
@@ -1766,7 +1767,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     stopsskipped = 0
     forts = []
     wild_pokemon = []
-    nearby_pokemon = []
+    nearby_pokemon = 0
     spawn_points = {}
     scan_spawn_points = {}
     sightings = {}
@@ -1778,12 +1779,18 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
+    # Get the level for the pokestop spin in any case delete inventory 
+    if args.complete_tutorial and config['parse_pokestops']:
+        level = get_player_level(map_dict)
+    if 'GET_INVENTORY' in map_dict['responses']:
+        del map_dict['responses']['GET_INVENTORY']
     for i, cell in enumerate(cells):
         # If we have map responses then use the time from the request
         if i == 0:
             now_date = datetime.utcfromtimestamp(
                                 cell['current_timestamp_ms'] / 1000)
         nearby_pokemon += cell.get('nearby_pokemons', [])
+        nearby_pokemon += len(cell.get('nearby_pokemons', []))
         # Parse everything for stats (counts).  Future enhancement -- we don't
         # necessarily need to know *how many* forts/wild/nearby were found but
         # we'd like to know whether or not *any* were found to help determine
@@ -1792,7 +1799,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
         forts += cell.get('forts', [])
 
-    now_secs = date_secs(now_date)
+    del map_dict['responses']['GET_MAP_OBJECTS']
+
     # If there are no wild or nearby Pokemon . . .
     if not wild_pokemon and not nearby_pokemon:
         # . . . and there are no gyms/pokestops then it's unusable/bad.
@@ -1917,14 +1925,15 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     spawn_point_id=p['spawn_point_id'],
                     player_latitude=step_location[0],
                     player_longitude=step_location[1])
-                encounter_result = req.check_challenge()
-                encounter_result = req.get_hatched_eggs()
-                encounter_result = req.get_inventory()
-                encounter_result = req.check_awarded_badges()
-                encounter_result = req.download_settings()
-                encounter_result = req.get_buddy_walked()
+                req.check_challenge()
+                req.get_hatched_eggs()
+                req.get_inventory()
+                req.check_awarded_badges()
+                req.download_settings()
+                req.get_buddy_walked()
                 encounter_result = req.call()
-
+                encounter_result = clear_dict_response(encounter_result);
+                
                 captcha_url = encounter_result['responses']['CHECK_CHALLENGE'][
                         'challenge_url']  # Check for captcha
                 if len(captcha_url) > 1:  # Throw warning but finish parsing
@@ -1980,6 +1989,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 })
                 wh_update_queue.put(('pokemon', wh_poke))
 
+    wild_pokemon = len(wild_pokemon)
+                
     if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
             stop_ids = [f['id'] for f in forts if f.get('type') == 1]
@@ -1996,7 +2007,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         if args.complete_tutorial and not (len(captcha_url) > 1):
             if config['parse_pokestops']:
                 tutorial_pokestop_spin(
-                    api, map_dict, forts, step_location, account)
+                    api, level, forts, step_location, account)
             else:
                 log.error(
                     'Pokestop can not be spun since parsing Pokestops is ' +
@@ -2091,10 +2102,12 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'last_modified': datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0),
                 }
+        
+        forts = len(forts)
 
     log.info('Parsing found Pokemon: %d, nearby: %d, pokestops: %d, gyms: %d.',
              len(pokemon) + skipped,
-             len(nearby_pokemon),
+             nearby_pokemon,
              len(pokestops) + stopsskipped,
              len(gyms))
 
@@ -2158,7 +2171,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         # After parsing the forts, we'll mark this scan as bad due to
         # a possible speed violation.
         return {
-            'count': len(wild_pokemon) + len(forts),
+            'count': wild_pokemon + forts,
             'gyms': gyms,
             'sp_id_list': sp_id_list,
             'bad_scan': True,
@@ -2166,7 +2179,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         }
 
     return {
-        'count': len(wild_pokemon) + len(forts),
+        'count': wild_pokemon + forts,
         'gyms': gyms,
         'sp_id_list': sp_id_list,
         'bad_scan': False,
@@ -2334,7 +2347,9 @@ def db_updater(args, q, db):
                           len(data),
                           q.qsize(),
                           default_timer() - last_upsert)
-
+                del model
+                del data
+                          
                 if q.qsize() > 50:
                     log.warning(
                         "DB queue is > 50 (@%d); try increasing --db-threads.",

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1779,7 +1779,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
-    # Get the level for the pokestop spin in any case delete inventory 
+    # Get the level for the pokestop spin in any case delete inventory
     if args.complete_tutorial and config['parse_pokestops']:
         level = get_player_level(map_dict)
     if 'GET_INVENTORY' in map_dict['responses']:
@@ -1789,7 +1789,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         if i == 0:
             now_date = datetime.utcfromtimestamp(
                                 cell['current_timestamp_ms'] / 1000)
-        nearby_pokemon += cell.get('nearby_pokemons', [])
         nearby_pokemon += len(cell.get('nearby_pokemons', []))
         # Parse everything for stats (counts).  Future enhancement -- we don't
         # necessarily need to know *how many* forts/wild/nearby were found but
@@ -1932,8 +1931,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 req.download_settings()
                 req.get_buddy_walked()
                 encounter_result = req.call()
-                encounter_result = clear_dict_response(encounter_result);
-                
+                encounter_result = clear_dict_response(encounter_result)
+
                 captcha_url = encounter_result['responses']['CHECK_CHALLENGE'][
                         'challenge_url']  # Check for captcha
                 if len(captcha_url) > 1:  # Throw warning but finish parsing
@@ -1990,7 +1989,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 wh_update_queue.put(('pokemon', wh_poke))
 
     wild_pokemon = len(wild_pokemon)
-                
+
     if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
             stop_ids = [f['id'] for f in forts if f.get('type') == 1]
@@ -2102,7 +2101,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'last_modified': datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0),
                 }
-        
+
         forts = len(forts)
 
     log.info('Parsing found Pokemon: %d, nearby: %d, pokestops: %d, gyms: %d.',
@@ -2349,7 +2348,7 @@ def db_updater(args, q, db):
                           default_timer() - last_upsert)
                 del model
                 del data
-                          
+
                 if q.qsize() > 50:
                     log.warning(
                         "DB queue is > 50 (@%d); try increasing --db-threads.",

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1027,7 +1027,8 @@ def search_worker_thread(args, account_queue, account_failures,
                                                            account['username'])
                     log.exception('{}. Exception message: {}'.format(
                         status['message'], repr(e)))
-                    del response_dict
+                    if response_dict is not None:
+                        del response_dict
 
                 # Get detailed information about gyms.
                 if args.gym_info and parsed:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -42,7 +42,7 @@ from pgoapi.hash_server import HashServer
 
 from .models import parse_map, GymDetails, parse_gyms, MainWorker, WorkerStatus
 from .fakePogoApi import FakePogoApi
-from .utils import now, generate_device_info
+from .utils import now, generate_device_info, clear_dict_response
 from .transform import get_new_coords, jitter_location
 from .account import check_login, get_tutorial_state, complete_tutorial
 from .captcha import captcha_overseer_thread, handle_captcha
@@ -1000,6 +1000,7 @@ def search_worker_thread(args, account_queue, account_failures,
 
                     parsed = parse_map(args, response_dict, step_location,
                                        dbq, whq, api, scan_date, account)
+                    del response_dict
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1
@@ -1026,6 +1027,7 @@ def search_worker_thread(args, account_queue, account_failures,
                                                            account['username'])
                     log.exception('{}. Exception message: {}'.format(
                         status['message'], repr(e)))
+                    del response_dict                        
 
                 # Get detailed information about gyms.
                 if args.gym_info and parsed:
@@ -1093,7 +1095,7 @@ def search_worker_thread(args, account_queue, account_failures,
                             else:
                                 gym_responses[gym['gym_id']] = response[
                                     'responses']['GET_GYM_DETAILS']
-
+                            del response
                             # Increment which gym we're on for status messages.
                             current_gym += 1
 
@@ -1107,6 +1109,7 @@ def search_worker_thread(args, account_queue, account_failures,
                         if gym_responses:
                             parse_gyms(args, gym_responses,
                                        whq, dbq)
+                            del gym_responses
 
                 if args.hash_key:
                     key_instance = key_scheduler.keys[key_scheduler.current()]
@@ -1165,17 +1168,18 @@ def map_request(api, position, no_jitter=False):
         cell_ids = util.get_cell_ids(scan_location[0], scan_location[1])
         timestamps = [0, ] * len(cell_ids)
         req = api.create_request()
-        response = req.get_map_objects(latitude=f2i(scan_location[0]),
-                                       longitude=f2i(scan_location[1]),
-                                       since_timestamp_ms=timestamps,
-                                       cell_id=cell_ids)
-        response = req.check_challenge()
-        response = req.get_hatched_eggs()
-        response = req.get_inventory()
-        response = req.check_awarded_badges()
-        response = req.download_settings()
-        response = req.get_buddy_walked()
+        req.get_map_objects(latitude=f2i(scan_location[0]),
+                            longitude=f2i(scan_location[1]),
+                            since_timestamp_ms=timestamps,
+                            cell_id=cell_ids)
+        req.check_challenge()
+        req.get_hatched_eggs()
+        req.get_inventory()
+        req.check_awarded_badges()
+        req.download_settings()
+        req.get_buddy_walked()
         response = req.call()
+        response = clear_dict_response(response, True)
         return response
 
     except Exception as e:
@@ -1189,18 +1193,19 @@ def gym_request(api, position, gym):
                   gym['latitude'], gym['longitude'],
                   calc_distance(position, [gym['latitude'], gym['longitude']]))
         req = api.create_request()
-        x = req.get_gym_details(gym_id=gym['gym_id'],
+        req.get_gym_details(gym_id=gym['gym_id'],
                                 player_latitude=f2i(position[0]),
                                 player_longitude=f2i(position[1]),
                                 gym_latitude=gym['latitude'],
                                 gym_longitude=gym['longitude'])
-        x = req.check_challenge()
-        x = req.get_hatched_eggs()
-        x = req.get_inventory()
-        x = req.check_awarded_badges()
-        x = req.download_settings()
-        x = req.get_buddy_walked()
+        req.check_challenge()
+        req.get_hatched_eggs()
+        req.get_inventory()
+        req.check_awarded_badges()
+        req.download_settings()
+        req.get_buddy_walked()
         x = req.call()
+        x = clear_dict_response(x)
         # Print pretty(x).
         return x
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1027,7 +1027,7 @@ def search_worker_thread(args, account_queue, account_failures,
                                                            account['username'])
                     log.exception('{}. Exception message: {}'.format(
                         status['message'], repr(e)))
-                    del response_dict                        
+                    del response_dict
 
                 # Get detailed information about gyms.
                 if args.gym_info and parsed:
@@ -1194,10 +1194,10 @@ def gym_request(api, position, gym):
                   calc_distance(position, [gym['latitude'], gym['longitude']]))
         req = api.create_request()
         req.get_gym_details(gym_id=gym['gym_id'],
-                                player_latitude=f2i(position[0]),
-                                player_longitude=f2i(position[1]),
-                                gym_latitude=gym['latitude'],
-                                gym_longitude=gym['longitude'])
+                            player_latitude=f2i(position[0]),
+                            player_longitude=f2i(position[1]),
+                            gym_latitude=gym['latitude'],
+                            gym_longitude=gym['longitude'])
         req.check_challenge()
         req.get_hatched_eggs()
         req.get_inventory()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -890,3 +890,20 @@ def extract_sprites():
     zip = zipfile.ZipFile('static01.zip', 'r')
     zip.extractall('static')
     zip.close()
+
+def clear_dict_response(response, keep_inventory = False):
+    if 'platform_returns' in response:
+        del response['platform_returns']
+    if 'responses' not in response:
+        return response;
+    if 'GET_INVENTORY' in response['responses'] and not keep_inventory:
+        del response['responses']['GET_INVENTORY']
+    if 'GET_HATCHED_EGGS' in response['responses']:
+        del response['responses']['GET_HATCHED_EGGS']
+    if 'CHECK_AWARDED_BADGES' in response['responses']:
+        del response['responses']['CHECK_AWARDED_BADGES']
+    if 'DOWNLOAD_SETTINGS' in response['responses']:
+        del response['responses']['DOWNLOAD_SETTINGS']
+    if 'GET_BUDDY_WALKED' in response['responses']:
+        del response['responses']['GET_BUDDY_WALKED']
+    return response

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -891,11 +891,12 @@ def extract_sprites():
     zip.extractall('static')
     zip.close()
 
-def clear_dict_response(response, keep_inventory = False):
+
+def clear_dict_response(response, keep_inventory=False):
     if 'platform_returns' in response:
         del response['platform_returns']
     if 'responses' not in response:
-        return response;
+        return response
     if 'GET_INVENTORY' in response['responses'] and not keep_inventory:
         del response['responses']['GET_INVENTORY']
     if 'GET_HATCHED_EGGS' in response['responses']:

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -54,18 +54,19 @@ def wh_updater(args, queue, key_cache):
     # connection, giving a performance increase.
     session = __get_requests_session(args)
 
+    # Extract the proper identifier.
+    ident_fields = {
+        'pokestop': 'pokestop_id',
+        'pokemon': 'encounter_id',
+        'gym': 'gym_id'
+    }
+
     # The forever loop.
     while True:
         try:
             # Loop the queue.
             whtype, message = queue.get()
 
-            # Extract the proper identifier.
-            ident_fields = {
-                'pokestop': 'pokestop_id',
-                'pokemon': 'encounter_id',
-                'gym': 'gym_id'
-            }
             ident = message.get(ident_fields.get(whtype), None)
 
             # cachetools in Python2.7 isn't thread safe, so we add a lock.
@@ -95,6 +96,10 @@ def wh_updater(args, queue, key_cache):
                     else:
                         log.debug('Not resending %s to webhook: %s.',
                                   whtype, ident)
+            
+            del whtype
+            del message
+            del ident
 
             # Webhook queue moving too slow.
             if (not wh_over_threshold) and (

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -96,7 +96,7 @@ def wh_updater(args, queue, key_cache):
                     else:
                         log.debug('Not resending %s to webhook: %s.',
                                   whtype, ident)
-            
+
             del whtype
             del message
             del ident


### PR DESCRIPTION

## Description
Free variables as soon as possible to let Python GC free the memory, this was done on all thread but focused on search thread.
Minor changes where needed in pokespin function to allow an early del of inventory data in map request.

## Motivation and Context
One of the main memory hugs right now is keeping all the reponses while the thread is paused.
This is due to the lack of scopes in python  outside the function scope and the fact that the current code has enormous functions.
So the first thing to reduce memory is free it as soon as possible in the thread functions as otherwise it will be kept referenced until a new value is assigned to it.
Request responses are fairly big specially for accounts that have non empty inventory, so I did review all threads and functions used in those threads trying to delete the variables so Python GC can free them.

For that I did include a new function that clears all the extra info that is not needed but it is requested every time (badges, buddy, settings...) I am not even sure if it is needed in every request, probably it would be enough if made in map requests, anyway it is freed as soon it is returned from api.

In DB and WH threads I did the same thing for the objects that can be freed, those changes are probably minor as those threads are almost never paused, not like search threads.

I did choose to use `del var` over `var = None` as it seems more obvious the reason of that line and would make future commiters aware. Another option would be leaving just the main loop in the thread function and then make everything else in another function that way local variables would be cleared on exit. 

## How Has This Been Tested?

This was tested for 7h using develop branch and then with the same config with this changes, the only minor change I did was add another database worker as the baseline test was not able to cope with data (so there gain is a bit less than shown), still in previous tests the results were similar, around 30% decrease in memory consumption and almost 90% decrease in dict objects in memory (responses have a bunch of dicts inside dicts).
The test setup did not have web server, st 39, 230 workers, 1 webhook with gym info and not encounter.

My accounts are leveled so their inventory has a lot more items, setups with lvl 1 and lvl 2 accounts will see smaller improvements.
The only modification I did aside of the PR was adding a hook for pdb-clone so I could connect and get some insight of the running instance, only used after the memory screenshoots were taken.

**Not tested:** Tutorial usage

## Screenshots (if appropriate):

Current develop branch, after 7h of work, around 1.1Gb memory

PM2 info (test app is the one your are looking for):
![2017-03-30 11_54_28-bitvise xterm - pokemad bscp - pokemad neoseo es_81](https://cloud.githubusercontent.com/assets/487098/24530731/3101b84e-15b4-11e7-9001-76aed99d8b45.png)

Top:
![2017-03-30 11_55_47-bitvise xterm - pokemad bscp - pokemad neoseo es_81](https://cloud.githubusercontent.com/assets/487098/24530733/35b55a8a-15b4-11e7-85a0-17f5941f2288.png)

Objgraph info:
![2017-03-30 11_57_04-bitvise xterm - pokemad bscp - pokemad neoseo es_81](https://cloud.githubusercontent.com/assets/487098/24530740/3eb5f0e0-15b4-11e7-90a4-4e3b87956d5d.png)

After PR, 7h working 800Mb
![2017-03-31 01_13_43-bitvise xterm - pokemad bscp - pokemad neoseo es_81](https://cloud.githubusercontent.com/assets/487098/24530776/86aa8e88-15b4-11e7-9400-1b6a071c3af5.png)

Top:
![2017-03-31 01_10_13-bitvise xterm - pokemad bscp - pokemad neoseo es_81](https://cloud.githubusercontent.com/assets/487098/24530783/930c6bb0-15b4-11e7-8975-b256b62686d2.png)

Objgraph:
![2017-03-31 01_11_40-bitvise xterm - pokemad bscp - pokemad neoseo es_81](https://cloud.githubusercontent.com/assets/487098/24530786/9a4fb85a-15b4-11e7-9d97-68fd4081c7a5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
