### PR TITLE
Fix issue where pokéstop doesn't have the 'enabled' field.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2076,7 +2076,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
                 pokestops[f['id']] = {
                     'pokestop_id': f['id'],
-                    'enabled': f['enabled'],
+                    'enabled': f.get('enabled', 0),
                     'latitude': f['latitude'],
                     'longitude': f['longitude'],
                     'last_modified': datetime.utcfromtimestamp(


### PR DESCRIPTION
## Motivation and Context
Fixes:
```
Traceback (most recent call last):
  File "/RocketMap/pogom/search.py", line 1002, in search_worker_thread
    dbq, whq, api, scan_date, account)
  File "/public_html/RocketMap/pogom/models.py", line 2079, in parse_map
    'enabled': f['enabled'],
KeyError: 'enabled'
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
