### PR TITLE
Add IV/CP scanning support with a L30 account pool.

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -100,8 +100,7 @@
 #encounter                      # Set to true to start encounters to pull more info, like IVs or movesets. (default=False)
 #encounter-delay:               # Delay in seconds before starting an encounter. Must not be zero. (default=1)
 #high-lvl-accounts:             # File containing a list high level accounts, in the format "25 or 30,auth_service,username,password"
-#iv-whitelist-file:             # File containing a list of Pokemon IDs to encounter for IVs. Requires L25 or higher accounts in --high-lvl-accounts.
-#cp-whitelist-file:             # File containing a list of Pokemon IDs to encounter for CPs. Requires L30 or higher accounts in --high-lvl-accounts.
+#enc-whitelist-file:            # File containing a list of Pokemon IDs to encounter for IV/CPs. Requires L30 or higher accounts in --high-lvl-accounts.
 
 
 # Webserver settings

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -99,10 +99,9 @@
 
 #encounter                      # Set to true to start encounters to pull more info, like IVs or movesets. (default=False)
 #encounter-delay:               # Delay in seconds before starting an encounter. Must not be zero. (default=1)
-#encounter-whitelist:           # Whitelist of pokemon ids to encounter. Syntax [id,id,id,id] (Do not use with blacklist)
-#encounter-whitelist-file:      # File containing a list of Pokemon to encounter for more stats. (Do not use with blacklist-file)
-#encounter-blacklist:           # Blacklist of pokemon ids to NOT encounter. Syntax [id,id,id,id] (Do not use with whitelist)
-#encounter-blacklist-file:      # File containing a list of Pokemon to NOT encounter formore stats. (Do not use with whitelist-file)
+#high-lvl-accounts:             # File containing a list high level accounts, in the format "25 or 30,auth_service,username,password"
+#iv-whitelist-file:             # File containing a list of Pokemon IDs to encounter for IVs. Requires L25 or higher accounts in --high-lvl-accounts.
+#cp-whitelist-file:             # File containing a list of Pokemon IDs to encounter for CPs. Requires L30 or higher accounts in --high-lvl-accounts.
 
 
 # Webserver settings

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -10,7 +10,7 @@
                     [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
                     [-mcr MANUAL_CAPTCHA_REFRESH]
                     [-mct MANUAL_CAPTCHA_TIMEOUT] [-ed ENCOUNTER_DELAY]
-                    [-ivwf IV_WHITELIST_FILE] [-cpwf CP_WHITELIST_FILE]
+                    [-encwf ENC_WHITELIST_FILE]
                     [-nostore]
                     [-wwht WEBHOOK_WHITELIST | -wblk WEBHOOK_BLACKLIST | -wwhtf WEBHOOK_WHITELIST_FILE | -wblkf WEBHOOK_BLACKLIST_FILE]
                     [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
@@ -142,12 +142,9 @@
     -ed ENCOUNTER_DELAY, --encounter-delay ENCOUNTER_DELAY
                         Time delay between encounter pokemon in scan threads.
                         [env var: POGOMAP_ENCOUNTER_DELAY]
-    -ivwf IV_WHITELIST_FILE, --iv-whitelist-file IV_WHITELIST_FILE
+    -encwf ENC_WHITELIST_FILE, --enc-whitelist-file ENC_WHITELIST_FILE
                         File containing a list of Pokemon IDs to encounter for
-                        IV scanning. [env var: POGOMAP_IV_WHITELIST_FILE]
-    -cpwf CP_WHITELIST_FILE, --cp-whitelist-file CP_WHITELIST_FILE
-                        File containing a list of Pokemon IDs to encounter for
-                        CP scanning. [env var: POGOMAP_CP_WHITELIST_FILE]
+                        IV/CP scanning. [env var: POGOMAP_IV_WHITELIST_FILE]
     -nostore, --no-api-store
                         Don't store the API objects used by the high level
                         accounts in memory. This will increase the number of

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -1,374 +1,375 @@
 # Command Line
 
     usage: runserver.py [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
-                        [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
-                        [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV] [-bh]
-                        [-wph WORKERS_PER_HIVE] [-l LOCATION] [-alt ALTITUDE]
-                        [-altv ALTITUDE_VARIANCE] [-uac] [-nj] [-al]
-                        [-st STEP_LIMIT] [-sd SCAN_DELAY]
-                        [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
-                        [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
-                        [-mcr MANUAL_CAPTCHA_REFRESH]
-                        [-mct MANUAL_CAPTCHA_TIMEOUT] [-ed ENCOUNTER_DELAY]
-                        [-ewht ENCOUNTER_WHITELIST | -eblk ENCOUNTER_BLACKLIST | -ewhtf ENCOUNTER_WHITELIST_FILE | -eblkf ENCOUNTER_BLACKLIST_FILE]
-                        [-wwht WEBHOOK_WHITELIST | -wblk WEBHOOK_BLACKLIST | -wwhtf WEBHOOK_WHITELIST_FILE | -wblkf WEBHOOK_BLACKLIST_FILE]
-                        [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
-                        [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
-                        [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
-                        [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-sc] [-nfl] -k
-                        GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np] [-ng]
-                        [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH]
-                        [-ldur LURE_DURATION] [--dump-spawnpoints]
-                        [-pd PURGE_DATA] [-px PROXY] [-pxsc] [-pxt PROXY_TIMEOUT]
-                        [-pxd PROXY_DISPLAY] [-pxf PROXY_FILE]
-                        [-pxr PROXY_REFRESH] [-pxo PROXY_ROTATION]
-                        [--db-type DB_TYPE] [--db-name DB_NAME]
-                        [--db-user DB_USER] [--db-pass DB_PASS]
-                        [--db-host DB_HOST] [--db-port DB_PORT]
-                        [--db-max_connections DB_MAX_CONNECTIONS]
-                        [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi]
-                        [--disable-clean] [--webhook-updates-only]
-                        [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
-                        [-whr WH_RETRIES] [-wht WH_TIMEOUT]
-                        [-whbf WH_BACKOFF_FACTOR] [-whlfu WH_LFU_SIZE] [-whsu]
-                        [--ssl-certificate SSL_CERTIFICATE]
-                        [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]]
-                        [-slt STATS_LOG_TIMER] [-sn STATUS_NAME]
-                        [-spp STATUS_PAGE_PASSWORD] [-hk HASH_KEY] [-tut] [-novc]
-                        [-vci VERSION_CHECK_INTERVAL] [-el ENCRYPT_LIB]
-                        [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
-                        [-tp TRUSTED_PROXIES] [-v [filename.log] | -vv
-                        [filename.log]]
-    
-    Args that start with '--' (eg. -a) can also be set in a config file
-    (./config/config.ini or specified via -cf). 
-	The recognized syntax for setting (key, value) pairs is based on the INI and
+                    [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
+                    [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV]
+                    [-hlvl HIGH_LVL_ACCOUNTS] [-bh] [-wph WORKERS_PER_HIVE]
+                    [-l LOCATION] [-alt ALTITUDE] [-altv ALTITUDE_VARIANCE]
+                    [-uac] [-nj] [-al] [-st STEP_LIMIT] [-sd SCAN_DELAY]
+                    [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
+                    [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
+                    [-mcr MANUAL_CAPTCHA_REFRESH]
+                    [-mct MANUAL_CAPTCHA_TIMEOUT] [-ed ENCOUNTER_DELAY]
+                    [-ivwf IV_WHITELIST_FILE] [-cpwf CP_WHITELIST_FILE]
+                    [-wwht WEBHOOK_WHITELIST | -wblk WEBHOOK_BLACKLIST | -wwhtf WEBHOOK_WHITELIST_FILE | -wblkf WEBHOOK_BLACKLIST_FILE]
+                    [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
+                    [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
+                    [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
+                    [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-sc] [-nfl] -k
+                    GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np] [-ng]
+                    [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH]
+                    [-hkph HLVL_KPH] [-ldur LURE_DURATION]
+                    [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY] [-pxsc]
+                    [-pxt PROXY_TIMEOUT] [-pxd PROXY_DISPLAY]
+                    [-pxf PROXY_FILE] [-pxr PROXY_REFRESH]
+                    [-pxo PROXY_ROTATION] [--db-type DB_TYPE]
+                    [--db-name DB_NAME] [--db-user DB_USER]
+                    [--db-pass DB_PASS] [--db-host DB_HOST]
+                    [--db-port DB_PORT]
+                    [--db-max_connections DB_MAX_CONNECTIONS]
+                    [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi]
+                    [--disable-clean] [--webhook-updates-only]
+                    [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
+                    [-whr WH_RETRIES] [-wht WH_TIMEOUT]
+                    [-whbf WH_BACKOFF_FACTOR] [-whlfu WH_LFU_SIZE] [-whsu]
+                    [--ssl-certificate SSL_CERTIFICATE]
+                    [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]]
+                    [-slt STATS_LOG_TIMER] [-sn STATUS_NAME]
+                    [-spp STATUS_PAGE_PASSWORD] [-hk HASH_KEY] [-tut] [-novc]
+                    [-vci VERSION_CHECK_INTERVAL] [-el ENCRYPT_LIB]
+                    [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
+                    [-tp TRUSTED_PROXIES] [-v [filename.log] | -vv
+                    [filename.log]]
+
+    Args that start with '--' (eg. -a) can also be set in a config file or
+    specified via -cf).
+    The recognized syntax for setting (key, value) pairs is based on the INI and
     YAML formats (e.g. key=value or foo=TRUE). For full documentation of the
     differences from the standards please refer to the ConfigArgParse
     documentation. If an arg is specified in more than one place, then commandline
     values override environment variables which override config file values which
     override defaults.
-    
+
     optional arguments:
-      -h, --help            show this help message and exit [env var:
-                            POGOMAP_HELP]
-      -cf CONFIG, --config CONFIG
-                            Set configuration file
-      -a AUTH_SERVICE, --auth-service AUTH_SERVICE
-                            Auth Services, either one for all accounts or one per
-                            account: ptc or google. Defaults all to ptc. [env var:
-                            POGOMAP_AUTH_SERVICE]
-      -u USERNAME, --username USERNAME
-                            Usernames, one per account. [env var:
-                            POGOMAP_USERNAME]
-      -p PASSWORD, --password PASSWORD
-                            Passwords, either single one for all accounts or one
-                            per account. [env var: POGOMAP_PASSWORD]
-      -w WORKERS, --workers WORKERS
-                            Number of search worker threads to start. Defaults to
-                            the number of accounts specified. [env var:
-                            POGOMAP_WORKERS]
-      -asi ACCOUNT_SEARCH_INTERVAL, --account-search-interval ACCOUNT_SEARCH_INTERVAL
-                            Seconds for accounts to search before switching to a
-                            new account. 0 to disable. [env var:
-                            POGOMAP_ACCOUNT_SEARCH_INTERVAL]
-      -ari ACCOUNT_REST_INTERVAL, --account-rest-interval ACCOUNT_REST_INTERVAL
-                            Seconds for accounts to rest when they fail or are
-                            switched out. [env var: POGOMAP_ACCOUNT_REST_INTERVAL]
-      -ac ACCOUNTCSV, --accountcsv ACCOUNTCSV
-                            Load accounts from CSV file containing
-                            "auth_service,username,passwd" lines. [env var:
-                            POGOMAP_ACCOUNTCSV]
-      -bh, --beehive        Use beehive configuration for multiple accounts, one
-                            account per hex. Make sure to keep -st under 5, and -w
-                            under the total amount of accounts available. [env
-                            var: POGOMAP_BEEHIVE]
-      -wph WORKERS_PER_HIVE, --workers-per-hive WORKERS_PER_HIVE
-                            Only referenced when using --beehive. Sets number of
-                            workers per hive. Default value is 1. [env var:
-                            POGOMAP_WORKERS_PER_HIVE]
-      -l LOCATION, --location LOCATION
-                            Location, can be an address or coordinates. [env var:
-                            POGOMAP_LOCATION]
-      -alt ALTITUDE, --altitude ALTITUDE
-                            Default altitude in meters. [env var:
-                            POGOMAP_ALTITUDE]
-      -altv ALTITUDE_VARIANCE, --altitude-variance ALTITUDE_VARIANCE
-                            Variance for --altitude in meters [env var:
-                            POGOMAP_ALTITUDE_VARIANCE]
-      -uac, --use-altitude-cache
-                            Query the Elevation API for each step, rather than
-                            only once, and store results in the database. [env
-                            var: POGOMAP_USE_ALTITUDE_CACHE]
-      -nj, --no-jitter      Don't apply random -9m to +9m jitter to location. [env
-                            var: POGOMAP_NO_JITTER]
-      -al, --access-logs    Write web logs to access.log. [env var:
-                            POGOMAP_ACCESS_LOGS]
-      -st STEP_LIMIT, --step-limit STEP_LIMIT
-                            Steps. [env var: POGOMAP_STEP_LIMIT]
-      -sd SCAN_DELAY, --scan-delay SCAN_DELAY
-                            Time delay between requests in scan threads. [env var:
-                            POGOMAP_SCAN_DELAY]
-      --spawn-delay SPAWN_DELAY
-                            Number of seconds after spawn time to wait before
-                            scanning to be sure the Pokemon is there. [env var:
-                            POGOMAP_SPAWN_DELAY]
-      -enc, --encounter     Start an encounter to gather IVs and moves. [env var:
-                            POGOMAP_ENCOUNTER]
-      -cs, --captcha-solving
-                            Enables captcha solving. [env var:
-                            POGOMAP_CAPTCHA_SOLVING]
-      -ck CAPTCHA_KEY, --captcha-key CAPTCHA_KEY
-                            2Captcha API key. [env var: POGOMAP_CAPTCHA_KEY]
-      -cds CAPTCHA_DSK, --captcha-dsk CAPTCHA_DSK
-                            Pokemon Go captcha data-sitekey. [env var:
-                            POGOMAP_CAPTCHA_DSK]
-      -mcd MANUAL_CAPTCHA_DOMAIN, --manual-captcha-domain MANUAL_CAPTCHA_DOMAIN
-                            Domain to where captcha tokens will be sent. [env var:
-                            POGOMAP_MANUAL_CAPTCHA_DOMAIN]
-      -mcr MANUAL_CAPTCHA_REFRESH, --manual-captcha-refresh MANUAL_CAPTCHA_REFRESH
-                            Time available before captcha page refreshes. [env
-                            var: POGOMAP_MANUAL_CAPTCHA_REFRESH]
-      -mct MANUAL_CAPTCHA_TIMEOUT, --manual-captcha-timeout MANUAL_CAPTCHA_TIMEOUT
-                            Maximum time captchas will wait for manual captcha
-                            solving. On timeout, if enabled, 2Captcha will be used
-                            to solve captcha. Default is 0. [env var:
-                            POGOMAP_MANUAL_CAPTCHA_TIMEOUT]
-      -ed ENCOUNTER_DELAY, --encounter-delay ENCOUNTER_DELAY
-                            Time delay between encounter pokemon in scan threads.
-                            [env var: POGOMAP_ENCOUNTER_DELAY]
-      -ewht ENCOUNTER_WHITELIST, --encounter-whitelist ENCOUNTER_WHITELIST
-                            List of Pokemon to encounter for more stats. [env var:
-                            POGOMAP_ENCOUNTER_WHITELIST]
-      -eblk ENCOUNTER_BLACKLIST, --encounter-blacklist ENCOUNTER_BLACKLIST
-                            List of Pokemon to NOT encounter for more stats. [env
-                            var: POGOMAP_ENCOUNTER_BLACKLIST]
-      -ewhtf ENCOUNTER_WHITELIST_FILE, --encounter-whitelist-file ENCOUNTER_WHITELIST_FILE
-                            File containing a list of Pokemon to encounter for
-                            more stats. [env var:
-                            POGOMAP_ENCOUNTER_WHITELIST_FILE]
-      -eblkf ENCOUNTER_BLACKLIST_FILE, --encounter-blacklist-file ENCOUNTER_BLACKLIST_FILE
-                            File containing a list of Pokemon to NOT encounter for
-                            more stats. [env var:
-                            POGOMAP_ENCOUNTER_BLACKLIST_FILE]
-      -wwht WEBHOOK_WHITELIST, --webhook-whitelist WEBHOOK_WHITELIST
-                            List of Pokemon to send to webhooks. Specified as
-                            Pokemon ID. [env var: POGOMAP_WEBHOOK_WHITELIST]
-      -wblk WEBHOOK_BLACKLIST, --webhook-blacklist WEBHOOK_BLACKLIST
-                            List of Pokemon NOT to send to webhooks. Specified as
-                            Pokemon ID. [env var: POGOMAP_WEBHOOK_BLACKLIST]
-      -wwhtf WEBHOOK_WHITELIST_FILE, --webhook-whitelist-file WEBHOOK_WHITELIST_FILE
-                            File containing a list of Pokemon to send to webhooks.
-                            Pokemon are specified by their name, one on each line.
-                            [env var: POGOMAP_WEBHOOK_WHITELIST_FILE]
-      -wblkf WEBHOOK_BLACKLIST_FILE, --webhook-blacklist-file WEBHOOK_BLACKLIST_FILE
-                            File containing a list of Pokemon NOT to send
-                            towebhooks. Pokemon are specified by their name, one
-                            on each line. [env var:
-                            POGOMAP_WEBHOOK_BLACKLIST_FILE]
-      -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
-                            Time delay between each login attempt. [env var:
-                            POGOMAP_LOGIN_DELAY]
-      -lr LOGIN_RETRIES, --login-retries LOGIN_RETRIES
-                            Number of times to retry the login before refreshing a
-                            thread. [env var: POGOMAP_LOGIN_RETRIES]
-      -mf MAX_FAILURES, --max-failures MAX_FAILURES
-                            Maximum number of failures to parse locations before
-                            an account will go into a sleep for -ari/--account-
-                            rest-interval seconds. [env var: POGOMAP_MAX_FAILURES]
-      -me MAX_EMPTY, --max-empty MAX_EMPTY
-                            Maximum number of empty scans before an account will
-                            go into a sleep for -ari/--account-rest-interval
-                            seconds.Reasonable to use with proxies. [env var:
-                            POGOMAP_MAX_EMPTY]
-      -bsr BAD_SCAN_RETRY, --bad-scan-retry BAD_SCAN_RETRY
-                            Number of bad scans before giving up on a step.
-                            Default 2, 0 to disable. [env var:
-                            POGOMAP_BAD_SCAN_RETRY]
-      -msl MIN_SECONDS_LEFT, --min-seconds-left MIN_SECONDS_LEFT
-                            Time that must be left on a spawn before considering
-                            it too late and skipping it. For example 600 would
-                            skip anything with < 10 minutes remaining. Default 0.
-                            [env var: POGOMAP_MIN_SECONDS_LEFT]
-      -dc, --display-in-console
-                            Display Found Pokemon in Console. [env var:
-                            POGOMAP_DISPLAY_IN_CONSOLE]
-      -H HOST, --host HOST  Set web server listening host. [env var: POGOMAP_HOST]
-      -P PORT, --port PORT  Set web server listening port. [env var: POGOMAP_PORT]
-      -L LOCALE, --locale LOCALE
-                            Locale for Pokemon names (default: en, check
-                            static/dist/locales for more). [env var:
-                            POGOMAP_LOCALE]
-      -c, --china           Coordinates transformer for China. [env var:
-                            POGOMAP_CHINA]
-      -m MOCK, --mock MOCK  Mock mode - point to a fpgo endpoint instead of using
-                            the real PogoApi, ec: http://127.0.0.1:9090 [env var:
-                            POGOMAP_MOCK]
-      -ns, --no-server      No-Server Mode. Starts the searcher but not the
-                            Webserver. [env var: POGOMAP_NO_SERVER]
-      -os, --only-server    Server-Only Mode. Starts only the Webserver without
-                            the searcher. [env var: POGOMAP_ONLY_SERVER]
-      -sc, --search-control
-                            Enables search control. [env var:
-                            POGOMAP_SEARCH_CONTROL]
-      -nfl, --no-fixed-location
-                            Disables a fixed map location and shows the search bar
-                            for use in shared maps. [env var:
-                            POGOMAP_NO_FIXED_LOCATION]
-      -k GMAPS_KEY, --gmaps-key GMAPS_KEY
-                            Google Maps Javascript API Key. [env var:
-                            POGOMAP_GMAPS_KEY]
-      --skip-empty          Enables skipping of empty cells in normal scans -
-                            requires previously populated database (not to be used
-                            with -ss) [env var: POGOMAP_SKIP_EMPTY]
-      -C, --cors            Enable CORS on web server. [env var: POGOMAP_CORS]
-      -D DB, --db DB        Database filename for SQLite. [env var: POGOMAP_DB]
-      -cd, --clear-db       Deletes the existing database before starting the
-                            Webserver. [env var: POGOMAP_CLEAR_DB]
-      -np, --no-pokemon     Disables Pokemon from the map (including parsing them
-                            into local db.) [env var: POGOMAP_NO_POKEMON]
-      -ng, --no-gyms        Disables Gyms from the map (including parsing them
-                            into local db). [env var: POGOMAP_NO_GYMS]
-      -nk, --no-pokestops   Disables PokeStops from the map (including parsing
-                            them into local db). [env var: POGOMAP_NO_POKESTOPS]
-      -ss [SPAWNPOINT_SCANNING], --spawnpoint-scanning [SPAWNPOINT_SCANNING]
-                            Use spawnpoint scanning (instead of hex grid). Scans
-                            in a circle based on step_limit when on DB. [env var:
-                            POGOMAP_SPAWNPOINT_SCANNING]
-      -speed, --speed-scan  Use speed scanning to identify spawn points and then
-                            scan closest spawns. [env var: POGOMAP_SPEED_SCAN]
-      -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
-                            [env var: POGOMAP_KPH]
-      -ldur LURE_DURATION, --lure-duration LURE_DURATION
-                            Change duration for lures set on pokestops. This is
-                            useful for events that extend lure duration. [env var:
-                            POGOMAP_LURE_DURATION]
-      --dump-spawnpoints    Dump the spawnpoints from the db to json (only for use
-                            with -ss). [env var: POGOMAP_DUMP_SPAWNPOINTS]
-      -pd PURGE_DATA, --purge-data PURGE_DATA
-                            Clear Pokemon from database this many hours after they
-                            disappear (0 to disable). [env var:
-                            POGOMAP_PURGE_DATA]
-      -px PROXY, --proxy PROXY
-                            Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
-                            POGOMAP_PROXY]
-      -pxsc, --proxy-skip-check
-                            Disable checking of proxies before start. [env var:
-                            POGOMAP_PROXY_SKIP_CHECK]
-      -pxt PROXY_TIMEOUT, --proxy-timeout PROXY_TIMEOUT
-                            Timeout settings for proxy checker in seconds. [env
-                            var: POGOMAP_PROXY_TIMEOUT]
-      -pxd PROXY_DISPLAY, --proxy-display PROXY_DISPLAY
-                            Display info on which proxy being used (index or
-                            full). To be used with -ps. [env var:
-                            POGOMAP_PROXY_DISPLAY]
-      -pxf PROXY_FILE, --proxy-file PROXY_FILE
-                            Load proxy list from text file (one proxy per line),
-                            overrides -px/--proxy. [env var: POGOMAP_PROXY_FILE]
-      -pxr PROXY_REFRESH, --proxy-refresh PROXY_REFRESH
-                            Period of proxy file reloading, in seconds. Works only
-                            with -pxf/--proxy-file. (0 to disable). [env var:
-                            POGOMAP_PROXY_REFRESH]
-      -pxo PROXY_ROTATION, --proxy-rotation PROXY_ROTATION
-                            Enable proxy rotation with account changing for search
-                            threads (none/round/random). [env var:
-                            POGOMAP_PROXY_ROTATION]
-      --db-type DB_TYPE     Type of database to be used (default: sqlite). [env
-                            var: POGOMAP_DB_TYPE]
-      --db-name DB_NAME     Name of the database to be used. [env var:
-                            POGOMAP_DB_NAME]
-      --db-user DB_USER     Username for the database. [env var: POGOMAP_DB_USER]
-      --db-pass DB_PASS     Password for the database. [env var: POGOMAP_DB_PASS]
-      --db-host DB_HOST     IP or hostname for the database. [env var:
-                            POGOMAP_DB_HOST]
-      --db-port DB_PORT     Port for the database. [env var: POGOMAP_DB_PORT]
-      --db-max_connections DB_MAX_CONNECTIONS
-                            Max connections (per thread) for the database. [env
-                            var: POGOMAP_DB_MAX_CONNECTIONS]
-      --db-threads DB_THREADS
-                            Number of db threads; increase if the db queue falls
-                            behind. [env var: POGOMAP_DB_THREADS]
-      -wh WEBHOOKS, --webhook WEBHOOKS
-                            Define URL(s) to POST webhook information to. [env
-                            var: POGOMAP_WEBHOOK]
-      -gi, --gym-info       Get all details about gyms (causes an additional API
-                            hit for every gym). [env var: POGOMAP_GYM_INFO]
-      --disable-clean       Disable clean db loop. [env var:
-                            POGOMAP_DISABLE_CLEAN]
-      --webhook-updates-only
-                            Only send updates (Pokemon & lured pokestops). [env
-                            var: POGOMAP_WEBHOOK_UPDATES_ONLY]
-      --wh-threads WH_THREADS
-                            Number of webhook threads; increase if the webhook
-                            queue falls behind. [env var: POGOMAP_WH_THREADS]
-      -whc WH_CONCURRENCY, --wh-concurrency WH_CONCURRENCY
-                            Async requests pool size. [env var:
-                            POGOMAP_WH_CONCURRENCY]
-      -whr WH_RETRIES, --wh-retries WH_RETRIES
-                            Number of times to retry sending webhook data on
-                            failure. [env var: POGOMAP_WH_RETRIES]
-      -wht WH_TIMEOUT, --wh-timeout WH_TIMEOUT
-                            Timeout (in seconds) for webhook requests. [env var:
-                            POGOMAP_WH_TIMEOUT]
-      -whbf WH_BACKOFF_FACTOR, --wh-backoff-factor WH_BACKOFF_FACTOR
-                            Factor (in seconds) by which the delay until next
-                            retry will increase. [env var:
-                            POGOMAP_WH_BACKOFF_FACTOR]
-      -whlfu WH_LFU_SIZE, --wh-lfu-size WH_LFU_SIZE
-                            Webhook LFU cache max size. [env var:
-                            POGOMAP_WH_LFU_SIZE]
-      -whsu, --webhook-scheduler-updates
-                            Send webhook updates with scheduler status (use with
-                            -wh). [env var: POGOMAP_WEBHOOK_SCHEDULER_UPDATES]
-      --ssl-certificate SSL_CERTIFICATE
-                            Path to SSL certificate file. [env var:
-                            POGOMAP_SSL_CERTIFICATE]
-      --ssl-privatekey SSL_PRIVATEKEY
-                            Path to SSL private key file. [env var:
-                            POGOMAP_SSL_PRIVATEKEY]
-      -ps [logs], --print-status [logs]
-                            Show a status screen instead of log messages. Can
-                            switch between status and logs by pressing enter.
-                            Optionally specify "logs" to startup in logging mode.
-                            [env var: POGOMAP_PRINT_STATUS]
-      -slt STATS_LOG_TIMER, --stats-log-timer STATS_LOG_TIMER
-                            In log view, list per hr stats every X seconds [env
-                            var: POGOMAP_STATS_LOG_TIMER]
-      -sn STATUS_NAME, --status-name STATUS_NAME
-                            Enable status page database update using STATUS_NAME
-                            as main worker name. [env var: POGOMAP_STATUS_NAME]
-      -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
-                            Set the status page password. [env var:
-                            POGOMAP_STATUS_PAGE_PASSWORD]
-      -hk HASH_KEY, --hash-key HASH_KEY
-                            Key for hash server [env var: POGOMAP_HASH_KEY]
-      -tut, --complete-tutorial
-                            Complete ToS and tutorial steps on accounts if they
-                            haven't already. [env var: POGOMAP_COMPLETE_TUTORIAL]
-      -novc, --no-version-check
-                            Disable API version check. [env var:
-                            POGOMAP_NO_VERSION_CHECK]
-      -vci VERSION_CHECK_INTERVAL, --version-check-interval VERSION_CHECK_INTERVAL
-                            Interval to check API version in seconds (Default: in
-                            [60, 300]). [env var: POGOMAP_VERSION_CHECK_INTERVAL]
-      -el ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
-                            Path to encrypt lib to be used instead of the shipped
-                            ones. [env var: POGOMAP_ENCRYPT_LIB]
-      -odt ON_DEMAND_TIMEOUT, --on-demand_timeout ON_DEMAND_TIMEOUT
-                            Pause searching while web UI is inactive for this
-                            timeout (in seconds). [env var:
-                            POGOMAP_ON_DEMAND_TIMEOUT]
-      --disable-blacklist   Disable the global anti-scraper IP blacklist. [env
-                            var: POGOMAP_DISABLE_BLACKLIST]
-      -tp TRUSTED_PROXIES, --trusted-proxies TRUSTED_PROXIES
-                            Enables the use of X-FORWARDED-FOR headers to identify
-                            the IP of clients connecting through these trusted
-                            proxies. [env var: POGOMAP_TRUSTED_PROXIES]
-      -v [filename.log], --verbose [filename.log]
-                            Show debug messages from RocketMap and pgoapi.
-                            Optionally specify file to log to. [env var:
-                            POGOMAP_VERBOSE]
-      -vv [filename.log], --very-verbose [filename.log]
-                            Like verbose, but show debug messages from all modules
-                            as well. Optionally specify file to log to. [env var:
-                            POGOMAP_VERY_VERBOSE]
+    -h, --help            show this help message and exit [env var:
+                        POGOMAP_HELP]
+    -cf CONFIG, --config CONFIG
+                        Set configuration file
+    -a AUTH_SERVICE, --auth-service AUTH_SERVICE
+                        Auth Services, either one for all accounts or one per
+                        account: ptc or google. Defaults all to ptc. [env var:
+                        POGOMAP_AUTH_SERVICE]
+    -u USERNAME, --username USERNAME
+                        Usernames, one per account. [env var:
+                        POGOMAP_USERNAME]
+    -p PASSWORD, --password PASSWORD
+                        Passwords, either single one for all accounts or one
+                        per account. [env var: POGOMAP_PASSWORD]
+    -w WORKERS, --workers WORKERS
+                        Number of search worker threads to start. Defaults to
+                        the number of accounts specified. [env var:
+                        POGOMAP_WORKERS]
+    -asi ACCOUNT_SEARCH_INTERVAL, --account-search-interval ACCOUNT_SEARCH_INTERVAL
+                        Seconds for accounts to search before switching to a
+                        new account. 0 to disable. [env var:
+                        POGOMAP_ACCOUNT_SEARCH_INTERVAL]
+    -ari ACCOUNT_REST_INTERVAL, --account-rest-interval ACCOUNT_REST_INTERVAL
+                        Seconds for accounts to rest when they fail or are
+                        switched out. [env var: POGOMAP_ACCOUNT_REST_INTERVAL]
+    -ac ACCOUNTCSV, --accountcsv ACCOUNTCSV
+                        Load accounts from CSV file containing
+                        "auth_service,username,passwd" lines. [env var:
+                        POGOMAP_ACCOUNTCSV]
+    -hlvl HIGH_LVL_ACCOUNTS, --high-lvl-accounts HIGH_LVL_ACCOUNTS
+                        Load high level accounts from CSV file containing "25
+                        or 30,auth_service,username,passwd" lines. [env var:
+                        POGOMAP_HIGH_LVL_ACCOUNTS]
+    -bh, --beehive        Use beehive configuration for multiple accounts, one
+                        account per hex. Make sure to keep -st under 5, and -w
+                        under the total amount of accounts available. [env
+                        var: POGOMAP_BEEHIVE]
+    -wph WORKERS_PER_HIVE, --workers-per-hive WORKERS_PER_HIVE
+                        Only referenced when using --beehive. Sets number of
+                        workers per hive. Default value is 1. [env var:
+                        POGOMAP_WORKERS_PER_HIVE]
+    -l LOCATION, --location LOCATION
+                        Location, can be an address or coordinates. [env var:
+                        POGOMAP_LOCATION]
+    -alt ALTITUDE, --altitude ALTITUDE
+                        Default altitude in meters. [env var:
+                        POGOMAP_ALTITUDE]
+    -altv ALTITUDE_VARIANCE, --altitude-variance ALTITUDE_VARIANCE
+                        Variance for --altitude in meters [env var:
+                        POGOMAP_ALTITUDE_VARIANCE]
+    -uac, --use-altitude-cache
+                        Query the Elevation API for each step, rather than
+                        only once, and store results in the database. [env
+                        var: POGOMAP_USE_ALTITUDE_CACHE]
+    -nj, --no-jitter      Don't apply random -9m to +9m jitter to location. [env
+                        var: POGOMAP_NO_JITTER]
+    -al, --access-logs    Write web logs to access.log. [env var:
+                        POGOMAP_ACCESS_LOGS]
+    -st STEP_LIMIT, --step-limit STEP_LIMIT
+                        Steps. [env var: POGOMAP_STEP_LIMIT]
+    -sd SCAN_DELAY, --scan-delay SCAN_DELAY
+                        Time delay between requests in scan threads. [env var:
+                        POGOMAP_SCAN_DELAY]
+    --spawn-delay SPAWN_DELAY
+                        Number of seconds after spawn time to wait before
+                        scanning to be sure the Pokemon is there. [env var:
+                        POGOMAP_SPAWN_DELAY]
+    -enc, --encounter     Start an encounter to gather IVs and moves. [env var:
+                        POGOMAP_ENCOUNTER]
+    -cs, --captcha-solving
+                        Enables captcha solving. [env var:
+                        POGOMAP_CAPTCHA_SOLVING]
+    -ck CAPTCHA_KEY, --captcha-key CAPTCHA_KEY
+                        2Captcha API key. [env var: POGOMAP_CAPTCHA_KEY]
+    -cds CAPTCHA_DSK, --captcha-dsk CAPTCHA_DSK
+                        Pokemon Go captcha data-sitekey. [env var:
+                        POGOMAP_CAPTCHA_DSK]
+    -mcd MANUAL_CAPTCHA_DOMAIN, --manual-captcha-domain MANUAL_CAPTCHA_DOMAIN
+                        Domain to where captcha tokens will be sent. [env var:
+                        POGOMAP_MANUAL_CAPTCHA_DOMAIN]
+    -mcr MANUAL_CAPTCHA_REFRESH, --manual-captcha-refresh MANUAL_CAPTCHA_REFRESH
+                        Time available before captcha page refreshes. [env
+                        var: POGOMAP_MANUAL_CAPTCHA_REFRESH]
+    -mct MANUAL_CAPTCHA_TIMEOUT, --manual-captcha-timeout MANUAL_CAPTCHA_TIMEOUT
+                        Maximum time captchas will wait for manual captcha
+                        solving. On timeout, if enabled, 2Captcha will be used
+                        to solve captcha. Default is 0. [env var:
+                        POGOMAP_MANUAL_CAPTCHA_TIMEOUT]
+    -ed ENCOUNTER_DELAY, --encounter-delay ENCOUNTER_DELAY
+                        Time delay between encounter pokemon in scan threads.
+                        [env var: POGOMAP_ENCOUNTER_DELAY]
+    -ivwf IV_WHITELIST_FILE, --iv-whitelist-file IV_WHITELIST_FILE
+                        File containing a list of Pokemon IDs to encounter for
+                        IV scanning. [env var: POGOMAP_IV_WHITELIST_FILE]
+    -cpwf CP_WHITELIST_FILE, --cp-whitelist-file CP_WHITELIST_FILE
+                        File containing a list of Pokemon IDs to encounter for
+                        CP scanning. [env var: POGOMAP_CP_WHITELIST_FILE]
+    -wwht WEBHOOK_WHITELIST, --webhook-whitelist WEBHOOK_WHITELIST
+                        List of Pokemon to send to webhooks. Specified as
+                        Pokemon ID. [env var: POGOMAP_WEBHOOK_WHITELIST]
+    -wblk WEBHOOK_BLACKLIST, --webhook-blacklist WEBHOOK_BLACKLIST
+                        List of Pokemon NOT to send to webhooks. Specified as
+                        Pokemon ID. [env var: POGOMAP_WEBHOOK_BLACKLIST]
+    -wwhtf WEBHOOK_WHITELIST_FILE, --webhook-whitelist-file WEBHOOK_WHITELIST_FILE
+                        File containing a list of Pokemon to send to webhooks.
+                        Pokemon are specified by their name, one on each line.
+                        [env var: POGOMAP_WEBHOOK_WHITELIST_FILE]
+    -wblkf WEBHOOK_BLACKLIST_FILE, --webhook-blacklist-file WEBHOOK_BLACKLIST_FILE
+                        File containing a list of Pokemon NOT to send
+                        towebhooks. Pokemon are specified by their name, one
+                        on each line. [env var:
+                        POGOMAP_WEBHOOK_BLACKLIST_FILE]
+    -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
+                        Time delay between each login attempt. [env var:
+                        POGOMAP_LOGIN_DELAY]
+    -lr LOGIN_RETRIES, --login-retries LOGIN_RETRIES
+                        Number of times to retry the login before refreshing a
+                        thread. [env var: POGOMAP_LOGIN_RETRIES]
+    -mf MAX_FAILURES, --max-failures MAX_FAILURES
+                        Maximum number of failures to parse locations before
+                        an account will go into a sleep for -ari/--account-
+                        rest-interval seconds. [env var: POGOMAP_MAX_FAILURES]
+    -me MAX_EMPTY, --max-empty MAX_EMPTY
+                        Maximum number of empty scans before an account will
+                        go into a sleep for -ari/--account-rest-interval
+                        seconds.Reasonable to use with proxies. [env var:
+                        POGOMAP_MAX_EMPTY]
+    -bsr BAD_SCAN_RETRY, --bad-scan-retry BAD_SCAN_RETRY
+                        Number of bad scans before giving up on a step.
+                        Default 2, 0 to disable. [env var:
+                        POGOMAP_BAD_SCAN_RETRY]
+    -msl MIN_SECONDS_LEFT, --min-seconds-left MIN_SECONDS_LEFT
+                        Time that must be left on a spawn before considering
+                        it too late and skipping it. For example 600 would
+                        skip anything with < 10 minutes remaining. Default 0.
+                        [env var: POGOMAP_MIN_SECONDS_LEFT]
+    -dc, --display-in-console
+                        Display Found Pokemon in Console. [env var:
+                        POGOMAP_DISPLAY_IN_CONSOLE]
+    -H HOST, --host HOST  Set web server listening host. [env var: POGOMAP_HOST]
+    -P PORT, --port PORT  Set web server listening port. [env var: POGOMAP_PORT]
+    -L LOCALE, --locale LOCALE
+                        Locale for Pokemon names (default: en, check
+                        static/dist/locales for more). [env var:
+                        POGOMAP_LOCALE]
+    -c, --china           Coordinates transformer for China. [env var:
+                        POGOMAP_CHINA]
+    -m MOCK, --mock MOCK  Mock mode - point to a fpgo endpoint instead of using
+                        the real PogoApi, ec: http://127.0.0.1:9090 [env var:
+                        POGOMAP_MOCK]
+    -ns, --no-server      No-Server Mode. Starts the searcher but not the
+                        Webserver. [env var: POGOMAP_NO_SERVER]
+    -os, --only-server    Server-Only Mode. Starts only the Webserver without
+                        the searcher. [env var: POGOMAP_ONLY_SERVER]
+    -sc, --search-control
+                        Enables search control. [env var:
+                        POGOMAP_SEARCH_CONTROL]
+    -nfl, --no-fixed-location
+                        Disables a fixed map location and shows the search bar
+                        for use in shared maps. [env var:
+                        POGOMAP_NO_FIXED_LOCATION]
+    -k GMAPS_KEY, --gmaps-key GMAPS_KEY
+                        Google Maps Javascript API Key. [env var:
+                        POGOMAP_GMAPS_KEY]
+    --skip-empty          Enables skipping of empty cells in normal scans -
+                        requires previously populated database (not to be used
+                        with -ss) [env var: POGOMAP_SKIP_EMPTY]
+    -C, --cors            Enable CORS on web server. [env var: POGOMAP_CORS]
+    -D DB, --db DB        Database filename for SQLite. [env var: POGOMAP_DB]
+    -cd, --clear-db       Deletes the existing database before starting the
+                        Webserver. [env var: POGOMAP_CLEAR_DB]
+    -np, --no-pokemon     Disables Pokemon from the map (including parsing them
+                        into local db.) [env var: POGOMAP_NO_POKEMON]
+    -ng, --no-gyms        Disables Gyms from the map (including parsing them
+                        into local db). [env var: POGOMAP_NO_GYMS]
+    -nk, --no-pokestops   Disables PokeStops from the map (including parsing
+                        them into local db). [env var: POGOMAP_NO_POKESTOPS]
+    -ss [SPAWNPOINT_SCANNING], --spawnpoint-scanning [SPAWNPOINT_SCANNING]
+                        Use spawnpoint scanning (instead of hex grid). Scans
+                        in a circle based on step_limit when on DB. [env var:
+                        POGOMAP_SPAWNPOINT_SCANNING]
+    -speed, --speed-scan  Use speed scanning to identify spawn points and then
+                        scan closest spawns. [env var: POGOMAP_SPEED_SCAN]
+    -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
+                        [env var: POGOMAP_KPH]
+    -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
+                        Set a maximum speed in km/hour for scanner movement,
+                        for high-level (L25/L30) accounts. [env var:
+                        POGOMAP_HLVL_KPH]
+    -ldur LURE_DURATION, --lure-duration LURE_DURATION
+                        Change duration for lures set on pokestops. This is
+                        useful for events that extend lure duration. [env var:
+                        POGOMAP_LURE_DURATION]
+    --dump-spawnpoints    Dump the spawnpoints from the db to json (only for use
+                        with -ss). [env var: POGOMAP_DUMP_SPAWNPOINTS]
+    -pd PURGE_DATA, --purge-data PURGE_DATA
+                        Clear Pokemon from database this many hours after they
+                        disappear (0 to disable). [env var:
+                        POGOMAP_PURGE_DATA]
+    -px PROXY, --proxy PROXY
+                        Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
+                        POGOMAP_PROXY]
+    -pxsc, --proxy-skip-check
+                        Disable checking of proxies before start. [env var:
+                        POGOMAP_PROXY_SKIP_CHECK]
+    -pxt PROXY_TIMEOUT, --proxy-timeout PROXY_TIMEOUT
+                        Timeout settings for proxy checker in seconds. [env
+                        var: POGOMAP_PROXY_TIMEOUT]
+    -pxd PROXY_DISPLAY, --proxy-display PROXY_DISPLAY
+                        Display info on which proxy being used (index or
+                        full). To be used with -ps. [env var:
+                        POGOMAP_PROXY_DISPLAY]
+    -pxf PROXY_FILE, --proxy-file PROXY_FILE
+                        Load proxy list from text file (one proxy per line),
+                        overrides -px/--proxy. [env var: POGOMAP_PROXY_FILE]
+    -pxr PROXY_REFRESH, --proxy-refresh PROXY_REFRESH
+                        Period of proxy file reloading, in seconds. Works only
+                        with -pxf/--proxy-file. (0 to disable). [env var:
+                        POGOMAP_PROXY_REFRESH]
+    -pxo PROXY_ROTATION, --proxy-rotation PROXY_ROTATION
+                        Enable proxy rotation with account changing for search
+                        threads (none/round/random). [env var:
+                        POGOMAP_PROXY_ROTATION]
+    --db-type DB_TYPE     Type of database to be used (default: sqlite). [env
+                        var: POGOMAP_DB_TYPE]
+    --db-name DB_NAME     Name of the database to be used. [env var:
+                        POGOMAP_DB_NAME]
+    --db-user DB_USER     Username for the database. [env var: POGOMAP_DB_USER]
+    --db-pass DB_PASS     Password for the database. [env var: POGOMAP_DB_PASS]
+    --db-host DB_HOST     IP or hostname for the database. [env var:
+                        POGOMAP_DB_HOST]
+    --db-port DB_PORT     Port for the database. [env var: POGOMAP_DB_PORT]
+    --db-max_connections DB_MAX_CONNECTIONS
+                        Max connections (per thread) for the database. [env
+                        var: POGOMAP_DB_MAX_CONNECTIONS]
+    --db-threads DB_THREADS
+                        Number of db threads; increase if the db queue falls
+                        behind. [env var: POGOMAP_DB_THREADS]
+    -wh WEBHOOKS, --webhook WEBHOOKS
+                        Define URL(s) to POST webhook information to. [env
+                        var: POGOMAP_WEBHOOK]
+    -gi, --gym-info       Get all details about gyms (causes an additional API
+                        hit for every gym). [env var: POGOMAP_GYM_INFO]
+    --disable-clean       Disable clean db loop. [env var:
+                        POGOMAP_DISABLE_CLEAN]
+    --webhook-updates-only
+                        Only send updates (Pokemon & lured pokestops). [env
+                        var: POGOMAP_WEBHOOK_UPDATES_ONLY]
+    --wh-threads WH_THREADS
+                        Number of webhook threads; increase if the webhook
+                        queue falls behind. [env var: POGOMAP_WH_THREADS]
+    -whc WH_CONCURRENCY, --wh-concurrency WH_CONCURRENCY
+                        Async requests pool size. [env var:
+                        POGOMAP_WH_CONCURRENCY]
+    -whr WH_RETRIES, --wh-retries WH_RETRIES
+                        Number of times to retry sending webhook data on
+                        failure. [env var: POGOMAP_WH_RETRIES]
+    -wht WH_TIMEOUT, --wh-timeout WH_TIMEOUT
+                        Timeout (in seconds) for webhook requests. [env var:
+                        POGOMAP_WH_TIMEOUT]
+    -whbf WH_BACKOFF_FACTOR, --wh-backoff-factor WH_BACKOFF_FACTOR
+                        Factor (in seconds) by which the delay until next
+                        retry will increase. [env var:
+                        POGOMAP_WH_BACKOFF_FACTOR]
+    -whlfu WH_LFU_SIZE, --wh-lfu-size WH_LFU_SIZE
+                        Webhook LFU cache max size. [env var:
+                        POGOMAP_WH_LFU_SIZE]
+    -whsu, --webhook-scheduler-updates
+                        Send webhook updates with scheduler status (use with
+                        -wh). [env var: POGOMAP_WEBHOOK_SCHEDULER_UPDATES]
+    --ssl-certificate SSL_CERTIFICATE
+                        Path to SSL certificate file. [env var:
+                        POGOMAP_SSL_CERTIFICATE]
+    --ssl-privatekey SSL_PRIVATEKEY
+                        Path to SSL private key file. [env var:
+                        POGOMAP_SSL_PRIVATEKEY]
+    -ps [logs], --print-status [logs]
+                        Show a status screen instead of log messages. Can
+                        switch between status and logs by pressing enter.
+                        Optionally specify "logs" to startup in logging mode.
+                        [env var: POGOMAP_PRINT_STATUS]
+    -slt STATS_LOG_TIMER, --stats-log-timer STATS_LOG_TIMER
+                        In log view, list per hr stats every X seconds [env
+                        var: POGOMAP_STATS_LOG_TIMER]
+    -sn STATUS_NAME, --status-name STATUS_NAME
+                        Enable status page database update using STATUS_NAME
+                        as main worker name. [env var: POGOMAP_STATUS_NAME]
+    -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
+                        Set the status page password. [env var:
+                        POGOMAP_STATUS_PAGE_PASSWORD]
+    -hk HASH_KEY, --hash-key HASH_KEY
+                        Key for hash server [env var: POGOMAP_HASH_KEY]
+    -tut, --complete-tutorial
+                        Complete ToS and tutorial steps on accounts if they
+                        haven't already. [env var: POGOMAP_COMPLETE_TUTORIAL]
+    -novc, --no-version-check
+                        Disable API version check. [env var:
+                        POGOMAP_NO_VERSION_CHECK]
+    -vci VERSION_CHECK_INTERVAL, --version-check-interval VERSION_CHECK_INTERVAL
+                        Interval to check API version in seconds (Default: in
+                        [60, 300]). [env var: POGOMAP_VERSION_CHECK_INTERVAL]
+    -el ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
+                        Path to encrypt lib to be used instead of the shipped
+                        ones. [env var: POGOMAP_ENCRYPT_LIB]
+    -odt ON_DEMAND_TIMEOUT, --on-demand_timeout ON_DEMAND_TIMEOUT
+                        Pause searching while web UI is inactive for this
+                        timeout (in seconds). [env var:
+                        POGOMAP_ON_DEMAND_TIMEOUT]
+    --disable-blacklist   Disable the global anti-scraper IP blacklist. [env
+                        var: POGOMAP_DISABLE_BLACKLIST]
+    -tp TRUSTED_PROXIES, --trusted-proxies TRUSTED_PROXIES
+                        Enables the use of X-FORWARDED-FOR headers to identify
+                        the IP of clients connecting through these trusted
+                        proxies. [env var: POGOMAP_TRUSTED_PROXIES]
+    -v [filename.log], --verbose [filename.log]
+                        Show debug messages from RocketMap and pgoapi.
+                        Optionally specify file to log to. [env var:
+                        POGOMAP_VERBOSE]
+    -vv [filename.log], --very-verbose [filename.log]
+                        Like verbose, but show debug messages from all modules
+                        as well. Optionally specify file to log to. [env var:
+                        POGOMAP_VERY_VERBOSE]

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -11,6 +11,7 @@
                     [-mcr MANUAL_CAPTCHA_REFRESH]
                     [-mct MANUAL_CAPTCHA_TIMEOUT] [-ed ENCOUNTER_DELAY]
                     [-ivwf IV_WHITELIST_FILE] [-cpwf CP_WHITELIST_FILE]
+                    [-nostore]
                     [-wwht WEBHOOK_WHITELIST | -wblk WEBHOOK_BLACKLIST | -wwhtf WEBHOOK_WHITELIST_FILE | -wblkf WEBHOOK_BLACKLIST_FILE]
                     [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
                     [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
@@ -41,8 +42,7 @@
                     [-tp TRUSTED_PROXIES] [-v [filename.log] | -vv
                     [filename.log]]
 
-    Args that start with '--' (eg. -a) can also be set in a config file or
-    specified via -cf).
+    Args that start with '--' (eg. -a) can also be set in a config file.
     The recognized syntax for setting (key, value) pairs is based on the INI and
     YAML formats (e.g. key=value or foo=TRUE). For full documentation of the
     differences from the standards please refer to the ConfigArgParse
@@ -148,6 +148,11 @@
     -cpwf CP_WHITELIST_FILE, --cp-whitelist-file CP_WHITELIST_FILE
                         File containing a list of Pokemon IDs to encounter for
                         CP scanning. [env var: POGOMAP_CP_WHITELIST_FILE]
+    -nostore, --no-api-store
+                        Don't store the API objects used by the high level
+                        accounts in memory. This will increase the number of
+                        logins per account, but decreases memory usage. [env
+                        var: POGOMAP_NO_API_STORE]
     -wwht WEBHOOK_WHITELIST, --webhook-whitelist WEBHOOK_WHITELIST
                         List of Pokemon to send to webhooks. Specified as
                         Pokemon ID. [env var: POGOMAP_WEBHOOK_WHITELIST]

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -240,7 +240,7 @@
                         [env var: POGOMAP_KPH]
     -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
                         Set a maximum speed in km/hour for scanner movement,
-                        for high-level (L25/L30) accounts. [env var:
+                        for high-level (L30) accounts. [env var:
                         POGOMAP_HLVL_KPH]
     -ldur LURE_DURATION, --lure-duration LURE_DURATION
                         Change duration for lures set on pokestops. This is

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -1,0 +1,44 @@
+# Pokémon Encounters
+
+Since the IV update of April 21st which makes IVs the same for players of level 25 and above, the encounter system has been reworked and now includes CP/IV scanning.
+
+Steps for using the new encounter system:
+
+1. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
+   ```
+   25,ptc,randOMusername1,P4ssw0rd!
+   25,ptc,randOMusername2,P4ssw0rd!
+   30,ptc,randOMusername1,P4ssw0rd!
+   ```
+2. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
+   iv-whitelist.txt:
+   ```
+   10
+   25
+   38
+   168
+   ```
+   cp-whitelist.txt:
+   ```
+   35
+   66
+   89
+   ```
+3. Enabled the whitelist files in your config or cli parameters (check commandline.md for usage):
+   ```
+   --iv-whitelist-file iv-whitelist.txt --cp-whitelist-file cp-whitelist.txt
+   ```
+4. Optionally set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
+   ```
+   --hlvl-kph 25
+   ```
+
+L25/L30 accounts are not being recycled and are not in the usual account flow. This is intentional, to allow for future reworks to handle accounts properly. This also keeps interaction with high level accounts to a minimum. We can consider handling them more automatically when the account handlers are properly fully implemented.
+
+Some important notes:
+
+ * The old encounter whitelists/blacklists have been removed entirely.
+ * Both the IV and CP whitelists are optional.
+ * When no L25 accounts are available but IV encounters are enabled, it will try to get a L30 account instead for the encounter.
+ * Captcha'd L25/L30 accounts will be logged and disabled in the scheduler. Having `-v` enabled will show you an entry in the logs mentioning "High level account x encountered a captcha". They will not be solved automatically.
+ * The encounter is a single request (1 RPM). We intentionally don't use the account for anything else besides the encounter.

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -4,7 +4,8 @@ Since the IV update of April 21st which makes IVs the same for players of level 
 
 Steps for using the new encounter system:
 
-1. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
+1. Enabled encounters on your map (`-enc`).
+2. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
    ```
    25,ptc,randOMusername1,P4ssw0rd!
    25,ptc,randOMusername2,P4ssw0rd!
@@ -14,7 +15,7 @@ Steps for using the new encounter system:
    ```
    --high-lvl-accounts high-level.csv
    ```
-2. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
+3. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
    iv-whitelist.txt:
    ```
    10
@@ -28,11 +29,11 @@ Steps for using the new encounter system:
    66
    89
    ```
-3. Enable the whitelist files in your config or cli parameters (check commandline.md for usage):
+4. Enable the whitelist files in your config or cli parameters (check commandline.md for usage):
    ```
    --iv-whitelist-file iv-whitelist.txt --cp-whitelist-file cp-whitelist.txt
    ```
-4. Optionally set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
+5. Optionally set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
    ```
    --hlvl-kph 25
    ```

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -4,11 +4,15 @@ Since the IV update of April 21st which makes IVs the same for players of level 
 
 Steps for using the new encounter system:
 
-1. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
+1. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
    ```
    25,ptc,randOMusername1,P4ssw0rd!
    25,ptc,randOMusername2,P4ssw0rd!
    30,ptc,randOMusername1,P4ssw0rd!
+   ```
+   The config item or parameter to use this separate account file is:
+   ```
+   --high-lvl-accounts high-level.csv
    ```
 2. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
    iv-whitelist.txt:

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -6,7 +6,7 @@ Steps for using the new encounter system:
 
 1. Make sure initial scan has finished. Enabling encounters during initial scan is a waste of requests.
 2. Enable encounters on your map (`-enc`).
-3. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
+3. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). **Warning: read the important points below if you're scanning with only L30s!** The lines should be formatted as "25 or 30,service,user,pass":
    ```
    25,ptc,randOMusername1,P4ssw0rd!
    25,ptc,randOMusername2,P4ssw0rd!
@@ -43,6 +43,7 @@ L25/L30 accounts are not being recycled and are not in the usual account flow. T
 
 Some important notes:
 
+ * If you're only scanning with high level accounts (i.e. your regular accounts file only has L30s), the `--high-lvl-accounts` file can stay empty. The encounter code will use your regular accounts to encounter Pokémon if they're high enough level. But don't mix low level accounts with high levels, otherwise encounters will be skipped.
  * To report Unown form, Unown's Pokémon ID must be added to the IV or CP whitelist.
  * The old encounter whitelists/blacklists have been removed entirely.
  * Both the IV and CP whitelists are optional.

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -6,33 +6,27 @@ Steps for using the new encounter system:
 
 1. Make sure initial scan has finished. Enabling encounters during initial scan is a waste of requests.
 2. Enable encounters on your map (`-enc`).
-3. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). **Warning: read the important points below if you're scanning with only L30s!** The lines should be formatted as "25 or 30,service,user,pass":
+3. Add L30 accounts for IV/CP scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). **Warning: read the important points below if you're scanning with only L30s!** The lines should be formatted as "service,user,pass":
    ```
-   25,ptc,randOMusername1,P4ssw0rd!
-   25,ptc,randOMusername2,P4ssw0rd!
-   30,ptc,randOMusername1,P4ssw0rd!
+   ptc,randOMusername1,P4ssw0rd!
+   ptc,randOMusername2,P4ssw0rd!
+   ptc,randOMusername1,P4ssw0rd!
    ```
    The config item or parameter to use this separate account file is:
    ```
    --high-lvl-accounts high-level.csv
    ```
-4. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
-   iv-whitelist.txt:
+4. Create files for your IV/CP encounter whitelist and add the Pokémon IDs which you want to encounter, one per line.
+   enc-whitelist.txt:
    ```
    10
    25
    38
    168
    ```
-   cp-whitelist.txt:
-   ```
-   35
-   66
-   89
-   ```
 5. Enable the whitelist files in your config or cli parameters (check commandline.md for usage):
    ```
-   --iv-whitelist-file iv-whitelist.txt --cp-whitelist-file cp-whitelist.txt
+   --enc-whitelist-file enc-whitelist.txt
    ```
 6. (Optional) Set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
    ```
@@ -43,7 +37,7 @@ Steps for using the new encounter system:
    --no-api-store
    ```
 
-L25/L30 accounts are not being recycled and are not in the usual account flow. This is intentional, to allow for future reworks to handle accounts properly. This also keeps interaction with high level accounts to a minimum. We can consider handling them more automatically when the account handlers are properly fully implemented.
+L30 accounts are not being recycled and are not in the usual account flow. This is intentional, to allow for future reworks to handle accounts properly. This also keeps interaction with high level accounts to a minimum. We can consider handling them more automatically when the account handlers are properly fully implemented.
 
 Some important notes:
 
@@ -51,7 +45,6 @@ Some important notes:
  * To report Unown form, Unown's Pokémon ID must be added to the IV or CP whitelist.
  * The old encounter whitelists/blacklists have been removed entirely.
  * Both the IV and CP whitelists are optional.
- * When no L25 accounts are available but IV encounters are enabled, it will try to get a L30 account instead for the encounter.
- * Captcha'd L25/L30 accounts will be logged in console and disabled in the scheduler. Having `-v` enabled will show you an entry in the logs mentioning "High level account x encountered a captcha". They will not be solved automatically.
+ * Captcha'd L30 accounts will be logged in console and disabled in the scheduler. Having `-v` enabled will show you an entry in the logs mentioning "High level account x encountered a captcha". They will not be solved automatically.
  * The encounter is a single request (1 RPM). We intentionally don't use the account for anything else besides the encounter.
  * The high level account properly uses a proxy if one is set for the scan, and properly rotates hashing keys when needed.

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -1,6 +1,6 @@
 # Pokémon Encounters
 
-Since the IV update of April 21st which makes IVs the same for players of level 25 and above, the encounter system has been reworked and now includes CP/IV scanning.
+Since the IV update of April 21st 2017 which makes IVs the same for players of level 25 and above, the encounter system has been reworked and now includes CP/IV scanning.
 
 Steps for using the new encounter system:
 
@@ -34,9 +34,13 @@ Steps for using the new encounter system:
    ```
    --iv-whitelist-file iv-whitelist.txt --cp-whitelist-file cp-whitelist.txt
    ```
-6. Optionally set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
+6. (Optional) Set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
    ```
    --hlvl-kph 25
+   ```
+7. (Optional) To reduce the number of times a high level account will log into the game via the API, the API objects are stored in memory to re-use them rather than recreating them. This is enabled by default to keep high level accounts *safer* but it will cause an increase in memory usage. To reduce memory usage, disable the feature with:
+   ```
+   --no-api-store
    ```
 
 L25/L30 accounts are not being recycled and are not in the usual account flow. This is intentional, to allow for future reworks to handle accounts properly. This also keeps interaction with high level accounts to a minimum. We can consider handling them more automatically when the account handlers are properly fully implemented.

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -40,5 +40,6 @@ Some important notes:
  * The old encounter whitelists/blacklists have been removed entirely.
  * Both the IV and CP whitelists are optional.
  * When no L25 accounts are available but IV encounters are enabled, it will try to get a L30 account instead for the encounter.
- * Captcha'd L25/L30 accounts will be logged and disabled in the scheduler. Having `-v` enabled will show you an entry in the logs mentioning "High level account x encountered a captcha". They will not be solved automatically.
+ * Captcha'd L25/L30 accounts will be logged in console and disabled in the scheduler. Having `-v` enabled will show you an entry in the logs mentioning "High level account x encountered a captcha". They will not be solved automatically.
  * The encounter is a single request (1 RPM). We intentionally don't use the account for anything else besides the encounter.
+ * The high level account properly uses a proxy if one is set for the scan, and properly rotates hashing keys when needed.

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -4,8 +4,9 @@ Since the IV update of April 21st which makes IVs the same for players of level 
 
 Steps for using the new encounter system:
 
-1. Enabled encounters on your map (`-enc`).
-2. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
+1. Make sure initial scan has finished. Enabling encounters during initial scan is a waste of requests.
+2. Enable encounters on your map (`-enc`).
+3. Add L25 (and optionally L30) accounts for IV scanning into a CSV file (separate from your regular accounts file, e.g. 'high-level.csv'). The lines should be formatted as "25 or 30,service,user,pass":
    ```
    25,ptc,randOMusername1,P4ssw0rd!
    25,ptc,randOMusername2,P4ssw0rd!
@@ -15,7 +16,7 @@ Steps for using the new encounter system:
    ```
    --high-lvl-accounts high-level.csv
    ```
-3. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
+4. Create files for your IV and CP encounter whitelists and add the Pokémon IDs which you want to encounter, one per line.
    iv-whitelist.txt:
    ```
    10
@@ -29,11 +30,11 @@ Steps for using the new encounter system:
    66
    89
    ```
-4. Enable the whitelist files in your config or cli parameters (check commandline.md for usage):
+5. Enable the whitelist files in your config or cli parameters (check commandline.md for usage):
    ```
    --iv-whitelist-file iv-whitelist.txt --cp-whitelist-file cp-whitelist.txt
    ```
-5. Optionally set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
+6. Optionally set a speed limit for your high level accounts. This is separate from the usual speed limit, to allow a lower speed to keep high level accounts safer:
    ```
    --hlvl-kph 25
    ```
@@ -42,6 +43,7 @@ L25/L30 accounts are not being recycled and are not in the usual account flow. T
 
 Some important notes:
 
+ * To report Unown form, Unown's Pokémon ID must be added to the IV or CP whitelist.
  * The old encounter whitelists/blacklists have been removed entirely.
  * Both the IV and CP whitelists are optional.
  * When no L25 accounts are available but IV encounters are enabled, it will try to get a L30 account instead for the encounter.

--- a/docs/extras/encounters.md
+++ b/docs/extras/encounters.md
@@ -24,7 +24,7 @@ Steps for using the new encounter system:
    66
    89
    ```
-3. Enabled the whitelist files in your config or cli parameters (check commandline.md for usage):
+3. Enable the whitelist files in your config or cli parameters (check commandline.md for usage):
    ```
    --iv-whitelist-file iv-whitelist.txt --cp-whitelist-file cp-whitelist.txt
    ```

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -389,7 +389,7 @@ class AccountSet(object):
                 last_scanned = account.get('last_scanned', False)
 
                 if last_scanned:
-                    seconds_passed = last_scanned - now
+                    seconds_passed = now - last_scanned
                     old_coords = account.get('last_coords', coords_to_scan)
 
                     distance_km = equi_rect_distance(

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -4,10 +4,15 @@
 import logging
 import time
 import random
+from threading import Lock
+from timeit import default_timer
 
+from pgoapi import PGoApi
 from pgoapi.exceptions import AuthException
 
-from .utils import in_radius
+from .fakePogoApi import FakePogoApi
+from .utils import in_radius, generate_device_info, equi_rect_distance
+from .proxy import get_new_proxy
 
 log = logging.getLogger(__name__)
 
@@ -16,6 +21,39 @@ class TooManyLoginAttempts(Exception):
     pass
 
 
+# Create the API object that'll be used to scan.
+def setup_api(args, status):
+    # Create the API instance this will use.
+    if args.mock != '':
+        api = FakePogoApi(args.mock)
+    else:
+        device_info = generate_device_info()
+        api = PGoApi(device_info=device_info)
+
+    # New account - new proxy.
+    if args.proxy:
+        # If proxy is not assigned yet or if proxy-rotation is defined
+        # - query for new proxy.
+        if ((not status['proxy_url']) or
+                ((args.proxy_rotation is not None) and
+                 (args.proxy_rotation != 'none'))):
+
+            proxy_num, status['proxy_url'] = get_new_proxy(args)
+            if args.proxy_display.upper() != 'FULL':
+                status['proxy_display'] = proxy_num
+            else:
+                status['proxy_display'] = status['proxy_url']
+
+    if status['proxy_url']:
+        log.debug('Using proxy %s', status['proxy_url'])
+        api.set_proxy({
+            'http': status['proxy_url'],
+            'https': status['proxy_url']})
+
+    return api
+
+
+# Use API to check the login status, and retry the login if possible.
 def check_login(args, account, api, position, proxy_url):
 
     # Logged in? Enough time left? Cool!
@@ -303,4 +341,77 @@ def spin_pokestop_request(api, fort, step_location):
 
     except Exception as e:
         log.warning('Exception while spinning Pokestop: %s', repr(e))
+        return False
+
+
+# The AccountSet returns a scheduler that cycles through different
+# sets of accounts (e.g. L25/L30). Each set is defined at runtime, and is
+# (currently) used to separate regular accounts from L25/L30 accounts.
+# TODO: Migrate the old account Queue to a real AccountScheduler, preferably
+# handled globally via database instead of per instance.
+# TODO: Accounts in the AccountSet are exempt from things like the
+# account recycler thread. We could've hardcoded support into it, but that
+# would have added to the amount of ugly code. Instead, we keep it as is
+# until we have a proper account manager.
+class AccountSet(object):
+
+    def __init__(self, kph):
+        self.sets = {}
+
+        # Scanning limits.
+        self.kph = kph
+
+        # Thread safety.
+        self.next_lock = Lock()
+
+    # Set manipulation.
+    def create_set(self, name, values=[]):
+        if name in self.sets:
+            raise Exception('Account set ' + name + ' is being created twice.')
+
+        self.sets[name] = values
+
+    # Get next account that is ready to be used for scanning.
+    def next(self, set_name, coords_to_scan):
+        # Yay for thread safety.
+        with self.next_lock:
+            # Readability.
+            account_set = self.sets[set_name]
+
+            # Loop all accounts for a good one.
+            now = default_timer()
+            max_speed_kmph = self.kph
+
+            for i in range(len(account_set)):
+                account = account_set[i]
+
+                # Check if we're below speed limit for account.
+                last_scanned = account.get('last_scanned', False)
+
+                if last_scanned:
+                    seconds_passed = last_scanned - now
+                    old_coords = account.get('last_coords', coords_to_scan)
+
+                    distance_km = equi_rect_distance(
+                        old_coords,
+                        coords_to_scan)
+                    cooldown_time_sec = distance_km / max_speed_kmph
+
+                    # Not enough time has passed for this one.
+                    if seconds_passed < cooldown_time_sec:
+                        continue
+
+                # Make sure it's not captcha'd.
+                if account.get('captcha', False):
+                    continue
+
+                # We've found an account that's ready.
+                account['last_scanned'] = now
+                account['last_coords'] = coords_to_scan
+
+                return account
+
+        # TODO: Instead of returning False, return the amount of min. seconds
+        # the instance needs to wait until the first account becomes available,
+        # so it doesn't need to keep asking if we know we need to wait.
         return False

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -345,8 +345,8 @@ def spin_pokestop_request(api, fort, step_location):
 
 
 # The AccountSet returns a scheduler that cycles through different
-# sets of accounts (e.g. L25/L30). Each set is defined at runtime, and is
-# (currently) used to separate regular accounts from L25/L30 accounts.
+# sets of accounts (e.g. L30). Each set is defined at runtime, and is
+# (currently) used to separate regular accounts from L30 accounts.
 # TODO: Migrate the old account Queue to a real AccountScheduler, preferably
 # handled globally via database instead of per instance.
 # TODO: Accounts in the AccountSet are exempt from things like the

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1951,7 +1951,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
                     # If no 25s are available, fall back to a L30.
                     if not hlvl_account:
-                        hlvl_account = account_sets.next('25', step_location)
+                        hlvl_account = account_sets.next('30', step_location)
 
                 # If we didn't get an account, it means we can't encounter.
                 if hlvl_account:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2820,7 +2820,7 @@ def database_migrate(db, old_ver):
     if old_ver < 18:
         migrate(
             migrator.add_column('pokemon', 'cp',
-                                SmallIntegerField(null=True, default=0))
+                                SmallIntegerField(null=True))
         )
 
     # Always log that we're done.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1945,13 +1945,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
                 # Get account to use for IV or CP scanning.
                 if pokemon_id in args.cp_whitelist:
-                    hlvl_account = account_sets.next('30')
+                    hlvl_account = account_sets.next('30', step_location)
                 elif pokemon_id in args.iv_whitelist:
-                    hlvl_account = account_sets.next('25')
+                    hlvl_account = account_sets.next('25', step_location)
 
                     # If no 25s are available, fall back to a L30.
                     if not hlvl_account:
-                        hlvl_account = account_sets.next('25')
+                        hlvl_account = account_sets.next('25', step_location)
 
                 # If we didn't get an account, it means we can't encounter.
                 if hlvl_account:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -40,7 +40,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 17
+db_schema_version = 18
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -104,6 +104,7 @@ class Pokemon(BaseModel):
     individual_stamina = SmallIntegerField(null=True)
     move_1 = SmallIntegerField(null=True)
     move_2 = SmallIntegerField(null=True)
+    cp = SmallIntegerField(null=True)
     weight = FloatField(null=True)
     height = FloatField(null=True)
     gender = SmallIntegerField(null=True)
@@ -1971,6 +1972,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'individual_stamina': None,
                 'move_1': None,
                 'move_2': None,
+                'cp': None,
                 'height': None,
                 'weight': None,
                 'gender': None,
@@ -1990,6 +1992,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'individual_stamina', 0),
                     'move_1': pokemon_info['move_1'],
                     'move_2': pokemon_info['move_2'],
+                    'cp': pokemon_info['cp'],
                     'height': pokemon_info['height_m'],
                     'weight': pokemon_info['weight_kg'],
                     'gender': pokemon_info['pokemon_display']['gender']
@@ -2756,6 +2759,12 @@ def database_migrate(db, old_ver):
         migrate(
             migrator.add_column('pokemon', 'form',
                                 SmallIntegerField(null=True))
+        )
+
+    if old_ver < 18:
+        migrate(
+            migrator.add_column('pokemon', 'cp',
+                                SmallIntegerField(null=True, default=0))
         )
 
     # Always log that we're done.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2832,7 +2832,7 @@ def database_migrate(db, old_ver):
     if old_ver < 18:
         migrate(
             migrator.add_column('pokemon', 'cp',
-                                SmallIntegerField(null=True, default=0))
+                                SmallIntegerField(null=True))
         )
 
     # Always log that we're done.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1939,8 +1939,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             pokemon_id = p['pokemon_data']['pokemon_id']
             encounter_result = None
 
-            if args.encounter and (pokemon_id in args.iv_whitelist or
-                                   pokemon_id in args.cp_whitelist):
+            if args.encounter and (pokemon_id in args.enc_whitelist):
                 time.sleep(args.encounter_delay)
 
                 hlvl_account = None
@@ -1954,22 +1953,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     hlvl_api = api
                 else:
                     # Get account to use for IV or CP scanning.
-                    if pokemon_id in args.cp_whitelist:
+                    if pokemon_id in args.enc_whitelist:
                         hlvl_account = account_sets.next('30', step_location)
-                    elif pokemon_id in args.iv_whitelist:
-                        # Or if the host has L25s in the regular pool, we can
-                        # use them here.
-                        if level >= 25:
-                            hlvl_account = account
-                            hlvl_api = api
-                        else:
-                            hlvl_account = account_sets.next(
-                                '25', step_location)
-
-                        # If no 25s are available, fall back to a L30.
-                        if not hlvl_account:
-                            hlvl_account = account_sets.next(
-                                '30', step_location)
 
                 # If we don't have an API object yet, it means we didn't re-use
                 # an old one, so we're using AccountSet.
@@ -2048,8 +2033,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         encounter_level = get_player_level(encounter_result)
 
                         # User error?
-                        if encounter_level < 25:
-                            raise Exception('Expected account of level 25 or'
+                        if encounter_level < 30:
+                            raise Exception('Expected account of level 30 or'
                                             + ' higher, but account '
                                             + hlvl_account['username']
                                             + ' is only level '
@@ -2063,7 +2048,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     # Clear the response for memory management.
                     encounter_result = clear_dict_response(encounter_result)
                 else:
-                    log.error('No L25 or L30 accounts are available, please'
+                    log.error('No L30 accounts are available, please'
                               + ' consider adding more. Skipping encounter.')
 
             pokemon[p['encounter_id']] = {

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1789,7 +1789,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     # Get the level for the pokestop spin, and to send to webhook.
     level = get_player_level(map_dict)
-    # Use separate level indicator for our L25/L30 encounters.
+    # Use separate level indicator for our L30 encounters.
     encounter_level = level
 
     # Helping out the GC.

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -577,12 +577,12 @@ class SpeedScan(HexSearch):
                 # the current ring (90,150,210,270,330 and 30 degrees from
                 # origin) to form a star
                 star_loc = get_new_coords(self.scan_location, xdist * ring,
-                                          90 + 60*i)
+                                          90 + 60 * i)
                 for j in range(0, ring):
                     # Then from each point on the star, create locations
                     # towards the next point of star along the edge of the
                     # current ring
-                    loc = get_new_coords(star_loc, xdist * (j), 210 + 60*i)
+                    loc = get_new_coords(star_loc, xdist * (j), 210 + 60 * i)
                     results.append((loc[0], loc[1], 0))
 
         generated_locations = []

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -368,8 +368,8 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     Create sets of special case accounts. Currently limited to L25+ IV and
     L30+ CP scanning.
     '''
-    account_sets.create_set('L25', args.accounts_L25)
-    account_sets.create_set('L30', args.accounts_L30)
+    account_sets.create_set('25', args.accounts_L25)
+    account_sets.create_set('30', args.accounts_L30)
 
     # Create a list for failed accounts.
     account_failures = []

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -26,6 +26,8 @@ import random
 import time
 import copy
 import requests
+import schedulers
+import terminalsize
 
 from datetime import datetime
 from threading import Thread, Lock
@@ -35,22 +37,17 @@ from collections import deque
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-from pgoapi import PGoApi
 from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.hash_server import HashServer
 
 from .models import parse_map, GymDetails, parse_gyms, MainWorker, WorkerStatus
-from .fakePogoApi import FakePogoApi
-from .utils import now, generate_device_info, clear_dict_response
+from .utils import now, clear_dict_response
 from .transform import get_new_coords, jitter_location
-from .account import check_login, get_tutorial_state, complete_tutorial
+from .account import (setup_api, check_login, get_tutorial_state,
+                      complete_tutorial, AccountSet)
 from .captcha import captcha_overseer_thread, handle_captcha
-
 from .proxy import get_new_proxy
-
-import schedulers
-import terminalsize
 
 log = logging.getLogger(__name__)
 
@@ -351,6 +348,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     search_items_queue_array = []
     scheduler_array = []
     account_queue = Queue()
+    account_sets = AccountSet(args.hlvl_kph)
     threadStatus = {}
     key_scheduler = None
     api_version = '0.61.0'
@@ -365,6 +363,13 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     '''
     for i, account in enumerate(args.accounts):
         account_queue.put(account)
+
+    '''
+    Create sets of special case accounts. Currently limited to L25+ IV and
+    L30+ CP scanning.
+    '''
+    account_sets.create_set('L25', args.accounts_L25)
+    account_sets.create_set('L30', args.accounts_L30)
 
     # Create a list for failed accounts.
     account_failures = []
@@ -463,7 +468,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
 
         t = Thread(target=search_worker_thread,
                    name='search-worker-{}'.format(i),
-                   args=(args, account_queue, account_failures,
+                   args=(args, account_queue, account_sets, account_failures,
                          account_captchas, search_items_queue, pause_bit,
                          threadStatus[workerId], db_updates_queue,
                          wh_queue, scheduler, key_scheduler))
@@ -729,7 +734,7 @@ def generate_hive_locations(current_location, step_distance,
     return results
 
 
-def search_worker_thread(args, account_queue, account_failures,
+def search_worker_thread(args, account_queue, account_sets, account_failures,
                          account_captchas, search_items_queue, pause_bit,
                          status, dbq, whq, scheduler, key_scheduler):
 
@@ -741,7 +746,7 @@ def search_worker_thread(args, account_queue, account_failures,
     # This reinitializes the API and grabs a new account from the queue.
     while True:
         try:
-            # Force storing of previous worker info to keep consistency
+            # Force storing of previous worker info to keep consistency.
             if 'starttime' in status:
                 dbq.put((WorkerStatus, {0: WorkerStatus.db_format(status)}))
 
@@ -750,12 +755,12 @@ def search_worker_thread(args, account_queue, account_failures,
             # Track per loop.
             first_login = True
 
-            # Make sure the scheduler is done for valid locations
+            # Make sure the scheduler is done for valid locations.
             while not scheduler.ready:
                 time.sleep(1)
 
-            status['message'] = ('Waiting to get new account from the ' +
-                                 'queue...')
+            status['message'] = ('Waiting to get new account from the'
+                                 + ' queue...')
             log.info(status['message'])
 
             # Get an account.
@@ -783,32 +788,7 @@ def search_worker_thread(args, account_queue, account_failures,
             # for stat purposes.
             consecutive_noitems = 0
 
-            # Create the API instance this will use.
-            if args.mock != '':
-                api = FakePogoApi(args.mock)
-            else:
-                device_info = generate_device_info()
-                api = PGoApi(device_info=device_info)
-
-            # New account - new proxy.
-            if args.proxy:
-                # If proxy is not assigned yet or if proxy-rotation is defined
-                # - query for new proxy.
-                if ((not status['proxy_url']) or
-                        ((args.proxy_rotation is not None) and
-                         (args.proxy_rotation != 'none'))):
-
-                    proxy_num, status['proxy_url'] = get_new_proxy(args)
-                    if args.proxy_display.upper() != 'FULL':
-                        status['proxy_display'] = proxy_num
-                    else:
-                        status['proxy_display'] = status['proxy_url']
-
-            if status['proxy_url']:
-                log.debug('Using proxy %s', status['proxy_url'])
-                api.set_proxy({
-                    'http': status['proxy_url'],
-                    'https': status['proxy_url']})
+            api = setup_api(args, status)
 
             # The forever loop for the searches.
             while True:
@@ -853,7 +833,7 @@ def search_worker_thread(args, account_queue, account_failures,
                 # If used proxy disappears from "live list" after background
                 # checking - switch account but do not freeze it (it's not an
                 # account failure).
-                if (args.proxy) and (not status['proxy_url'] in args.proxy):
+                if args.proxy and status['proxy_url'] not in args.proxy:
                     status['message'] = (
                         'Account {} proxy {} is not in a live list any ' +
                         'more. Switching accounts...').format(
@@ -999,7 +979,8 @@ def search_worker_thread(args, account_queue, account_failures,
                         break
 
                     parsed = parse_map(args, response_dict, step_location,
-                                       dbq, whq, api, scan_date, account)
+                                       dbq, whq, key_scheduler, api, status,
+                                       scan_date, account, account_sets)
                     del response_dict
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -371,6 +371,10 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     account_sets.create_set('25', args.accounts_L25)
     account_sets.create_set('30', args.accounts_L30)
 
+    # Debug.
+    log.info('Added %s accounts to the L25 pool.', args.accounts_L25)
+    log.info('Added %s accounts to the L30 pool.', args.accounts_L30)
+
     # Create a list for failed accounts.
     account_failures = []
     # Create a double-ended queue for captcha'd accounts

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -365,14 +365,12 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         account_queue.put(account)
 
     '''
-    Create sets of special case accounts. Currently limited to L25+ IV and
-    L30+ CP scanning.
+    Create sets of special case accounts.
+    Currently limited to L30+ IV/CP scanning.
     '''
-    account_sets.create_set('25', args.accounts_L25)
     account_sets.create_set('30', args.accounts_L30)
 
     # Debug.
-    log.info('Added %s accounts to the L25 pool.', args.accounts_L25)
     log.info('Added %s accounts to the L30 pool.', args.accounts_L30)
 
     # Create a list for failed accounts.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -647,6 +647,10 @@ def get_args():
             # Context processor.
             with open(args.high_lvl_accounts, 'r') as accs:
                 for line in accs:
+                    # Make sure it's not an empty line.
+                    if not line.strip():
+                        continue
+
                     line = line.split(',')
 
                     # We need "25 or 30, service, user, pass".

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -662,6 +662,7 @@ def get_args():
                     password = line[3].strip()
 
                     hlvl_account = {
+                        'type': set_type,
                         'auth_service': service,
                         'username': username,
                         'password': password,

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -89,7 +89,7 @@ def get_args():
     parser.add_argument('-hlvl', '--high-lvl-accounts',
                         help=('Load high level accounts from CSV file '
                               + ' containing '
-                              + '"25 or 30,auth_service,username,passwd"'
+                              + '"auth_service,username,passwd"'
                               + ' lines.'))
     parser.add_argument('-bh', '--beehive',
                         help=('Use beehive configuration for multiple ' +
@@ -160,14 +160,10 @@ def get_args():
                         help=('Time delay between encounter pokemon ' +
                               'in scan threads.'),
                         type=float, default=1)
-    parser.add_argument('-ivwf', '--iv-whitelist-file',
+    parser.add_argument('-encwf', '--enc-whitelist-file',
                         default='', help='File containing a list of '
                         'Pokemon IDs to encounter for'
-                        ' IV scanning.')
-    parser.add_argument('-cpwf', '--cp-whitelist-file',
-                        default='', help='File containing a list of '
-                        'Pokemon IDs to encounter for'
-                        ' CP scanning.')
+                        ' IV/CP scanning.')
     parser.add_argument('-nostore', '--no-api-store',
                         help=("Don't store the API objects used by the high"
                               + ' level accounts in memory. This will increase'
@@ -304,7 +300,7 @@ def get_args():
                         type=int, default=35)
     parser.add_argument('-hkph', '--hlvl-kph',
                         help=('Set a maximum speed in km/hour for scanner ' +
-                              'movement, for high-level (L25/L30) accounts.'),
+                              'movement, for high-level (L30) accounts.'),
                         type=int, default=25)
     parser.add_argument('-ldur', '--lure-duration',
                         help=('Change duration for lures set on pokestops. ' +
@@ -645,8 +641,7 @@ def get_args():
                                   'password': args.password[i],
                                   'auth_service': args.auth_service[i]})
 
-        # Prepare the L25/L30 accounts for the account sets.
-        args.accounts_L25 = []
+        # Prepare the L30 accounts for the account sets.
         args.accounts_L30 = []
 
         if args.high_lvl_accounts:
@@ -659,50 +654,33 @@ def get_args():
 
                     line = line.split(',')
 
-                    # We need "25 or 30, service, user, pass".
-                    if len(line) < 4:
-                        raise Exception('L25/L30 account is missing a'
+                    # We need "service, user, pass".
+                    if len(line) < 3:
+                        raise Exception('L30 account is missing a'
                                         + ' field. Each line requires: '
-                                        + '"25 or 30,service,user,pass".')
+                                        + '"service,user,pass".')
 
                     # Let's remove trailing whitespace.
-                    set_type = line[0].strip()
-                    service = line[1].strip()
-                    username = line[2].strip()
-                    password = line[3].strip()
+                    service = line[0].strip()
+                    username = line[1].strip()
+                    password = line[2].strip()
 
                     hlvl_account = {
-                        'type': set_type,
                         'auth_service': service,
                         'username': username,
                         'password': password,
                         'captcha': False
                     }
 
-                    if set_type == '25':
-                        args.accounts_L25.append(hlvl_account)
-                    elif set_type == '30':
-                        args.accounts_L30.append(hlvl_account)
-                    else:
-                        raise Exception('Tried adding high level account '
-                                        + username
-                                        + ' to set of unknown type: "'
-                                        + set_type
-                                        + '". Type must be 25 or 30.')
+                    args.accounts_L30.append(hlvl_account)
 
         # Prepare the IV/CP scanning filters.
-        args.iv_whitelist = []
-        args.cp_whitelist = []
+        args.enc_whitelist = []
 
-        # IV scanning.
-        if args.iv_whitelist_file:
-            with open(args.iv_whitelist_file) as f:
-                args.iv_whitelist = frozenset([int(l.strip()) for l in f])
-
-        # CP scanning.
-        if args.cp_whitelist_file:
-            with open(args.cp_whitelist_file) as f:
-                args.cp_whitelist = frozenset([int(l.strip()) for l in f])
+        # IV/CP scanning.
+        if args.enc_whitelist_file:
+            with open(args.enc_whitelist_file) as f:
+                args.enc_whitelist = frozenset([int(l.strip()) for l in f])
 
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -691,12 +691,12 @@ def get_args():
         # IV scanning.
         if args.iv_whitelist_file:
             with open(args.iv_whitelist_file) as f:
-                args.iv_whitelist = [int(l.strip()) for l in f]
+                args.iv_whitelist = frozenset([int(l.strip()) for l in f])
 
         # CP scanning.
         if args.cp_whitelist_file:
             with open(args.cp_whitelist_file) as f:
-                args.cp_whitelist = [int(l.strip()) for l in f]
+                args.cp_whitelist = frozenset([int(l.strip()) for l in f])
 
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -86,6 +86,11 @@ def get_args():
     parser.add_argument('-ac', '--accountcsv',
                         help=('Load accounts from CSV file containing ' +
                               '"auth_service,username,passwd" lines.'))
+    parser.add_argument('-hlvl', '--high-lvl-accounts',
+                        help=('Load high level accounts from CSV file '
+                              + ' containing '
+                              + '"25 or 30,auth_service,username,passwd"'
+                              + ' lines.'))
     parser.add_argument('-bh', '--beehive',
                         help=('Use beehive configuration for multiple ' +
                               'accounts, one account per hex.  Make sure ' +
@@ -155,23 +160,14 @@ def get_args():
                         help=('Time delay between encounter pokemon ' +
                               'in scan threads.'),
                         type=float, default=1)
-    encounter_list = parser.add_mutually_exclusive_group()
-    encounter_list.add_argument('-ewht', '--encounter-whitelist',
-                                action='append', default=[],
-                                help=('List of Pokemon to encounter for ' +
-                                      'more stats.'))
-    encounter_list.add_argument('-eblk', '--encounter-blacklist',
-                                action='append', default=[],
-                                help=('List of Pokemon to NOT encounter for ' +
-                                      'more stats.'))
-    encounter_list.add_argument('-ewhtf', '--encounter-whitelist-file',
-                                default='', help='File containing a list of '
-                                                 'Pokemon to encounter for'
-                                                 ' more stats.')
-    encounter_list.add_argument('-eblkf', '--encounter-blacklist-file',
-                                default='', help='File containing a list of '
-                                                 'Pokemon to NOT encounter for'
-                                                 ' more stats.')
+    parser.add_argument('-ivwf', '--iv-whitelist-file',
+                        default='', help='File containing a list of '
+                        'Pokemon IDs to encounter for'
+                        ' IV scanning.')
+    parser.add_argument('-cpwf', '--cp-whitelist-file',
+                        default='', help='File containing a list of '
+                        'Pokemon IDs to encounter for'
+                        ' CP scanning.')
     webhook_list = parser.add_mutually_exclusive_group()
     webhook_list.add_argument('-wwht', '--webhook-whitelist',
                               action='append', default=[],
@@ -300,6 +296,10 @@ def get_args():
                         help=('Set a maximum speed in km/hour for scanner ' +
                               'movement.'),
                         type=int, default=35)
+    parser.add_argument('-hkph', '--hlvl-kph',
+                        help=('Set a maximum speed in km/hour for scanner ' +
+                              'movement, for high-level (L25/L30) accounts.'),
+                        type=int, default=25)
     parser.add_argument('-ldur', '--lure-duration',
                         help=('Change duration for lures set on pokestops. ' +
                               'This is useful for events that extend lure ' +
@@ -639,6 +639,60 @@ def get_args():
                                   'password': args.password[i],
                                   'auth_service': args.auth_service[i]})
 
+        # Prepare the L25/L30 accounts for the account sets.
+        args.accounts_L25 = []
+        args.accounts_L30 = []
+
+        if args.high_lvl_accounts:
+            # Context processor.
+            with open(args.high_lvl_accounts, 'r') as accs:
+                for line in accs:
+                    line = line.split(',')
+
+                    # We need "25 or 30, service, user, pass".
+                    if len(line) < 4:
+                        raise Exception('L25/L30 account is missing a'
+                                        + ' field. Each line requires: '
+                                        + '"25 or 30,service,user,pass".')
+
+                    # Let's remove trailing whitespace.
+                    set_type = line[0].strip()
+                    service = line[1].strip()
+                    username = line[2].strip()
+                    password = line[3].strip()
+
+                    hlvl_account = {
+                        'auth_service': service,
+                        'username': username,
+                        'password': password,
+                        'captcha': False
+                    }
+
+                    if set_type == '25':
+                        args.accounts_L25.append(hlvl_account)
+                    elif set_type == '30':
+                        args.accounts_L30.append(hlvl_account)
+                    else:
+                        raise Exception('Tried adding high level account '
+                                        + username
+                                        + ' to set of unknown type: "'
+                                        + set_type
+                                        + '". Type must be 25 or 30.')
+
+        # Prepare the IV/CP scanning filters.
+        args.iv_whitelist = []
+        args.cp_whitelist = []
+
+        # IV scanning.
+        if args.iv_whitelist_file:
+            with open(args.iv_whitelist_file) as f:
+                args.iv_whitelist = [int(l.strip()) for l in f]
+
+        # CP scanning.
+        if args.cp_whitelist_file:
+            with open(args.cp_whitelist_file) as f:
+                args.cp_whitelist = [int(l.strip()) for l in f]
+
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.
         if args.workers is None:
@@ -656,20 +710,6 @@ def get_args():
                   ": Error: no accounts specified. Use -a, -u, and -p or " +
                   "--accountcsv to add accounts.")
             sys.exit(1)
-
-        if args.encounter_whitelist_file:
-            with open(args.encounter_whitelist_file) as f:
-                args.encounter_whitelist = [get_pokemon_id(name) for name in
-                                            f.read().splitlines()]
-        elif args.encounter_blacklist_file:
-            with open(args.encounter_blacklist_file) as f:
-                args.encounter_blacklist = [get_pokemon_id(name) for name in
-                                            f.read().splitlines()]
-        else:
-            args.encounter_blacklist = [int(i) for i in
-                                        args.encounter_blacklist]
-            args.encounter_whitelist = [int(i) for i in
-                                        args.encounter_whitelist]
 
         if args.webhook_whitelist_file:
             with open(args.webhook_whitelist_file) as f:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -168,6 +168,12 @@ def get_args():
                         default='', help='File containing a list of '
                         'Pokemon IDs to encounter for'
                         ' CP scanning.')
+    parser.add_argument('-nostore', '--no-api-store',
+                        help=("Don't store the API objects used by the high"
+                              + ' level accounts in memory. This will increase'
+                              + ' the number of logins per account, but '
+                              + ' decreases memory usage.'),
+                        action='store_true', default=False)
     webhook_list = parser.add_mutually_exclusive_group()
     webhook_list.add_argument('-wwht', '--webhook-whitelist',
                               action='append', default=[],

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -188,7 +188,7 @@ def __get_key_fields(whtype):
         'pokemon': ['spawnpoint_id', 'pokemon_id', 'latitude', 'longitude',
                     'disappear_time', 'move_1', 'move_2',
                     'individual_stamina', 'individual_defense',
-                    'individual_attack', 'form'],
+                    'individual_attack', 'form', 'cp'],
         'gym': ['team_id', 'guard_pokemon_id',
                 'gym_points', 'enabled', 'latitude', 'longitude'],
         'gym_details': ['latitude', 'longitude', 'team', 'pokemon']

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -423,6 +423,7 @@ function pokemonLabel(item) {
     var height = item['height']
     var gender = item['gender']
     var form = item['form']
+    var cp = item['cp']
 
     $.each(types, function (index, type) {
         typesDisplay += getTypeSpan(type)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -423,7 +423,7 @@ function pokemonLabel(item) {
     var height = item['height']
     var gender = item['gender']
     var form = item['form']
-    var cp = item['cp']
+    var cp = parseInt(item['cp']) || 0
 
     $.each(types, function (index, type) {
         typesDisplay += getTypeSpan(type)
@@ -436,9 +436,17 @@ function pokemonLabel(item) {
             <div>
                 IV: ${iv.toFixed(1)}% (${atk}/${def}/${sta})
             </div>
+            `
+
+        if (cp !== null && cp > 0) {
+            details += `
             <div>
                 CP: ${cp}
             </div>
+            `
+        }
+
+        details += `
             <div>
                 Moves: ${pMove1} / ${pMove2}
             </div>

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -436,6 +436,9 @@ function pokemonLabel(item) {
                 IV: ${iv.toFixed(1)}% (${atk}/${def}/${sta})
             </div>
             <div>
+                CP: ${cp}
+            </div>
+            <div>
                 Moves: ${pMove1} / ${pMove2}
             </div>
             `

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -423,7 +423,7 @@ function pokemonLabel(item) {
     var height = item['height']
     var gender = item['gender']
     var form = item['form']
-    var cp = parseInt(item['cp']) || 0
+    var cp = item['cp']
 
     $.each(types, function (index, type) {
         typesDisplay += getTypeSpan(type)
@@ -438,7 +438,7 @@ function pokemonLabel(item) {
             </div>
             `
 
-        if (cp !== null && cp > 0) {
+        if (cp !== null) {
             details += `
             <div>
                 CP: ${cp}


### PR DESCRIPTION
## Description
**Seb edit:** This PR implements IV & CP scanning with L25/L30 account pools.

**It's important** to read the included new doc, [encounters.md](https://github.com/StevenHickson/RocketMap/blob/83c07d992a600ff20471e0f8cc31644aadf090c5/docs/extras/encounters.md).

## Motivation and Context
**Seb edit:** This allows people to see correct IVs for L25 and above, and correct CP for L30 and above.

## How Has This Been Tested?
Tested on two of my own maps on my computers. It does require -cd as we are adding a new column to the database.

## Screenshots (if appropriate):
![selection_010](https://cloud.githubusercontent.com/assets/3792797/25305730/8c0dd97e-274e-11e7-962e-4f2e10ee55c9.png)


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
