### PR TITLE
Lowered Rarity of certain (quite common) Pokemon.

### DIFF
--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -328,7 +328,7 @@
   },
   "26": {
     "name": "Raichu",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Electric",
@@ -1889,7 +1889,7 @@
   },
   "149": {
     "name": "Dragonite",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Dragon",

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -1,7 +1,7 @@
 {
   "1": {
     "name": "Bulbasaur",
-    "rarity": "Uncommon",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Grass",
@@ -16,7 +16,7 @@
   },
   "2": {
     "name": "Ivysaur",
-    "rarity": "Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Grass",
@@ -31,7 +31,7 @@
   },
   "3": {
     "name": "Venusaur",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Grass",
@@ -68,7 +68,7 @@
   },
   "6": {
     "name": "Charizard",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Fire",
@@ -94,7 +94,7 @@
   },
   "8": {
     "name": "Wartortle",
-    "rarity": "Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Water",
@@ -105,7 +105,7 @@
   },
   "9": {
     "name": "Blastoise",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Water",
@@ -127,7 +127,7 @@
   },
   "11": {
     "name": "Metapod",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Bug",
@@ -138,7 +138,7 @@
   },
   "12": {
     "name": "Butterfree",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Bug",
@@ -168,7 +168,7 @@
   },
   "14": {
     "name": "Kakuna",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Bug",
@@ -228,7 +228,7 @@
   },
   "18": {
     "name": "Pidgeot",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Normal",
@@ -254,7 +254,7 @@
   },
   "20": {
     "name": "Raticate",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Normal",
@@ -265,7 +265,7 @@
   },
   "21": {
     "name": "Spearow",
-    "rarity": "Uncommon",
+    "rarity": "Common",
     "types": [
       {
         "type": "Normal",
@@ -306,7 +306,7 @@
   },
   "24": {
     "name": "Arbok",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Poison",
@@ -328,7 +328,7 @@
   },
   "26": {
     "name": "Raichu",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Electric",
@@ -372,7 +372,7 @@
   },
   "30": {
     "name": "Nidorina",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Poison",
@@ -409,7 +409,7 @@
   },
   "33": {
     "name": "Nidorino",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Poison",
@@ -468,7 +468,7 @@
   },
   "38": {
     "name": "Ninetales",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Fire",
@@ -479,7 +479,7 @@
   },
   "39": {
     "name": "Jigglypuff",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Normal",
@@ -494,7 +494,7 @@
   },
   "40": {
     "name": "Wigglytuff",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Normal",
@@ -524,7 +524,7 @@
   },
   "42": {
     "name": "Golbat",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Poison",
@@ -666,7 +666,7 @@
   },
   "52": {
     "name": "Meowth",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Normal",
@@ -688,7 +688,7 @@
   },
   "54": {
     "name": "Psyduck",
-    "rarity": "Rare",
+    "rarity": "Common",
     "types": [
       {
         "type": "Water",
@@ -699,7 +699,7 @@
   },
   "55": {
     "name": "Golduck",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Water",
@@ -732,7 +732,7 @@
   },
   "58": {
     "name": "Growlithe",
-    "rarity": "Uncommon",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Fire",
@@ -776,7 +776,7 @@
   },
   "62": {
     "name": "Poliwrath",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Water",
@@ -898,7 +898,7 @@
   },
   "72": {
     "name": "Tentacool",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Water",
@@ -995,7 +995,7 @@
   },
   "79": {
     "name": "Slowpoke",
-    "rarity": "Rare",
+    "rarity": "Common",
     "types": [
       {
         "type": "Water",
@@ -1040,7 +1040,7 @@
   },
   "82": {
     "name": "Magneton",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Electric",
@@ -1111,7 +1111,7 @@
   },
   "87": {
     "name": "Dewgong",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Water",
@@ -1159,7 +1159,7 @@
   },
   "91": {
     "name": "Cloyster",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Water",
@@ -1204,7 +1204,7 @@
   },
   "94": {
     "name": "Gengar",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Ghost",
@@ -1267,7 +1267,7 @@
   },
   "99": {
     "name": "Kingler",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Water",
@@ -1289,7 +1289,7 @@
   },
   "101": {
     "name": "Electrode",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Electric",
@@ -1363,7 +1363,7 @@
   },
   "107": {
     "name": "Hitmonchan",
-    "rarity": "Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Fighting",
@@ -1437,7 +1437,7 @@
   },
   "113": {
     "name": "Chansey",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Normal",
@@ -1470,7 +1470,7 @@
   },
   "116": {
     "name": "Horsea",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Water",
@@ -1503,7 +1503,7 @@
   },
   "119": {
     "name": "Seaking",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Water",
@@ -1514,7 +1514,7 @@
   },
   "120": {
     "name": "Staryu",
-    "rarity": "Uncommon",
+    "rarity": "Common",
     "types": [
       {
         "type": "Water",
@@ -1525,7 +1525,7 @@
   },
   "121": {
     "name": "Starmie",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Water",
@@ -1540,7 +1540,7 @@
   },
   "122": {
     "name": "Mr. Mime",
-    "rarity": "Very Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Psychic",
@@ -1570,7 +1570,7 @@
   },
   "124": {
     "name": "Jynx",
-    "rarity": "Rare",
+    "rarity": "Uncommon",
     "types": [
       {
         "type": "Ice",
@@ -1607,7 +1607,7 @@
   },
   "127": {
     "name": "Pinsir",
-    "rarity": "Uncommon",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Bug",
@@ -1629,7 +1629,7 @@
   },
   "129": {
     "name": "Magikarp",
-    "rarity": "Uncommon",
+    "rarity": "Common",
     "types": [
       {
         "type": "Water",
@@ -1655,7 +1655,7 @@
   },
   "131": {
     "name": "Lapras",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Water",
@@ -1811,7 +1811,7 @@
   },
   "143": {
     "name": "Snorlax",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Normal",
@@ -1867,7 +1867,7 @@
   },
   "147": {
     "name": "Dratini",
-    "rarity": "Uncommon",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Dragon",
@@ -2579,7 +2579,7 @@
   },
   "203": {
     "name": "Girafarig",
-    "rarity": "Ultra Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Normal",
@@ -2683,7 +2683,7 @@
   },
   "211": {
     "name": "Qwilfish",
-    "rarity": "Very Rare",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Water",
@@ -2713,7 +2713,7 @@
   },
   "213": {
     "name": "Shuckle",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Bug",
@@ -2769,7 +2769,7 @@
   },
   "217": {
     "name": "Ursaring",
-    "rarity": "Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Normal",
@@ -2780,7 +2780,7 @@
   },
   "218": {
     "name": "Slugma",
-    "rarity": "Uncommon",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Fire",
@@ -2821,7 +2821,7 @@
   },
   "221": {
     "name": "Piloswine",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Ice",
@@ -2918,7 +2918,7 @@
   },
   "228": {
     "name": "Houndour",
-    "rarity": "Uncommon",
+    "rarity": "Rare",
     "types": [
       {
         "type": "Dark",
@@ -2948,7 +2948,7 @@
   },
   "230": {
     "name": "Kingdra",
-    "rarity": "Ultra Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Water",
@@ -2963,7 +2963,7 @@
   },
   "231": {
     "name": "Phanpy",
-    "rarity": "Rare",
+    "rarity": "Very Rare",
     "types": [
       {
         "type": "Ground",
@@ -2974,7 +2974,7 @@
   },
   "232": {
     "name": "Donphan",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Ground",
@@ -3132,7 +3132,7 @@
   },
   "246": {
     "name": "Larvitar",
-    "rarity": "Very Rare",
+    "rarity": "Ultra Rare",
     "types": [
       {
         "type": "Rock",


### PR DESCRIPTION
Using notifications such as "ultra rare" triggered too much "not so rare" notifications. On the other hand, some Pokemon are more rare than listed.

## Description
Changed rarity of Pokemon. For example:
Removed Girafarig/Shuckle from Ultra Rare. Added Charizard as Ultra-Rare instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It does not solve any problems. It's more convenient for map users and i'd like to share it.


## How Has This Been Tested?
Modified /static/data/pokemon.json. Linted it. 
Stopped server. 
Ran npm install. 
Start server.
Selected notification for rarity "Ultra Rare" and no more  Shuckles, Girafarigs and Piloswines were jumping on the screen and spammed my notifications. For "Very Rare" it does not count Mr. Mime (which is almost Common, and region-specific, so no nuisance for users from other continents)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Modification of Pokemon classification (non breaking change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
