### PR TITLE
Change error message to be less intrusive 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "jquery": true
   },
   "globals": {
+    "toastr": true,
     "google": true,
     "mapData": true,
     "Store": true,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -18,7 +18,6 @@ var $selectSearchIconMarker
 var $selectGymMarkerStyle
 var $selectLocationIconMarker
 var $switchGymSidebar
-var toastr
 
 var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
 var idToPokemon = {}
@@ -1142,7 +1141,7 @@ function loadRawData() {
         },
         error: function () {
             // Display error toast
-            toastr['error']('Please check connectivity or reduce marker settings.', 'Error getting Data')
+            toastr['error']('Please check connectivity or reduce marker settings.', 'Error getting data')
             toastr.options = {
                 'closeButton': true,
                 'debug': false,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -18,6 +18,7 @@ var $selectSearchIconMarker
 var $selectGymMarkerStyle
 var $selectLocationIconMarker
 var $switchGymSidebar
+var $toastr
 
 var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
 var idToPokemon = {}
@@ -1143,22 +1144,22 @@ function loadRawData() {
             // Display error toast
             toastr["error"]("Please check connectivity or reduce marker settings.", "Error getting Data")
             toastr.options = {
-                            "closeButton": true,
-                            "debug": false,
-                            "newestOnTop": true,
-                            "progressBar": false,
-                            "positionClass": "toast-top-right",
-                            "preventDuplicates": true,
-                            "onclick": null,
-                            "showDuration": "300",
-                            "hideDuration": "1000",
-                            "timeOut": "25000",
-                            "extendedTimeOut": "1000",
-                            "showEasing": "swing",
-                            "hideEasing": "linear",
-                            "showMethod": "fadeIn",
-                            "hideMethod": "fadeOut"
-                         }
+                'closeButton': true,
+                'debug': false,
+                'newestOnTop': true,
+                'progressBar': false,
+                'positionClass': 'toast-top-right',
+                'preventDuplicates': true,
+                'onclick': null,
+                'showDuration': '300',
+                'hideDuration': '1000',
+                'timeOut': '25000',
+                'extendedTimeOut': '1000',
+                'showEasing': 'swing',
+                'hideEasing': 'linear',
+                'showMethod': 'fadeIn',
+                'hideMethod': 'fadeOut'
+            }
         },
         complete: function () {
             rawDataIsLoading = false

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -18,7 +18,7 @@ var $selectSearchIconMarker
 var $selectGymMarkerStyle
 var $selectLocationIconMarker
 var $switchGymSidebar
-var $toastr
+var toastr
 
 var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
 var idToPokemon = {}
@@ -1142,7 +1142,7 @@ function loadRawData() {
         },
         error: function () {
             // Display error toast
-            toastr["error"]("Please check connectivity or reduce marker settings.", "Error getting Data")
+            toastr['error']('Please check connectivity or reduce marker settings.', 'Error getting Data')
             toastr.options = {
                 'closeButton': true,
                 'debug': false,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1140,17 +1140,11 @@ function loadRawData() {
                 rawDataIsLoading = true
             }
         },
+        success: function () {
+            document.getElementById('errstat').innerHTML = '<a href="#">Rocket Map - Scanning</a>'
+        },
         error: function () {
-            if (!$timeoutDialog) {
-                var opts = {
-                    title: 'Reduce marker settings'
-                }
-
-                $timeoutDialog = $('<div>Hmm... we\'re having problems getting data for your criteria. Try reducing what you\'re showing and zooming in to limit what\'s returned.</div>').dialog(opts)
-                $timeoutDialog.dialog('open')
-            } else if (!$timeoutDialog.dialog('isOpen')) {
-                $timeoutDialog.dialog('open')
-            }
+            document.getElementById('errstat').innerHTML = '<a href="#">Rocket Map - Error receiving data</a>'
         },
         complete: function () {
             rawDataIsLoading = false

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -18,7 +18,6 @@ var $selectSearchIconMarker
 var $selectGymMarkerStyle
 var $selectLocationIconMarker
 var $switchGymSidebar
-var $timeoutDialog
 
 var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
 var idToPokemon = {}

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1139,11 +1139,26 @@ function loadRawData() {
                 rawDataIsLoading = true
             }
         },
-        success: function () {
-            document.getElementById('errstat').innerHTML = '<a href="#">Rocket Map - Scanning</a>'
-        },
         error: function () {
-            document.getElementById('errstat').innerHTML = '<a href="#">Rocket Map - Error receiving data</a>'
+            // Display error toast
+            toastr["error"]("Please check connectivity or reduce marker settings.", "Error getting Data")
+            toastr.options = {
+                            "closeButton": true,
+                            "debug": false,
+                            "newestOnTop": true,
+                            "progressBar": false,
+                            "positionClass": "toast-top-right",
+                            "preventDuplicates": true,
+                            "onclick": null,
+                            "showDuration": "300",
+                            "hideDuration": "1000",
+                            "timeOut": "25000",
+                            "extendedTimeOut": "1000",
+                            "showEasing": "swing",
+                            "hideEasing": "linear",
+                            "showMethod": "fadeIn",
+                            "hideMethod": "fadeOut"
+                         }
         },
         complete: function () {
             rawDataIsLoading = false

--- a/templates/map.html
+++ b/templates/map.html
@@ -38,7 +38,7 @@
       <!-- Header -->
       <header id="header">
         <a href="#nav"><span class="label">Options</span></a>
-        <h1><a href="#">Rocket Map</a></h1>
+        <h1 id="errstat"><a href="#">Rocket Map</a></h1>
         <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
       </header>
       <!-- NAV -->

--- a/templates/map.html
+++ b/templates/map.html
@@ -32,13 +32,15 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css">
     <script src="{{ url_for('static', filename='js/vendor/modernizr.custom.js').lstrip('/') }}"></script>
+    <!-- Toastr -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
   </head>
   <body id="top">
     <div class="wrapper">
       <!-- Header -->
       <header id="header">
         <a href="#nav"><span class="label">Options</span></a>
-        <h1 id="errstat"><a href="#">Rocket Map</a></h1>
+        <h1><a href="#">Rocket Map</a></h1>
         <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
       </header>
       <!-- NAV -->
@@ -414,5 +416,6 @@
     <script src="{{ url_for('static', filename='dist/js/map.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='dist/js/stats.min.js').lstrip('/') }}"></script>
     <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script> 
   </body>
 </html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -412,10 +412,10 @@
       var centerLat = {{lat}};
       var centerLng = {{lng}};
     </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='dist/js/map.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='dist/js/stats.min.js').lstrip('/') }}"></script>
     <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script> 
   </body>
 </html>


### PR DESCRIPTION
The pop up "Reduce marker settings" popped up every time it timed out getting raw data and covered part of the map and stayed until manually closed, this PR removes that pop up and adds a Toastr pop up in the top right that times out.

## Motivation and Context
Due to a crappy connection this pop up was on almost constantly and had nothing to do with marker settings. The error message now times out after a set time

## How Has This Been Tested?
On a desktop pc running the map 

## Screenshots (if appropriate):
![toastr](https://cloud.githubusercontent.com/assets/8204684/25026776/26c37cb8-20a0-11e7-96af-7cbc1ec2de9a.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
