### PR TITLE
Move get_args() outside of send_to_webhook call

### DIFF
--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -20,10 +20,10 @@ wh_warning_threshold = 100
 wh_threshold_lifetime = int(5 * (wh_warning_threshold / 100.0))
 wh_lock = threading.Lock()
 
+args = get_args()
+
 
 def send_to_webhook(session, message_type, message):
-    args = get_args()
-
     if not args.webhooks:
         # What are you even doing here...
         log.warning('Called send_to_webhook() without webhooks.')


### PR DESCRIPTION
## Description
send_to_webhook is a frequently used function, and I realized that each call is 
parsing the arguments again.  After reviewing get_args() I couldn't see any reason
it needed to be process for each call.
The only two members of args that are referenced are args.wh_timeout and args.webooks
These two items are generated from config/command line and never change.

So, calling this inside send_to_webhook() doesn't provide the function with any new information that might be needed.

## Motivation and Context
More zooms.

## How Has This Been Tested?
Tested in my local development map environment for a few hours.

## Screenshots (if appropriate):

