### PR TITLE
Alter tables collation and charset

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2641,12 +2641,14 @@ def create_tables(db):
             SELECT table_name FROM information_schema.tables WHERE
             table_collation != "utf8mb4_unicode_ci" AND table_schema = "%s";
             ''' % args.db_name
-        tables = db.execute_sql(cmd_sql)
-        if tables.rowcount > 0:
+        change_tables = db.execute_sql(cmd_sql)
+        if change_tables.rowcount > 0:
             log.info('Changing collation and charset on %s tables.',
-                     tables.rowcount)
+                     change_tables.rowcount)
+            if change_tables.rowcount == len(tables) + 1:
+                log.info('Changing whole database, this might take while.')
             db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
-            for table in tables:
+            for table in change_tables:
                 log.debug('Changing collation and charset on table %s.',
                           table[0])
                 cmd_sql = '''ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2641,8 +2641,8 @@ def create_tables(db):
             for table in tables:
                 log.debug('Changing collation and charset on table %s.',
                           table[0])
-                cmd_sql = '''ALTER TABLE %s COLLATE=utf8mb4_unicode_ci,
-                            CONVERT TO CHARSET utf8mb4;''' % str(table[0])
+                cmd_sql = '''ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4
+                            COLLATE utf8mb4_unicode_ci;''' % str(table[0])
                 db.execute_sql(cmd_sql)
             db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2906,7 +2906,7 @@ def database_migrate(db, old_ver):
         # Change all tables for consistency
         if args.db_type == 'mysql':
             db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
-            tables = [str(x) for x in db.get_tables()]            
+            tables = [str(x) for x in db.get_tables()]
             for table in tables:
                 cmd_sql = '''ALTER TABLE %s COLLATE=utf8mb4_general_ci,
                             CONVERT TO CHARSET utf8mb4;''' % table

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2626,6 +2626,15 @@ def create_tables(db):
         else:
             log.debug('Skipping table %s, it already exists.', table.__name__)
 
+    # fixing encoding on future tables
+    if args.db_type == 'mysql':
+        db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
+        for table in tables:
+            cmd_sql = '''ALTER TABLE %s COLLATE=`utf8_general_ci`,
+                        CONVERT TO CHARSET utf8;''' % table
+            db.execute_sql(cmd_sql)
+        db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
+
     db.close()
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -49,6 +49,13 @@ class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
     pass
 
 
+# Reduction of CharField to fit max length inside 767 bytes for utf8mb4 charset
+class Utf8mb4CharField(CharField):
+    def __init__(self, max_length=191, *args, **kwargs):
+        self.max_length = max_length
+        super(CharField, self).__init__(*args, **kwargs)
+
+
 def init_database(app):
     if args.db_type == 'mysql':
         log.info('Connecting to MySQL database on %s:%i...',
@@ -96,8 +103,8 @@ class BaseModel(flaskDb.Model):
 class Pokemon(BaseModel):
     # We are base64 encoding the ids delivered by the api
     # because they are too big for sqlite to handle.
-    encounter_id = CharField(primary_key=True, max_length=50)
-    spawnpoint_id = CharField(index=True, max_length=191)
+    encounter_id = Utf8mb4CharField(primary_key=True, max_length=50)
+    spawnpoint_id = Utf8mb4CharField(index=True)
     pokemon_id = SmallIntegerField(index=True)
     latitude = DoubleField()
     longitude = DoubleField()
@@ -436,13 +443,14 @@ class Pokemon(BaseModel):
 
 
 class Pokestop(BaseModel):
-    pokestop_id = CharField(primary_key=True, max_length=50)
+    pokestop_id = Utf8mb4CharField(primary_key=True, max_length=50)
     enabled = BooleanField()
     latitude = DoubleField()
     longitude = DoubleField()
     last_modified = DateTimeField(index=True)
     lure_expiration = DateTimeField(null=True, index=True)
-    active_fort_modifier = CharField(max_length=50, null=True, index=True)
+    active_fort_modifier = Utf8mb4CharField(max_length=50,
+                                            null=True, index=True)
     last_updated = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
 
@@ -534,7 +542,7 @@ class Pokestop(BaseModel):
 
 class Gym(BaseModel):
 
-    gym_id = CharField(primary_key=True, max_length=50)
+    gym_id = Utf8mb4CharField(primary_key=True, max_length=50)
     team_id = SmallIntegerField()
     guard_pokemon_id = SmallIntegerField()
     gym_points = IntegerField()
@@ -702,7 +710,7 @@ class Gym(BaseModel):
 
 
 class LocationAltitude(BaseModel):
-    cellid = CharField(primary_key=True, max_length=50)
+    cellid = Utf8mb4CharField(primary_key=True, max_length=50)
     latitude = DoubleField()
     longitude = DoubleField()
     last_modified = DateTimeField(index=True, default=datetime.utcnow,
@@ -747,7 +755,7 @@ class LocationAltitude(BaseModel):
 
 
 class ScannedLocation(BaseModel):
-    cellid = CharField(primary_key=True, max_length=50)
+    cellid = Utf8mb4CharField(primary_key=True, max_length=50)
     latitude = DoubleField()
     longitude = DoubleField()
     last_modified = DateTimeField(
@@ -1084,9 +1092,9 @@ class ScannedLocation(BaseModel):
 
 
 class MainWorker(BaseModel):
-    worker_name = CharField(primary_key=True, max_length=50)
+    worker_name = Utf8mb4CharField(primary_key=True, max_length=50)
     message = TextField(null=True, default="")
-    method = CharField(max_length=50)
+    method = Utf8mb4CharField(max_length=50)
     last_modified = DateTimeField(index=True)
     accounts_working = IntegerField()
     accounts_captcha = IntegerField()
@@ -1109,15 +1117,15 @@ class MainWorker(BaseModel):
 
 
 class WorkerStatus(BaseModel):
-    username = CharField(primary_key=True, max_length=50)
-    worker_name = CharField(index=True, max_length=50)
+    username = Utf8mb4CharField(primary_key=True, max_length=50)
+    worker_name = Utf8mb4CharField(index=True, max_length=50)
     success = IntegerField()
     fail = IntegerField()
     no_items = IntegerField()
     skip = IntegerField()
     captcha = IntegerField()
     last_modified = DateTimeField(index=True)
-    message = CharField(max_length=255)
+    message = Utf8mb4CharField(max_length=191)
     last_scan_date = DateTimeField(index=True)
     latitude = DoubleField(null=True)
     longitude = DoubleField(null=True)
@@ -1188,13 +1196,13 @@ class WorkerStatus(BaseModel):
 
 
 class SpawnPoint(BaseModel):
-    id = CharField(primary_key=True, max_length=50)
+    id = Utf8mb4CharField(primary_key=True, max_length=50)
     latitude = DoubleField()
     longitude = DoubleField()
     last_scanned = DateTimeField(index=True)
     # kind gives the four quartiles of the spawn, as 's' for seen
     # or 'h' for hidden.  For example, a 30 minute spawn is 'hhss'.
-    kind = CharField(max_length=4, default='hhhs')
+    kind = Utf8mb4CharField(max_length=4, default='hhhs')
 
     # links shows whether a Pokemon encounter id changes between quartiles or
     # stays the same.  Both 1x45 and 1x60h3 have the kind of 'sssh', but the
@@ -1206,7 +1214,7 @@ class SpawnPoint(BaseModel):
     # Note index is shifted by a half. links[0] is the link between
     # kind[0] and kind[1] and so on. links[3] is the link between
     # kind[3] and kind[0]
-    links = CharField(max_length=4, default='????')
+    links = Utf8mb4CharField(max_length=4, default='????')
 
     # Count consecutive times spawn should have been seen, but wasn't.
     # If too high, will not be scheduled for review, and treated as inactive.
@@ -1422,11 +1430,11 @@ class ScanSpawnPoint(BaseModel):
 
 
 class SpawnpointDetectionData(BaseModel):
-    id = CharField(primary_key=True, max_length=54)
+    id = Utf8mb4CharField(primary_key=True, max_length=54)
     # Removed ForeignKeyField since it caused MySQL issues.
-    encounter_id = CharField(max_length=54)
+    encounter_id = Utf8mb4CharField(max_length=54)
     # Removed ForeignKeyField since it caused MySQL issues.
-    spawnpoint_id = CharField(max_length=54, index=True)
+    spawnpoint_id = Utf8mb4CharField(max_length=54, index=True)
     scan_time = DateTimeField()
     tth_secs = SmallIntegerField(null=True)
 
@@ -1621,7 +1629,7 @@ class SpawnpointDetectionData(BaseModel):
 
 
 class Versions(flaskDb.Model):
-    key = CharField()
+    key = Utf8mb4CharField()
     val = SmallIntegerField()
 
     class Meta:
@@ -1629,8 +1637,8 @@ class Versions(flaskDb.Model):
 
 
 class GymMember(BaseModel):
-    gym_id = CharField(index=True, max_length=191)
-    pokemon_uid = CharField(index=True, max_length=191)
+    gym_id = Utf8mb4CharField(index=True)
+    pokemon_uid = Utf8mb4CharField(index=True)
     last_scanned = DateTimeField(default=datetime.utcnow, index=True)
 
     class Meta:
@@ -1638,10 +1646,10 @@ class GymMember(BaseModel):
 
 
 class GymPokemon(BaseModel):
-    pokemon_uid = CharField(primary_key=True, max_length=50)
+    pokemon_uid = Utf8mb4CharField(primary_key=True, max_length=50)
     pokemon_id = SmallIntegerField()
     cp = SmallIntegerField()
-    trainer_name = CharField(index=True, max_length=191)
+    trainer_name = Utf8mb4CharField(index=True)
     num_upgrades = SmallIntegerField(null=True)
     move_1 = SmallIntegerField(null=True)
     move_2 = SmallIntegerField(null=True)
@@ -1658,17 +1666,17 @@ class GymPokemon(BaseModel):
 
 
 class Trainer(BaseModel):
-    name = CharField(primary_key=True, max_length=50)
+    name = Utf8mb4CharField(primary_key=True, max_length=50)
     team = SmallIntegerField()
     level = SmallIntegerField()
     last_seen = DateTimeField(default=datetime.utcnow)
 
 
 class GymDetails(BaseModel):
-    gym_id = CharField(primary_key=True, max_length=50)
-    name = CharField()
+    gym_id = Utf8mb4CharField(primary_key=True, max_length=50)
+    name = Utf8mb4CharField()
     description = TextField(null=True, default="")
-    url = CharField()
+    url = Utf8mb4CharField()
     last_scanned = DateTimeField(default=datetime.utcnow)
 
 
@@ -1706,7 +1714,7 @@ class Token(flaskDb.Model):
 
 
 class HashKeys(BaseModel):
-    key = CharField(primary_key=True, max_length=20)
+    key = Utf8mb4CharField(primary_key=True, max_length=20)
     maximum = SmallIntegerField(default=0)
     remaining = SmallIntegerField(default=0)
     peak = SmallIntegerField(default=0)
@@ -2712,12 +2720,13 @@ def database_migrate(db, old_ver):
 
     if old_ver < 2:
         migrate(migrator.add_column('pokestop', 'encounter_id',
-                                    CharField(max_length=50, null=True)))
+                                    Utf8mb4CharField(max_length=50,
+                                                     null=True)))
 
     if old_ver < 3:
         migrate(
             migrator.add_column('pokestop', 'active_fort_modifier',
-                                CharField(max_length=50, null=True)),
+                                Utf8mb4CharField(max_length=50, null=True)),
             migrator.drop_column('pokestop', 'encounter_id'),
             migrator.drop_column('pokestop', 'active_pokemon_id')
         )

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2642,7 +2642,7 @@ def create_tables(db):
                 log.debug('Changing collation and charset on table %s.',
                           table[0])
                 cmd_sql = '''ALTER TABLE %s COLLATE=utf8mb4_unicode_ci,
-                            CONVERT TO CHARSET utf8mb4, FORCE;''' % str(table[0])
+                            CONVERT TO CHARSET utf8mb4;''' % str(table[0])
                 db.execute_sql(cmd_sql)
             db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2885,17 +2885,17 @@ def database_migrate(db, old_ver):
             migrator.add_column('pokemon', 'cp',
                                 SmallIntegerField(null=True))
         )
-        
+
     if old_ver < 19:
-        # Change charset of gym details table to utf-8 to fix gym 
+        # Change charset of gym details table to utf-8 to fix gym
         # name warning on special characters
         # Change all tables for consistency
         if args.db_type == 'mysql':
             tables = [str(x) for x in db.get_tables()]
             db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
             for table in tables:
-                cmd_sql = '''ALTER TABLE %s COLLATE=`utf8_general_ci`, 
-                            CONVERT TO CHARSET utf8;''' % table  
+                cmd_sql = '''ALTER TABLE %s COLLATE=`utf8_general_ci`,
+                            CONVERT TO CHARSET utf8;''' % table
                 db.execute_sql(cmd_sql)
             db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2642,19 +2642,23 @@ def create_tables(db):
             table_collation != "utf8mb4_unicode_ci" AND table_schema = "%s";
             ''' % args.db_name
         change_tables = db.execute_sql(cmd_sql)
+
         if change_tables.rowcount > 0:
             log.info('Changing collation and charset on %s tables.',
                      change_tables.rowcount)
+
             if change_tables.rowcount == len(tables) + 1:
-                log.info('Changing whole database, this might take while.')
-            db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
-            for table in change_tables:
-                log.debug('Changing collation and charset on table %s.',
-                          table[0])
-                cmd_sql = '''ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4
-                            COLLATE utf8mb4_unicode_ci;''' % str(table[0])
-                db.execute_sql(cmd_sql)
-            db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
+                log.info('Changing whole database, this might a take while.')
+
+            with db.atomic():
+                db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
+                for table in change_tables:
+                    log.debug('Changing collation and charset on table %s.',
+                              table[0])
+                    cmd_sql = '''ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4
+                                COLLATE utf8mb4_unicode_ci;''' % str(table[0])
+                    db.execute_sql(cmd_sql)
+                db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 
     db.close()
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2630,6 +2630,7 @@ def create_tables(db):
     if args.db_type == 'mysql':
         db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
         for table in tables:
+            tables = [str(x) for x in db.get_tables()]
             cmd_sql = '''ALTER TABLE %s COLLATE=`utf8_general_ci`,
                         CONVERT TO CHARSET utf8;''' % table
             db.execute_sql(cmd_sql)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2887,13 +2887,15 @@ def database_migrate(db, old_ver):
         )
         
     if old_ver < 19:
-        # Change charset of gym details table to utf-8 to fix gym name warning on special characters
-        # Change all tables for consistency 
+        # Change charset of gym details table to utf-8 to fix gym 
+        # name warning on special characters
+        # Change all tables for consistency
         if args.db_type == 'mysql':
             tables = [str(x) for x in db.get_tables()]
             db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
             for table in tables:
-                cmd_sql = 'ALTER TABLE %s COLLATE=`utf8_general_ci`, CONVERT TO CHARSET utf8;' % table    
+                cmd_sql = '''ALTER TABLE %s COLLATE=`utf8_general_ci`, 
+                            CONVERT TO CHARSET utf8;''' % table  
                 db.execute_sql(cmd_sql)
             db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 

--- a/runserver.py
+++ b/runserver.py
@@ -223,9 +223,9 @@ def main():
         elif os.path.isfile(args.db):
             os.remove(args.db)
 
-    create_tables(db)
-
     verify_database_schema(db)
+
+    create_tables(db)
 
     # fixing encoding on present and future tables
     verify_table_encoding(db)

--- a/runserver.py
+++ b/runserver.py
@@ -23,7 +23,8 @@ from pogom.altitude import get_gmaps_altitude
 
 from pogom.search import search_overseer_thread
 from pogom.models import (init_database, create_tables, drop_tables,
-                          Pokemon, db_updater, clean_db_loop)
+                          Pokemon, db_updater, clean_db_loop,
+                          verify_table_encoding, verify_database_schema)
 from pogom.webhook import wh_updater
 
 from pogom.proxy import check_proxies, proxies_refresher
@@ -221,7 +222,14 @@ def main():
             drop_tables(db)
         elif os.path.isfile(args.db):
             os.remove(args.db)
+
     create_tables(db)
+
+    verify_database_schema(db)
+
+    # fixing encoding on present and future tables
+    verify_table_encoding(db)
+
     if args.clear_db:
         log.info("Drop and recreate is complete. Now remove -cd and restart.")
         sys.exit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR alters all tables according to #1740 to fix OperationalError 1366 

## Description
<!--- Describe your changes in detail -->
I altered collation of tables from 'latin1_swedish_ci' to 'utf8_general_ci' and charsets to 'utf-8'.

Fixes #2045.
Fixes #1740.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
mariaDB has default collation 'latin1_swedish_ci' and default charset 'latin1' after installation, which causes warning when parsing non-default characters from gym names:
```
2017-05-04 11:59:51,832 [   search-worker-2][        models][    INFO] Upserted gyms: 3, gym members: 25.
2017-05-04 11:59:51,832 [   search-worker-2][        search][    INFO] Processing details of 3 gyms for location 49.155774,16.505332... Sleeping 6.37s until 12:00:06.
2017-05-04 11:59:51,834 [      db-updater-0][        models][ WARNING] OperationalError(1366, "Incorrect string value: '\\xC5\\x99\\xC3\\xAD\\xC5\\xBE...' for column 'name' at row 2")... Retrying...
2017-05-04 11:59:52,835 [      db-updater-0][        models][ WARNING] OperationalError(1366, "Incorrect string value: '\\xC5\\x99\\xC3\\xAD\\xC5\\xBE...' for column 'name' at row 2")... Retrying...
2017-05-04 11:59:53,835 [      db-updater-0][        models][ WARNING] OperationalError(1366, "Incorrect string value: '\\xC5\\x99\\xC3\\xAD\\xC5\\xBE...' for column 'name' at row 2")... Retrying...
2017-05-04 11:59:54,836 [      db-updater-0][        models][ WARNING] OperationalError(1366, "Incorrect string value: '\\xC5\\x99\\xC3\\xAD\\xC5\\xBE...' for column 'name' at row 2")... Retrying...
2017-05-04 11:59:55,838 [      db-updater-0][        models][ WARNING] OperationalError(1366, "Incorrect string value: '\\xC5\\x99\\xC3\\xAD\\xC5\\xBE...' for column 'name' at row 2")... Retrying...
```
This warning never goes away, keeps it keeps spamming.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #1740 .
Changing only GymDetails table is enough to fix this issue, but for consistency this PR changes all tables at once.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I accidentaly managed to reproduce #1740 on location 49.155774 16.505332. There are 3 gyms and one of them is causing OperationalError to happen, because it's name contains special czech characters.
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on clean pull, clean install, clean MariaDB install according to docs, empty database.
Warning starts to appear immidiately the first time when processing details of gyms.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
