### PR TITLE
Separated WH LFU key caches per message type + added gym_details cache + increased WH LFU size.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -385,7 +385,7 @@ def get_args():
                         type=float, default=0.25)
     parser.add_argument('-whlfu', '--wh-lfu-size',
                         help='Webhook LFU cache max size.', type=int,
-                        default=1000)
+                        default=2500)
     parser.add_argument('-whsu', '--webhook-scheduler-updates',
                         help=('Send webhook updates with scheduler status ' +
                               '(use with -wh).'),

--- a/runserver.py
+++ b/runserver.py
@@ -13,7 +13,6 @@ from distutils.version import StrictVersion
 
 from threading import Thread, Event
 from queue import Queue
-from cachetools import LFUCache
 from flask_cors import CORS
 from flask_cache_bust import init_cache_busting
 
@@ -258,12 +257,12 @@ def main():
         t.daemon = True
         t.start()
 
-    # WH updates queue & WH gym/pokéstop unique key LFU cache.
-    # The LFU cache will stop the server from resending the same data an
-    # infinite number of times.
-    # TODO: Rework webhooks entirely so a LFU cache isn't necessary.
+    # WH updates queue & WH unique key LFU caches.
+    # The LFU caches will stop the server from resending the same data an
+    # infinite number of times. The caches will be instantiated in the
+    # webhook's startup code.
     wh_updates_queue = Queue()
-    wh_key_cache = LFUCache(maxsize=args.wh_lfu_size)
+    wh_key_cache = {}
 
     # Thread to process webhook updates.
     for i in range(args.wh_threads):


### PR DESCRIPTION
## Description
Separated WH LFU key caches per message type, added `gym_details` to the key caching and increased the key cache size.

Fixes #1982.

## Motivation and Context

1. Added `gym_details` to webhook caching.
2. Avoids conflicts when multiple message types use the same identifier field (e.g. `gym` and `gym_details` both use the gym's ID).
3. Caches are separated, so the cache size is per type rather than getting filled up with whatever item is most common and not leaving space for the other types.
4. Cache size increased to better handle setups that actually use webhooks. A cache of max. 1k items is too small for practical purposes.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
