### PR TITLE
Switch control logic to prevent unintended control from outside

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -112,7 +112,7 @@
 #only-server                    # Server-Only Mode. Starts only the Webserver without the searcher.
 #locale:                        # Pokemon translation
 #search-control                 # Enables search control.
-#no-fixed-location              # Shows the search bar for use in shared maps.
+#no-fixed-location              # Disables the fixed map location and shows the search bar for use in shared maps.
 #cors                           # Enable CORS on web server.
 #ssl-certificate:               # Path to ssl certificate
 #ssl-privatekey:                # Path to ssl private key

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -111,8 +111,8 @@
 #no-server                      # No-Server Mode. Starts the searcher but not the Webserver.
 #only-server                    # Server-Only Mode. Starts only the Webserver without the searcher.
 #locale:                        # Pokemon translation
-#no-search-control              # Disables search control.
-#fixed-location                 # Hides the search bar for use in shared maps.
+#search-control                 # Enables search control.
+#no-fixed-location              # Shows the search bar for use in shared maps.
 #cors                           # Enable CORS on web server.
 #ssl-certificate:               # Path to ssl certificate
 #ssl-privatekey:                # Path to ssl private key

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -234,7 +234,7 @@ def get_args():
                         action='store_true', dest='search_control',
                         default=False)
     parser.add_argument('-nfl', '--no-fixed-location',
-                        help='Disables a fix map location and shows the ' +
+                        help='Disables a fixed map location and shows the ' +
                         'search bar for use in shared maps.',
                         action='store_false', dest='fixed_location',
                         default=True)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -229,13 +229,15 @@ def get_args():
                         help=('Server-Only Mode. Starts only the Webserver ' +
                               'without the searcher.'),
                         action='store_true', default=False)
-    parser.add_argument('-nsc', '--no-search-control',
-                        help='Disables search control.',
-                        action='store_false', dest='search_control',
+    parser.add_argument('-sc', '--search-control',
+                        help='Enables search control.',
+                        action='store_true', dest='search_control',
+                        default=False)
+    parser.add_argument('-nfl', '--no-fixed-location',
+                        help='Disables a fix map location and shows the ' +
+                        'search bar for use in shared maps.',
+                        action='store_false', dest='fixed_location',
                         default=True)
-    parser.add_argument('-fl', '--fixed-location',
-                        help='Hides the search bar for use in shared maps.',
-                        action='store_true', default=False)
     parser.add_argument('-k', '--gmaps-key',
                         help='Google Maps Javascript API Key.',
                         required=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes how the arguments ``fixed-location`` and ``no-search-control`` work in their logic by switching from positive and negative logic to the other as default while maintaining a good to read code (where those arguments are used in ``pogom/app.py``) by usage of the arguments parse parameter ``dest``. 
Hereby, additional functionality is enabled by setting these arguments instead of forcing beginners to add arguments which they do not consider at the first glance of this program and are mostly compromising easy setups.

The new arguments are now:
- ``-sc`` or ``--search-control``
- ``-nfl`` or ``--no-fixed-location`` (yeah, US-Football fans love me, now)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From the very beginning of my own map and recent requests I am bugged that, by default, people can change your set-up location. Especially with -speed this is a not-wanted feature by default. Also the search location feature, intended for distributed big shared maps, is not a default behaviour for the standard use-case of a neighbourhood map.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my local machine. Tests from you guys are welcomed, who still use on demand hex on variable locations or general a non-fixed map.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change default configuration to the better

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.