### PR TITLE
Quick now_secs fix

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1775,7 +1775,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     sightings = {}
     new_spawn_points = []
     sp_id_list = []
-    now_secs = date_secs(now_date)
     captcha_url = ''
 
     # Consolidate the individual lists in each cell into two lists of Pokemon
@@ -1806,6 +1805,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         else:
             forts_count += len(cell.get('forts', []))
 
+    now_secs = date_secs(now_date)
     if wild_pokemon:
         wild_pokemon_count = len(wild_pokemon)
     if forts:


### PR DESCRIPTION
Just added a line that was removed in latest PR

## Description
Now_secs needs to be calculated based on cell data if any exist, now the system time.

## Motivation and Context
Noticed the line had been removed

## How Has This Been Tested?
Running my map now and checking spawnpointdetectiondata

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/24545326/24957757/adbf9980-1f84-11e7-8f56-102a68676c42.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
