### PR TITLE
Fix model column name usages

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2280,13 +2280,13 @@ def clean_db_loop(args):
         try:
             query = (MainWorker
                      .delete()
-                     .where((ScannedLocation.last_modified <
+                     .where((MainWorker.last_modified <
                              (datetime.utcnow() - timedelta(minutes=30)))))
             query.execute()
 
             query = (WorkerStatus
                      .delete()
-                     .where((ScannedLocation.last_modified <
+                     .where((WorkerStatus.last_modified <
                              (datetime.utcnow() - timedelta(minutes=30)))))
             query.execute()
 


### PR DESCRIPTION
Use the right table name when using the 'last_modified' column

## Description
I've noticed that it uses the wrong table name (ScannedLocation) when we use the last_modified column to make two queries related to MainWorker and WorkerStatus tables. It works since these three tables use the same column name. But we want consistency.

## Motivation and Context
Consistency

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
