### PR TITLE
Lower default startup verbosity regarding DB table creation

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2492,11 +2492,12 @@ def create_tables(db):
               Token, LocationAltitude]
     for table in tables:
         if not table.table_exists():
-            log.info("Creating table: %s", table.__name__)
+            log.info('Creating table: %s', table.__name__)
+            db.create_tables([table], safe=True)
         else:
-            log.debug("Table already exists: %s", table.__name__)
-        db.create_tables([table], safe=True)
-        db.close()
+            log.debug('Skipping table %s, it already exists.', table.__name__)
+
+    db.close()
 
 
 def drop_tables(db):
@@ -2509,8 +2510,9 @@ def drop_tables(db):
     db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
     for table in tables:
         if table.table_exists():
-            log.info("Dropping table: %s", table.__name__)
+            log.info('Dropping table: %s', table.__name__)
             db.drop_tables([table], safe=True)
+
     db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
     db.close()
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2494,7 +2494,7 @@ def create_tables(db):
         if not table.table_exists():
             log.info("Creating table: %s", table.__name__)
         else:
-            log.debug("Creating table: %s", table.__name__)
+            log.debug("Table already exists: %s", table.__name__)
         db.create_tables([table], safe=True)
         db.close()
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2491,7 +2491,10 @@ def create_tables(db):
               SpawnPoint, ScanSpawnPoint, SpawnpointDetectionData,
               Token, LocationAltitude]
     for table in tables:
-        log.info("Creating table: %s", table.__name__)
+        if not table.table_exists():
+            log.info("Creating table: %s", table.__name__)
+        else:
+            log.debug("Creating table: %s", table.__name__)
         db.create_tables([table], safe=True)
         db.close()
 
@@ -2505,7 +2508,10 @@ def drop_tables(db):
     db.connect()
     db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
     for table in tables:
-        log.info("Dropping table: %s", table.__name__)
+        if table.table_exists():
+            log.info("Dropping table: %s", table.__name__)
+        else:
+            log.debug("Dropping table: %s", table.__name__)
         db.drop_tables([table], safe=True)
     db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
     db.close()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2510,9 +2510,7 @@ def drop_tables(db):
     for table in tables:
         if table.table_exists():
             log.info("Dropping table: %s", table.__name__)
-        else:
-            log.debug("Dropping table: %s", table.__name__)
-        db.drop_tables([table], safe=True)
+            db.drop_tables([table], safe=True)
     db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
     db.close()
 


### PR DESCRIPTION
This PR prevents misleading verbosity of  ``Creating table: XYZ`` for each table, which let's some users think they just overwrote their database or stuff like that. Functionality of the quite new DB verbosity is still maintained for ``-cd`` flag as well as new Databases (referring to #1964).
With the additional ``-v`` flag all the current existing (and some of them misleading) log entries are still present, displaying the actual code work at the DB. Also, a table is only dropped if already there, otherwise pewee spits out a ugly warning (not an error) message.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The PR checks for a already existing or not existing table before outputting a log info for creation or not creation ``table.table_exists()``. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some were annoyed ¯\\__(ツ)_/¯

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My local setup with all kinds of empty/full, deleted Databases or single tables.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Text fix and preventing site-package warning message

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
