### PR TITLE
Added IV/CP/Level/Moves/etc. scouting via PGScout

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -10,7 +10,9 @@ from flask.json import JSONEncoder
 from flask_compress import Compress
 from datetime import datetime
 from s2sphere import LatLng
-from pogom.utils import get_args
+
+from pogom.pgscout import scout_error, pgscout_encounter
+from pogom.utils import get_args, get_pokemon_name
 from datetime import timedelta
 from collections import OrderedDict
 from bisect import bisect_left
@@ -64,6 +66,59 @@ class Pogom(Flask):
         self.route("/submit_token", methods=['POST'])(self.submit_token)
         self.route("/get_stats", methods=['GET'])(self.get_account_stats)
         self.route("/robots.txt", methods=['GET'])(self.render_robots_txt)
+        self.route("/scout", methods=['GET'])(self.scout_pokemon)
+
+    def scout_pokemon(self):
+        args = get_args()
+        if args.pgscout_url:
+            encounterId = request.args.get('encounter_id')
+            p = Pokemon.get(Pokemon.encounter_id == encounterId)
+            pokemon_name = get_pokemon_name(p.pokemon_id)
+            log.info(
+                "On demand PGScouting a {} at {}, {}.".format(pokemon_name,
+                                                              p.latitude,
+                                                              p.longitude))
+            scout_result = pgscout_encounter(p)
+            if scout_result['success']:
+                self.update_scouted_pokemon(p, scout_result)
+                log.info(
+                    "Successfully PGScouted a {:.1f}% lvl {} {} with {} CP ("
+                    "scout level {}).".format(
+                        scout_result['iv_percent'], scout_result['level'],
+                        pokemon_name, scout_result['cp'],
+                        scout_result['scout_level']))
+        else:
+            scout_result = scout_error("PGScout URL not configured.")
+        return jsonify(scout_result)
+
+    def update_scouted_pokemon(self, p, response):
+        # Update database
+        update_data = {
+            p.encounter_id: {
+                'encounter_id': p.encounter_id,
+                'spawnpoint_id': p.spawnpoint_id,
+                'pokemon_id': p.pokemon_id,
+                'latitude': p.latitude,
+                'longitude': p.longitude,
+                'disappear_time': p.disappear_time,
+                'individual_attack': response['iv_attack'],
+                'individual_defense': response['iv_defense'],
+                'individual_stamina': response['iv_stamina'],
+                'move_1': response['move_1'],
+                'move_2': response['move_2'],
+                'height': response['height'],
+                'weight': response['weight'],
+                'gender': response['gender'],
+                'cp': response['cp'],
+                'level': response['level'],
+                'catch_prob_1': response['catch_prob_1'],
+                'catch_prob_2': response['catch_prob_2'],
+                'catch_prob_3': response['catch_prob_3'],
+                'rating_attack': response['rating_attack'],
+                'rating_defense': response['rating_defense']
+            }
+        }
+        self.db_updates_queue.put((Pokemon, update_data))
 
     def render_robots_txt(self):
         return render_template('robots.txt')
@@ -117,6 +172,9 @@ class Pogom(Flask):
         end = dottedQuadToNum(ip_range[1])
 
         return start <= dottedQuadToNum(ip) <= end
+
+    def set_db_updates_queue(self, db_updates_queue):
+        self.db_updates_queue = db_updates_queue
 
     def set_search_control(self, control):
         self.search_control = control

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -26,6 +26,7 @@ from cachetools import TTLCache
 from cachetools import cached
 from timeit import default_timer
 
+from pogom.pgscout import pgscout_encounter
 from . import config
 from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, \
     get_args, cellid, in_radius, date_secs, clock_between, secs_between, \
@@ -42,7 +43,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 18
+db_schema_version = 19
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -111,6 +112,12 @@ class Pokemon(BaseModel):
     height = FloatField(null=True)
     gender = SmallIntegerField(null=True)
     form = SmallIntegerField(null=True)
+    level = SmallIntegerField(null=True)
+    catch_prob_1 = DoubleField(null=True)
+    catch_prob_2 = DoubleField(null=True)
+    catch_prob_3 = DoubleField(null=True)
+    rating_attack = CharField(null=True, max_length=1)
+    rating_defense = CharField(null=True, max_length=1)
     last_modified = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
 
@@ -1764,6 +1771,32 @@ def hex_bounds(center, steps=None, radius=None):
     return (n, e, s, w)
 
 
+def perform_pgscout(p):
+    pokemon_id = p['pokemon_data']['pokemon_id']
+    pokemon_name = get_pokemon_name(pokemon_id)
+    log.info("PGScouting a {} at {}, {}.".format(pokemon_name, p['latitude'],
+                                                 p['longitude']))
+
+    # Prepare Pokemon object
+    pkm = Pokemon()
+    pkm.pokemon_id = pokemon_id
+    pkm.encounter_id = b64encode(str(p['encounter_id']))
+    pkm.spawnpoint_id = p['spawn_point_id']
+    pkm.latitude = p['latitude']
+    pkm.longitude = p['longitude']
+    scout_result = pgscout_encounter(pkm)
+    if scout_result['success']:
+        log.info(
+            "Successfully PGScouted a {:.1f}% lvl {} {} with {} CP (scout "
+            "level {}).".format(
+                scout_result['iv_percent'], scout_result['level'],
+                pokemon_name, scout_result['cp'], scout_result['scout_level']))
+    else:
+        log.warning("Failed PGScouting {}: {}".format(pokemon_name,
+                                                      scout_result['error']))
+    return scout_result
+
+
 # todo: this probably shouldn't _really_ be in "models" anymore, but w/e.
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
               key_scheduler, api, status, now_date, account, account_sets):
@@ -1938,8 +1971,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             # Scan for IVs/CP and moves.
             pokemon_id = p['pokemon_data']['pokemon_id']
             encounter_result = None
+            scout_result = None
 
-            if args.encounter and (pokemon_id in args.enc_whitelist):
+            if args.encounter and (
+                    pokemon_id in args.enc_whitelist) and level < 30 and \
+                    args.pgscout_url:
+                    scout_result = perform_pgscout(p)
+            elif args.encounter and (pokemon_id in args.enc_whitelist):
                 time.sleep(args.encounter_delay)
 
                 hlvl_account = None
@@ -2076,7 +2114,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'height': None,
                 'weight': None,
                 'gender': None,
-                'form': None
+                'form': None,
+                'level': None,
+                'catch_prob_1': None,
+                'catch_prob_2': None,
+                'catch_prob_3': None,
+                'rating_attack': None,
+                'rating_defense': None
             }
 
             if (encounter_result is not None and 'wild_pokemon'
@@ -2121,6 +2165,26 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 if pokemon_info['pokemon_id'] == 201:
                     pokemon[p['encounter_id']]['form'] = pokemon_info[
                         'pokemon_display'].get('form', None)
+
+            # Updating Pokemon data from PGScout result
+            if scout_result is not None:
+                pokemon[p['encounter_id']].update({
+                    'individual_attack': scout_result['iv_attack'],
+                    'individual_defense': scout_result['iv_defense'],
+                    'individual_stamina': scout_result['iv_stamina'],
+                    'move_1': scout_result['move_1'],
+                    'move_2': scout_result['move_2'],
+                    'height': scout_result['height'],
+                    'weight': scout_result['weight'],
+                    'gender': scout_result['gender'],
+                    'cp': scout_result['cp'],
+                    'level': scout_result['level'],
+                    'catch_prob_1': scout_result['catch_prob_1'],
+                    'catch_prob_2': scout_result['catch_prob_2'],
+                    'catch_prob_3': scout_result['catch_prob_3'],
+                    'rating_attack': scout_result['rating_attack'],
+                    'rating_defense': scout_result['rating_defense'],
+                })
 
             if args.webhooks:
                 pokemon_id = p['pokemon_data']['pokemon_id']
@@ -2884,6 +2948,22 @@ def database_migrate(db, old_ver):
         migrate(
             migrator.add_column('pokemon', 'cp',
                                 SmallIntegerField(null=True))
+        )
+
+    if old_ver < 19:
+        migrate(
+            migrator.add_column('pokemon', 'level',
+                                SmallIntegerField(null=True)),
+            migrator.add_column('pokemon', 'catch_prob_1',
+                                DoubleField(null=True)),
+            migrator.add_column('pokemon', 'catch_prob_2',
+                                DoubleField(null=True)),
+            migrator.add_column('pokemon', 'catch_prob_3',
+                                DoubleField(null=True)),
+            migrator.add_column('pokemon', 'rating_attack',
+                                CharField(null=True, max_length=1)),
+            migrator.add_column('pokemon', 'rating_defense',
+                                CharField(null=True, max_length=1))
         )
 
     # Always log that we're done.

--- a/pogom/pgscout.py
+++ b/pogom/pgscout.py
@@ -1,0 +1,37 @@
+import logging
+import sys
+
+import requests
+
+from pogom.utils import get_args
+
+log = logging.getLogger(__name__)
+
+
+def scout_error(error_msg):
+    log.error(error_msg)
+    return {
+        "success": False,
+        "error": error_msg
+    }
+
+
+def pgscout_encounter(p):
+    args = get_args()
+
+    # Assemble PGScout request
+    params = {
+        'pokemon_id': p.pokemon_id,
+        'encounter_id': p.encounter_id,
+        'spawn_point_id': p.spawnpoint_id,
+        'latitude': p.latitude,
+        'longitude': p.longitude
+    }
+    try:
+        r = requests.get(args.pgscout_url, params=params)
+    except:
+        return scout_error(
+            "Exception on scout: {}".format(repr(sys.exc_info()[1])))
+
+    return r.json() if r.status_code == 200 else scout_error(
+        "Got error {} from scout service.".format(r.status_code))

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -162,7 +162,7 @@ def get_args():
                         type=float, default=1)
     parser.add_argument('-encwf', '--enc-whitelist-file',
                         default='', help='File containing a list of '
-                        'Pokemon IDs to encounter for'
+                        'Pokemon names to encounter for'
                         ' IV/CP scanning.')
     parser.add_argument('-nostore', '--no-api-store',
                         help=("Don't store the API objects used by the high"
@@ -452,6 +452,8 @@ def get_args():
                                  'specify file to log to.'),
                            nargs='?', const='nofile', default=False,
                            metavar='filename.log')
+    parser.add_argument('-pgsu', '--pgscout-url', default=None,
+                        help='URL to query PGScout for Pokemon IV/CP.')
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()
@@ -680,7 +682,8 @@ def get_args():
         # IV/CP scanning.
         if args.enc_whitelist_file:
             with open(args.enc_whitelist_file) as f:
-                args.enc_whitelist = frozenset([int(l.strip()) for l in f])
+                args.enc_whitelist = frozenset(
+                    [get_pokemon_id(name.strip()) for name in f])
 
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.

--- a/runserver.py
+++ b/runserver.py
@@ -242,6 +242,7 @@ def main():
 
     # DB Updates
     db_updates_queue = Queue()
+    app.set_db_updates_queue(db_updates_queue)
 
     # Thread(s) to process database updates.
     for i in range(args.db_threads):

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -403,6 +403,121 @@ function getDateStr(t) {
     return dateStr
 }
 
+function scout(encounterId) { // eslint-disable-line no-unused-vars
+    var encounterIdLong = atob(encounterId)
+    var infoEl = $('#scoutInfo' + encounterIdLong)
+    var ivEl = $('#pkmIV' + encounterIdLong)
+    var movesEl = $('#pkmMoves' + encounterIdLong)
+    var genderEl = $('#pkmGender' + encounterIdLong)
+    var cpEl = $('#pkmCP' + encounterIdLong)
+    var probsEl = $('#pkmProbs' + encounterIdLong)
+
+    $.ajax({
+        url: 'scout',
+        type: 'GET',
+        data: {
+            'encounter_id': encounterId
+        },
+        dataType: 'json',
+        cache: false,
+        beforeSend: function () {
+            infoEl.text('Scouting, please wait...')
+            infoEl.show()
+        },
+        error: function () {
+            infoEl.text('Error scouting, try again?')
+        },
+        success: function (data, textStatus, jqXHR) {
+            if (data.success) {
+                if (ivEl.length === 0) {
+                    $('#pkmLoc' + encounterIdLong).after(buildIVDiv(encounterIdLong, data.iv_attack, data.iv_defense, data.iv_stamina))
+                    ivEl = $('#pkmIV' + encounterIdLong)
+                }
+                if (cpEl.length === 0) {
+                    ivEl.after(buildCPDiv(encounterIdLong, data.cp, data.level))
+                    cpEl = $('#pkmCP' + encounterIdLong)
+                }
+                if (movesEl.length === 0) {
+                    cpEl.after(buildMovesDiv(encounterIdLong, data.move_1, data.move_2, data.rating_attack, data.rating_defense))
+                    movesEl = $('#pkmMoves' + encounterIdLong)
+                }
+                if (genderEl.length === 0) {
+                    movesEl.after(buildGenderDiv(encounterIdLong, data.weight, data.height, data.gender))
+                    genderEl = $('#pkmGender' + encounterIdLong)
+                }
+                if (probsEl.length === 0) {
+                    genderEl.after(buildProbsDiv(encounterIdLong, data.catch_prob_1, data.catch_prob_2, data.catch_prob_3))
+                }
+                infoEl.hide()
+
+                // update local values
+                var pkm = mapData.pokemons[encounterId]
+                pkm['individual_attack'] = data.iv_attack
+                pkm['individual_defense'] = data.iv_defense
+                pkm['individual_stamina'] = data.iv_stamina
+                pkm['move_1'] = data.move_1
+                pkm['move_2'] = data.move_2
+                pkm['weight'] = data.weight
+                pkm['height'] = data.height
+                pkm['gender'] = data.gender
+                pkm['cp'] = data.cp
+                pkm['level'] = data.level
+                pkm['catch_prob_1'] = data.catch_prob_1
+                pkm['catch_prob_2'] = data.catch_prob_2
+                pkm['catch_prob_3'] = data.catch_prob_3
+                pkm['rating_attack'] = data.rating_attack
+                pkm['rating_defense'] = data.rating_defense
+            } else {
+                infoEl.text(data.error)
+            }
+        }
+    })
+}
+
+function buildIVDiv(encounterIdLong, atk, def, sta) {
+    var iv = getIv(atk, def, sta)
+    return `
+        <div id="pkmIV${encounterIdLong}">
+            IV: <b>${iv.toFixed(1)}%</b> (${atk}/${def}/${sta})
+        </div>
+        `
+}
+
+function buildMovesDiv(encounterIdLong, pMove1, pMove2, ratingAttack, ratingDefense) {
+    return `
+        <div id="pkmMoves${encounterIdLong}">
+            Moves: <b>${pMove1}</b> / <b>${pMove2}</b> | Rating: <b title="Moveset Attack Rating">${ratingAttack}</b> / <b title="Moveset Defense Rating">${ratingDefense}</b>
+        </div>
+        `
+}
+
+function buildGenderDiv(encounterIdLong, weight, height, gender) {
+    return `
+        <div id="pkmGender${encounterIdLong}">
+            Gender: ${genderType[gender - 1]} | Weight: ${weight.toFixed(2)}kg | Height: ${height.toFixed(2)}m
+        </div>
+        `
+}
+
+function buildCPDiv(encounterIdLong, cp, level) {
+    return `
+        <div id="pkmCP${encounterIdLong}">
+            Level: <b title="Maximum Level is 30">${level}</b> | CP: <b>${cp}</b>
+        </div>
+        `
+}
+
+function buildProbsDiv(encounterIdLong, prob1, prob2, prob3) {
+    prob1 = prob1 * 100
+    prob2 = prob2 * 100
+    prob3 = prob3 * 100
+    return `
+        <div id="pkmProbs${encounterIdLong}">
+            Pokeball: ${prob1.toFixed(1)}% | Great Ball: ${prob2.toFixed(1)}% | Ultra Ball: ${prob3.toFixed(1)}%
+        </div>
+        `
+}
+
 function pokemonLabel(item) {
     var name = item['pokemon_name']
     var rarityDisplay = item['pokemon_rarity'] ? '(' + item['pokemon_rarity'] + ')' : ''
@@ -424,6 +539,13 @@ function pokemonLabel(item) {
     var gender = item['gender']
     var form = item['form']
     var cp = item['cp']
+    var level = item['level']
+    var prob1 = item['catch_prob_1']
+    var prob2 = item['catch_prob_2']
+    var prob3 = item['catch_prob_3']
+    var ratingAttack = item['ratingAttack']
+    var ratingDefense = item['ratingDefense']
+    var encounterIdLong = atob(encounterId)
 
     $.each(types, function (index, type) {
         typesDisplay += getTypeSpan(type)
@@ -431,34 +553,27 @@ function pokemonLabel(item) {
 
     var details = ''
     if (atk !== null && def !== null && sta !== null) {
-        var iv = getIv(atk, def, sta)
-        details = `
-            <div>
-                IV: ${iv.toFixed(1)}% (${atk}/${def}/${sta})
-            </div>
-            `
-
-        if (cp !== null) {
-            details += `
-            <div>
-                CP: ${cp}
-            </div>
-            `
-        }
-
-        details += `
-            <div>
-                Moves: ${pMove1} / ${pMove2}
-            </div>
-            `
+        details += buildIVDiv(encounterIdLong, atk, def, sta)
     }
-    if (gender !== null && weight !== null && height !== null) {
-        details += `
-            <div>
-                Gender: ${genderType[gender - 1]} | Weight: ${weight.toFixed(2)}kg | Height: ${height.toFixed(2)}m
-            </div>
-            `
+    if (cp != null) {
+        details += buildCPDiv(encounterIdLong, cp, level)
     }
+    if (pMove1 !== 'gen/unknown') {
+        details += buildMovesDiv(encounterIdLong, pMove1, pMove2, ratingAttack, ratingDefense)
+    }
+    if (gender != null) {
+        details += buildGenderDiv(encounterIdLong, weight, height, gender)
+    }
+    if (prob1 != null) {
+        details += buildProbsDiv(encounterIdLong, prob1, prob2, prob3)
+    }
+    var scoutLink
+    if (cp === null) {
+        scoutLink = `<a href='javascript:void(0);' onclick='javascript:scout("${encounterId}");' title='Scout CP'>Scout</a>`
+    } else {
+        scoutLink = ''
+    }
+
     var contentstring = `
         <div>
             <b>${name}</b>`
@@ -477,15 +592,17 @@ function pokemonLabel(item) {
             Disappears at ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
             <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
         </div>
-        <div>
+        <div id="pkmLoc${encounterIdLong}">
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
         </div>
             ${details}
+        <div id="scoutInfo${encounterIdLong}" style="display:none;"></div>
         <div>
             <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp
             <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp
             <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>&nbsp;&nbsp
-            <a href='javascript:void(0);' onclick='javascript:openMapDirections(${latitude},${longitude});' title='View in Maps'>Get directions</a>
+            <a href='javascript:void(0);' onclick='javascript:openMapDirections(${latitude},${longitude});' title='View in Maps'>Get directions</a>&nbsp;&nbsp
+            ${scoutLink}
         </div>`
     return contentstring
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds support for **IV/CP/Level/Moves/Catch Rates**/etc. scanning using the **[PGScout](https://github.com/sLoPPydrive/PGScout)** webservice and is fully compatible with the current IV/CP scanning algorithm. Consider you found a Pokemon which is part of your encounter whitelist and encounters are currently enabled:

- If you have a PGScout webservice URL configured PGScout is being queried to get the stats.
- If PGScout isn't configured but you have given a list of L30 accounts these are used to perform the encounter.
- Else no encounter will take place. You won't know the stats of the Pokemon.

Additionally PGScout will also return the **moveset rating** as determined by [GamePress](https://pokemongo.gamepress.gg/).

The result looks something like this:
![image](https://cloud.githubusercontent.com/assets/3931865/25614130/0270e9a0-2f31-11e7-8e9e-64ee1601c8a0.png)

This PR also allows you to perform an IV scan on any Pokemon that you usually don't encounter automatically. Just click the "Scout" link in the Pokemon window:
1. ![image](https://cloud.githubusercontent.com/assets/3931865/25614571/c99c8420-2f32-11e7-808a-dfb7304d13e7.png)
2. ![image](https://cloud.githubusercontent.com/assets/3931865/25614593/e10e5fb6-2f32-11e7-9c80-22e2a312dcde.png)
3. ![image](https://cloud.githubusercontent.com/assets/3931865/25614605/f0c445f6-2f32-11e7-805a-17b089b89683.png)

To use this service you need access to a running PGScout instance, either on your own machine or somewhere on the net. Then you have to configure RocketMap to use it as simple as this (assuming you are running PGScout locally on default port):

```
--pgscout-url http://localhost:4242/iv
```

Attention: This PR **changes the schema** by adding new columns to the found Pokemon (leve, catch probabilities and moveset ratings).

**Disclaimer:** PGScout basically works the same as the integrated IV/CP scanning in RocketMap but way more aggressive. It doesn't obey any speed limit, so you can "scout" far more often and at very different places. This sounds a lot less secure and I cannot guarantee that this might in fact be true but in the end nobody knows for sure if single encounter requests really do that much harm. Most probably the process of getting an account to L30 is way more problematic than simple "scouting" with encounter requests. My own L30 accounts even survived the last ban wave.

Anyways, use at your own risk.

## Motivation and Context
Since 2017-04-28 RocketMap is able to scan for Pokemon stats (IV, Moves, CP) using a dedicated level 30 account queue. While this is great news it lacks some essential features:

1. It only fetches CP from the Pokemon. This isn't a particular good value to rank the Pokemon strength. A better value would be the **Pokemon level** (going from 1 to 30) which can be compared among all types of Pokemon and directly relates to the amount of stardust you would have to use to max out the Pokemon.
2. Having the **catch probabilities** for ball types Poke Ball, Great Ball and Ultra Ball is also missing from the current implementation.
3. The encounter whitelist defines which Pokemon to scan. Other are never touched. I wanted to be able to **scan** any Pokemon **on demand** by clicking a link.
4. The main reason: A popular RocketMap setup is having one instances for only the web frontend and multiple scanner instances that just scan for Pokemon, all attached to the same database. While this is surely planned for a near future release currently RocketMap doesn't allow to **share L30 workers** (or "scanners") between RocketMap instances. This means you have to pre-assign your precious L30 accounts to certain instances which isn't very flexible.

As I also run other tools that like to know Pokemon stats I decided to implement PGScout as an external webservice. The only purpose of this tool is to throw basic Pokemon data (IDs and Location) at it and get back the full set of Pokemon stats for a trainer with level 30+.

## How Has This Been Tested?
On my local map and by some guys who forked my branch.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
