### PR TITLE
Fix timing in seconds.

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -412,7 +412,7 @@ class AccountSet(object):
                     distance_km = equi_rect_distance(
                         old_coords,
                         coords_to_scan)
-                    cooldown_time_sec = distance_km / max_speed_kmph
+                    cooldown_time_sec = distance_km / max_speed_kmph * 3600
 
                     # Not enough time has passed for this one.
                     if seconds_passed < cooldown_time_sec:


### PR DESCRIPTION
## Description
Fix a timing issue for L30 accounts where idle time was calculated in hours rather than in seconds.

## Motivation and Context
Fixes #2001.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
