### PR TITLE
Fix move names Future Sight & X-Scissor

### DIFF
--- a/static/data/moves.json
+++ b/static/data/moves.json
@@ -792,7 +792,7 @@
         "dps": 25.86
     },
     "100": {
-        "name": "X Scissor",
+        "name": "X-Scissor",
         "type": "Bug",
         "damage": 45,
         "duration": 1600,
@@ -1696,7 +1696,7 @@
         "dps": 10.91
     },
     "275": {
-        "name": "Futuresight",
+        "name": "Future Sight",
         "type": "Psychic",
         "damage": 120,
         "duration": 2700,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The same correction as the pr https://github.com/kvangent/PokeAlarm/pull/367 of the pokealarm

I did not notice that the names of these attacks were not well written when I updated all the movements

## Description
<!--- Describe your changes in detail -->
Write correctly the moves "Future Sight" and "X-Scissor" in moves.json

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
