### PR TITLE
Encounter code cleanup

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1785,7 +1785,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     sightings = {}
     new_spawn_points = []
     sp_id_list = []
-    captcha_url = ''
 
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
@@ -2158,7 +2157,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                      datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         # Complete tutorial with a Pokestop spin
-        if args.complete_tutorial and not (len(captcha_url) > 1):
+        if args.complete_tutorial:
             if config['parse_pokestops']:
                 tutorial_pokestop_spin(
                     api, level, forts, step_location, account)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2040,7 +2040,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                                                 + ' or higher, but account '
                                                 + hlvl_account['username']
                                                 + ' is only level '
-                                                + encounter_level + '.')
+                                                + str(encounter_level) + '.')
 
                         # We're done with the encounter. If it's from an
                         # AccountSet, release account back to the pool.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2114,7 +2114,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'individual_defense': individual_defense,
                     'individual_stamina': individual_stamina,
                     'cp': cp,
-                    'cp_multiplier'] = pokemon_info.get('cp_multiplier', None)
+                    'cp_multiplier': pokemon_info.get('cp_multiplier', None),
                     'move_1': pokemon_info.get('move_1', None),
                     'move_2': pokemon_info.get('move_2', None),
                     'height': pokemon_info.get('height_m', None),

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2091,7 +2091,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 pokemon_info = encounter_result['responses'][
                     'ENCOUNTER']['wild_pokemon']['pokemon_data']
 
-                # IVs, moves and CP.
+                # IVs and CP.
                 individual_attack = pokemon_info.get('individual_attack', 0)
                 individual_defense = pokemon_info.get('individual_defense', 0)
                 individual_stamina = pokemon_info.get('individual_stamina', 0)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2091,7 +2091,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 pokemon_info = encounter_result['responses'][
                     'ENCOUNTER']['wild_pokemon']['pokemon_data']
 
-                # IVs.
+                # IVs, moves and CP.
                 individual_attack = pokemon_info.get('individual_attack', 0)
                 individual_defense = pokemon_info.get('individual_defense', 0)
                 individual_stamina = pokemon_info.get('individual_stamina', 0)
@@ -2109,22 +2109,18 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                           individual_stamina,
                           cp)
 
+                # Add encounter data to pokemon dict.
                 pokemon[p['encounter_id']].update({
                     'individual_attack': individual_attack,
                     'individual_defense': individual_defense,
                     'individual_stamina': individual_stamina,
-                    'move_1': pokemon_info['move_1'],
-                    'move_2': pokemon_info['move_2'],
-                    'height': pokemon_info['height_m'],
-                    'weight': pokemon_info['weight_kg']
+                    'cp': cp,
+                    'cp_multiplier'] = pokemon_info.get('cp_multiplier', None)
+                    'move_1': pokemon_info.get('move_1', None),
+                    'move_2': pokemon_info.get('move_2', None),
+                    'height': pokemon_info.get('height_m', None),
+                    'weight': pokemon_info.get('weight_kg', None)
                 })
-
-                # Only add CP if we're level 30+.
-                if encounter_level >= 30:
-                    pokemon[p['encounter_id']]['cp'] = cp
-                    pokemon[p['encounter_id']][
-                        'cp_multiplier'] = pokemon_info.get(
-                        'cp_multiplier', None)
 
             if args.webhooks:
                 if (pokemon_id in args.webhook_whitelist or


### PR DESCRIPTION
Remove: `if pokemon_id in args.enc_whitelist:`
- This is checked in line 1942 already.
- https://github.com/RocketMap/RocketMap/blob/develop/pogom/models.py#L1942

Improve pokemon dict update
- remove unnecessary check for lvl 30 (exception is thrown if player_lvl < 30 in encounter code already)
  - https://github.com/RocketMap/RocketMap/blob/develop/pogom/models.py#L2037
- use safer dict .get() methods

Fix exception

Remove "unused" captcha_url
- captcha_url is used in encounter code only.
- captcha_url isn't set outside of encounter code so this check in line 2155 is wrong.
- It's only > 1 if a lvl 30 acc triggered a captcha.

## Motivation
over 9000

## How Has This Been Tested?
my map

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.