### PR TITLE
[Optimization] Use protobuf objects directly instead of dicts

### DIFF
--- a/pogom/captcha.py
+++ b/pogom/captcha.py
@@ -179,8 +179,12 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
 def handle_captcha(args, status, api, account, account_failures,
                    account_captchas, whq, response_dict, step_location):
     try:
-        captcha_url = response_dict['responses'][
-            'CHECK_CHALLENGE']['challenge_url']
+        if 'CHECK_CHALLENGE' not in response_dict['responses']:
+            return None
+
+        challenge = response_dict['responses']['CHECK_CHALLENGE']
+        captcha_url = challenge.challenge_url
+
         if len(captcha_url) > 1:
             status['captcha'] += 1
             if not args.captcha_solving:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1858,7 +1858,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
-    cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
+    cells = map_dict['responses']['GET_MAP_OBJECTS'].map_cells
     # Get the level for the pokestop spin, and to send to webhook.
     level = account['level']
     # Use separate level indicator for our L30 encounters.
@@ -1868,29 +1868,23 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         # If we have map responses then use the time from the request
         if i == 0:
             now_date = datetime.utcfromtimestamp(
-                cell['current_timestamp_ms'] / 1000)
+                cell.current_timestamp_ms / 1000)
 
-        nearby_pokemon += len(cell.get('nearby_pokemons', []))
+        nearby_pokemon += len(cell.nearby_pokemons)
         # Parse everything for stats (counts).  Future enhancement -- we don't
         # necessarily need to know *how many* forts/wild/nearby were found but
         # we'd like to know whether or not *any* were found to help determine
         # if a scan was actually bad.
         if config['parse_pokemon']:
-            wild_pokemon += cell.get('wild_pokemons', [])
+            wild_pokemon += cell.wild_pokemons
 
         if config['parse_pokestops'] or config['parse_gyms']:
-            forts += cell.get('forts', [])
+            forts += cell.forts
 
-        # Update count regardless of Pokémon parsing or not, we need the count.
-        # Length is O(1).
-        wild_pokemon_count += len(cell.get('wild_pokemons', []))
-        forts_count += len(cell.get('forts', []))
+        wild_pokemon_count += len(cell.wild_pokemons)
+        forts_count += len(cell.forts)
 
     now_secs = date_secs(now_date)
-    if wild_pokemon:
-        wild_pokemon_count = len(wild_pokemon)
-    if forts:
-        forts_count = len(forts)
 
     del map_dict['responses']['GET_MAP_OBJECTS']
 
@@ -1912,7 +1906,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     just_completed = not done_already and scan_loc['done']
 
     if wild_pokemon and config['parse_pokemon']:
-        encounter_ids = [b64encode(str(p['encounter_id']))
+        encounter_ids = [b64encode(str(p.encounter_id))
                          for p in wild_pokemon]
         # For all the wild Pokemon we found check if an active Pokemon is in
         # the database.
@@ -1929,28 +1923,28 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
         for p in wild_pokemon:
 
-            sp = SpawnPoint.get_by_id(p['spawn_point_id'], p[
-                                      'latitude'], p['longitude'])
-            spawn_points[p['spawn_point_id']] = sp
+            sp = SpawnPoint.get_by_id(p.spawn_point_id, p.latitude,
+                                      p.longitude)
+            spawn_points[p.spawn_point_id] = sp
             sp['missed_count'] = 0
 
             sighting = {
-                'id': b64encode(str(p['encounter_id'])) + '_' + str(now_secs),
-                'encounter_id': b64encode(str(p['encounter_id'])),
-                'spawnpoint_id': p['spawn_point_id'],
+                'id': b64encode(str(p.encounter_id)) + '_' + str(now_secs),
+                'encounter_id': b64encode(str(p.encounter_id)),
+                'spawnpoint_id': p.spawn_point_id,
                 'scan_time': now_date,
                 'tth_secs': None
             }
 
             # Keep a list of sp_ids to return.
-            sp_id_list.append(p['spawn_point_id'])
+            sp_id_list.append(p.spawn_point_id)
 
             # time_till_hidden_ms was overflowing causing a negative integer.
             # It was also returning a value above 3.6M ms.
-            if 0 < p['time_till_hidden_ms'] < 3600000:
+            if 0 < p.time_till_hidden_ms < 3600000:
                 d_t_secs = date_secs(datetime.utcfromtimestamp(
-                    (p['last_modified_timestamp_ms'] +
-                     p['time_till_hidden_ms']) / 1000.0))
+                    (p.last_modified_timestamp_ms +
+                     p.time_till_hidden_ms) / 1000.0))
                 if (sp['latest_seen'] != sp['earliest_unseen'] or
                         not sp['last_scanned']):
                     log.info('TTH found for spawnpoint %s.', sp['id'])
@@ -1984,12 +1978,12 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     not scan_loc['done'] or just_completed):
                 SpawnpointDetectionData.classify(sp, scan_loc, now_secs,
                                                  sighting)
-                sightings[p['encounter_id']] = sighting
+                sightings[p.encounter_id] = sighting
 
             sp['last_scanned'] = datetime.utcfromtimestamp(
-                p['last_modified_timestamp_ms'] / 1000.0)
+                p.last_modified_timestamp_ms / 1000.0)
 
-            if ((b64encode(str(p['encounter_id'])), p['spawn_point_id'])
+            if ((b64encode(str(p.encounter_id)), p.spawn_point_id)
                     in encountered_pokemon):
                 # If Pokemon has been encountered before don't process it.
                 skipped += 1
@@ -2000,8 +1994,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             disappear_time = now_date + \
                 timedelta(seconds=seconds_until_despawn)
 
-            pokemon_id = p['pokemon_data']['pokemon_id']
-            printPokemon(pokemon_id, p['latitude'], p['longitude'],
+            pokemon_id = p.pokemon_data.pokemon_id
+            printPokemon(pokemon_id, p.latitude, p.longitude,
                          disappear_time)
 
             # Scan for IVs/CP and moves.
@@ -2013,7 +2007,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 hlvl_api = None
                 using_accountset = False
 
-                scan_location = [p['latitude'], p['longitude']]
+                scan_location = [p.latitude, p.longitude]
 
                 # If the host has L30s in the regular account pool, we
                 # can just use the current account.
@@ -2074,8 +2068,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     encounter_result = encounter_pokemon_request(
                         hlvl_api,
                         account,
-                        p['encounter_id'],
-                        p['spawn_point_id'],
+                        p.encounter_id,
+                        p.spawn_point_id,
                         scan_location)
 
                     # Handle errors.
@@ -2085,7 +2079,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
                         # Check for captcha.
                         captcha_url = responses[
-                            'CHECK_CHALLENGE']['challenge_url']
+                            'CHECK_CHALLENGE'].challenge_url
 
                         # Throw warning but finish parsing.
                         if len(captcha_url) > 1:
@@ -2126,12 +2120,12 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     log.error('No L30 accounts are available, please'
                               + ' consider adding more. Skipping encounter.')
 
-            pokemon[p['encounter_id']] = {
-                'encounter_id': b64encode(str(p['encounter_id'])),
-                'spawnpoint_id': p['spawn_point_id'],
+            pokemon[p.encounter_id] = {
+                'encounter_id': b64encode(str(p.encounter_id)),
+                'spawnpoint_id': p.spawn_point_id,
                 'pokemon_id': pokemon_id,
-                'latitude': p['latitude'],
-                'longitude': p['longitude'],
+                'latitude': p.latitude,
+                'longitude': p.longitude,
                 'disappear_time': disappear_time,
                 'individual_attack': None,
                 'individual_defense': None,
@@ -2142,65 +2136,65 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'cp_multiplier': None,
                 'height': None,
                 'weight': None,
-                'gender': p['pokemon_data']['pokemon_display']['gender'],
+                'gender': p.pokemon_data.pokemon_display.gender,
                 'form': None
             }
 
             # Check for Unown's alphabetic character.
             if pokemon_id == 201:
-                pokemon[p['encounter_id']]['form'] = p['pokemon_data'][
-                    'pokemon_display'].get('form', None)
+                pokemon[p.encounter_id]['form'] = (p.pokemon_data
+                                                    .pokemon_display.form)
 
-            if (encounter_result is not None and 'wild_pokemon'
-                    in encounter_result['responses']['ENCOUNTER']):
+            # We need to check if exist and is not false due to a request error
+            if encounter_result and (encounter_result['responses'][
+                    'ENCOUNTER']):
                 pokemon_info = encounter_result['responses'][
-                    'ENCOUNTER']['wild_pokemon']['pokemon_data']
+                    'ENCOUNTER'].wild_pokemon.pokemon_data
 
                 # IVs.
-                individual_attack = pokemon_info.get('individual_attack', 0)
-                individual_defense = pokemon_info.get('individual_defense', 0)
-                individual_stamina = pokemon_info.get('individual_stamina', 0)
-                cp = pokemon_info.get('cp', None)
+                individual_attack = pokemon_info.individual_attack
+                individual_defense = pokemon_info.individual_defense
+                individual_stamina = pokemon_info.individual_stamina
+                cp = pokemon_info.cp
 
                 # Logging: let the user know we succeeded.
                 log.debug('Encounter for Pokémon ID %s'
                           + ' at %s, %s successful: '
                           + ' %s/%s/%s, %s CP.',
                           pokemon_id,
-                          p['latitude'],
-                          p['longitude'],
+                          p.latitude,
+                          p.longitude,
                           individual_attack,
                           individual_defense,
                           individual_stamina,
                           cp)
 
-                pokemon[p['encounter_id']].update({
+                pokemon[p.encounter_id].update({
                     'individual_attack': individual_attack,
                     'individual_defense': individual_defense,
                     'individual_stamina': individual_stamina,
-                    'move_1': pokemon_info['move_1'],
-                    'move_2': pokemon_info['move_2'],
-                    'height': pokemon_info['height_m'],
-                    'weight': pokemon_info['weight_kg']
+                    'move_1': pokemon_info.move_1,
+                    'move_2': pokemon_info.move_2,
+                    'height': pokemon_info.height_m,
+                    'weight': pokemon_info.weight_kg,
                 })
 
                 # Only add CP if we're level 30+.
                 if encounter_level >= 30:
-                    pokemon[p['encounter_id']]['cp'] = cp
-                    pokemon[p['encounter_id']][
-                        'cp_multiplier'] = pokemon_info.get(
-                        'cp_multiplier', None)
+                    pokemon[p.encounter_id]['cp'] = cp
+                    pokemon[p.encounter_id][
+                        'cp_multiplier'] = pokemon_info.cp_multiplier
 
             if args.webhooks:
                 if (pokemon_id in args.webhook_whitelist or
                     (not args.webhook_whitelist and pokemon_id
                      not in args.webhook_blacklist)):
-                    wh_poke = pokemon[p['encounter_id']].copy()
+                    wh_poke = pokemon[p.encounter_id].copy()
                     wh_poke.update({
                         'disappear_time': calendar.timegm(
                             disappear_time.timetuple()),
-                        'last_modified_time': p['last_modified_timestamp_ms'],
-                        'time_until_hidden_ms': p['time_till_hidden_ms'],
+                        'last_modified_time': p.last_modified_timestamp_ms,
+                        'time_until_hidden_ms': p.time_till_hidden_ms,
                         'verified': SpawnPoint.tth_found(sp),
                         'seconds_until_despawn': seconds_until_despawn,
                         'spawn_start': start_end[0],
@@ -2216,7 +2210,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
     if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
-            stop_ids = [f['id'] for f in forts if f.get('type') == 1]
+            stop_ids = [f.id for f in forts if f.type == 1]
             if stop_ids:
                 query = (Pokestop
                          .select(Pokestop.pokestop_id, Pokestop.last_modified)
@@ -2237,20 +2231,19 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'not active. Check if \'-nk\' flag is accidentally set.')
 
         for f in forts:
-            if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
-                if 'active_fort_modifier' in f:
+            if config['parse_pokestops'] and f.type == 1:  # Pokestops.
+                if len(f.active_fort_modifier) > 0:
                     lure_expiration = (datetime.utcfromtimestamp(
-                        f['last_modified_timestamp_ms'] / 1000.0) +
+                        f.last_modified_timestamp_ms / 1000.0) +
                         timedelta(minutes=args.lure_duration))
-                    active_fort_modifier = f['active_fort_modifier']
+                    active_fort_modifier = f.active_fort_modifier[0]
                     if args.webhooks and args.webhook_updates_only:
                         wh_update_queue.put(('pokestop', {
-                            'pokestop_id': b64encode(str(f['id'])),
-                            'enabled': f.get('enabled', False),
-                            'latitude': f['latitude'],
-                            'longitude': f['longitude'],
-                            'last_modified_time': f[
-                                'last_modified_timestamp_ms'],
+                            'pokestop_id': b64encode(str(f.id)),
+                            'enabled': f.enabled,
+                            'latitude': f.latitude,
+                            'longitude': f.longitude,
+                            'last_modified_time': f.last_modified_timestamp_ms,
                             'lure_expiration': calendar.timegm(
                                 lure_expiration.timetuple()),
                             'active_fort_modifier': active_fort_modifier
@@ -2269,43 +2262,43 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         l_e = calendar.timegm(lure_expiration.timetuple())
 
                     wh_update_queue.put(('pokestop', {
-                        'pokestop_id': b64encode(str(f['id'])),
-                        'enabled': f.get('enabled', False),
-                        'latitude': f['latitude'],
-                        'longitude': f['longitude'],
-                        'last_modified_time': f['last_modified_timestamp_ms'],
+                        'pokestop_id': b64encode(str(f.id)),
+                        'enabled': f.enabled,
+                        'latitude': f.latitude,
+                        'longitude': f.longitude,
+                        'last_modified_time': f.last_modified_timestamp_ms,
                         'lure_expiration': l_e,
                         'active_fort_modifier': active_fort_modifier
                     }))
 
-                if ((f['id'], int(f['last_modified_timestamp_ms'] / 1000.0))
+                if ((f.id, int(f.last_modified_timestamp_ms / 1000.0))
                         in encountered_pokestops):
                     # If pokestop has been encountered before and hasn't
                     # changed don't process it.
                     stopsskipped += 1
                     continue
 
-                pokestops[f['id']] = {
-                    'pokestop_id': f['id'],
-                    'enabled': f.get('enabled', False),
-                    'latitude': f['latitude'],
-                    'longitude': f['longitude'],
+                pokestops[f.id] = {
+                    'pokestop_id': f.id,
+                    'enabled': f.enabled,
+                    'latitude': f.latitude,
+                    'longitude': f.longitude,
                     'last_modified': datetime.utcfromtimestamp(
-                        f['last_modified_timestamp_ms'] / 1000.0),
+                        f.last_modified_timestamp_ms / 1000.0),
                     'lure_expiration': lure_expiration,
                     'active_fort_modifier': active_fort_modifier
                 }
 
             # Currently, there are only stops and gyms.
-            elif config['parse_gyms'] and f.get('type') is None:
-                b64_gym_id = b64encode(str(f['id']))
-                gym_display = f.get('gym_display', {})
-                raid_info = f.get('raid_info', {})
+            elif config['parse_gyms'] and f.type == 0:
+                b64_gym_id = b64encode(str(f.id))
+                gym_display = f.gym_display
+                raid_info = f.raid_info
                 # Send gyms to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
                     raid_active_until = 0
-                    raid_battle_ms = raid_info.get('raid_battle_ms', 0)
-                    raid_end_ms = raid_info.get('raid_end_ms', 0)
+                    raid_battle_ms = raid_info.raid_battle_ms
+                    raid_end_ms = raid_info.raid_end_ms
 
                     if raid_battle_ms / 1000 > time.time():
                         raid_active_until = raid_end_ms / 1000
@@ -2317,88 +2310,88 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'gym_id':
                             b64_gym_id,
                         'team_id':
-                            f.get('owned_by_team', 0),
+                            f.owned_by_team,
                         'guard_pokemon_id':
-                            f.get('guard_pokemon_id', 0),
+                            f.guard_pokemon_id,
                         'slots_available':
-                            gym_display.get('slots_available', 0),
+                            gym_display.slots_available,
                         'total_cp':
-                            gym_display.get('total_gym_cp', 0),
+                            gym_display.total_gym_cp,
                         'enabled':
-                            f['enabled'],
+                            f.enabled,
                         'latitude':
-                            f['latitude'],
+                            f.latitude,
                         'longitude':
-                            f['longitude'],
+                            f.longitude,
                         'lowest_pokemon_motivation':
-                            gym_display.get('lowest_pokemon_motivation', 0),
+                            gym_display.lowest_pokemon_motivation,
                         'occupied_since':
                             calendar.timegm((datetime.utcnow() - timedelta(
-                                milliseconds=gym_display.get(
-                                    'occupied_millis', 0))).timetuple()),
+                                milliseconds=gym_display.occupied_millis)
+                                            ).timetuple()),
                         'last_modified':
-                            f['last_modified_timestamp_ms'],
+                            f.last_modified_timestamp_ms,
                         'raid_active_until':
                             raid_active_until
                     }))
 
-                gyms[f['id']] = {
+                gyms[f.id] = {
                     'gym_id':
-                        f['id'],
+                        f.id,
                     'team_id':
-                        f.get('owned_by_team', 0),
+                        f.owned_by_team,
                     'guard_pokemon_id':
-                        f.get('guard_pokemon_id', 0),
+                        f.guard_pokemon_id,
                     'slots_available':
-                        gym_display.get('slots_available', 0),
+                        gym_display.slots_available,
                     'total_cp':
-                        gym_display.get('total_gym_cp', 0),
+                        gym_display.total_gym_cp,
                     'enabled':
-                        f['enabled'],
+                        f.enabled,
                     'latitude':
-                        f['latitude'],
+                        f.latitude,
                     'longitude':
-                        f['longitude'],
+                        f.longitude,
                     'last_modified':
                         datetime.utcfromtimestamp(
-                            f['last_modified_timestamp_ms'] / 1000.0),
+                            f.last_modified_timestamp_ms / 1000.0),
                 }
 
-                if config['parse_raids'] and f.get('type') is None:
+                if config['parse_raids'] and f.type == 0:
                     if raid_info:
-                        raids[f['id']] = {
-                            'gym_id': f['id'],
-                            'level': raid_info['raid_level'],
+                        raids[f.id] = {
+                            'gym_id': f.id,
+                            'level': raid_info.raid_level,
                             'spawn': datetime.utcfromtimestamp(
-                                raid_info['raid_spawn_ms'] / 1000.0),
+                                raid_info.raid_spawn_ms / 1000.0),
                             'start': datetime.utcfromtimestamp(
-                                raid_info['raid_battle_ms'] / 1000.0),
+                                raid_info.raid_battle_ms / 1000.0),
                             'end': datetime.utcfromtimestamp(
-                                raid_info['raid_end_ms'] / 1000.0),
+                                raid_info.raid_end_ms / 1000.0),
                             'pokemon_id': None,
                             'cp': None,
                             'move_1': None,
                             'move_2': None
                         }
 
-                        raid_pokemon = raid_info.get('raid_pokemon', {})
-                        if raid_pokemon:
-                            raids[f['id']].update({
-                                'pokemon_id': raid_pokemon['pokemon_id'],
-                                'cp': raid_pokemon['cp'],
-                                'move_1': raid_pokemon['move_1'],
-                                'move_2': raid_pokemon['move_2']
+                        if raid_info.HasField('raid_pokemon'):
+                            raid_pokemon = raid_info.raid_pokemon
+                            raids[f.id].update({
+                                'pokemon_id': raid_pokemon.pokemon_id,
+                                'cp': raid_pokemon.cp,
+                                'move_1': raid_pokemon.move_1,
+                                'move_2': raid_pokemon.move_2
                             })
 
                         if args.webhooks and not args.webhook_updates_only:
-                            wh_raid = raids[f['id']].copy()
+                            wh_raid = raids[f.id].copy()
                             wh_raid.update({
                                 'gym_id': b64_gym_id,
-                                'spawn': raid_info['raid_spawn_ms'] / 1000,
-                                'start': raid_info['raid_battle_ms'] / 1000,
-                                'end': raid_info['raid_end_ms'] / 1000,
-                                'latitude': f['latitude'],
-                                'longitude': f['longitude']
+                                'spawn': raid_info.raid_spawn_ms / 1000,
+                                'start': raid_info.raid_battle_ms / 1000,
+                                'end': raid_info.raid_end_ms / 1000,
+                                'latitude': f.latitude,
+                                'longitude': f.longitude
                             })
                             wh_update_queue.put(('raid', wh_raid))
 
@@ -2498,84 +2491,66 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
     trainers = {}
     i = 0
     for g in gym_responses.values():
-        gym_state = g['gym_status_and_defenders']
-        gym_id = gym_state['pokemon_fort_proto']['id']
+        gym_state = g.gym_status_and_defenders
+        gym_id = gym_state.pokemon_fort_proto.id
 
         gym_details[gym_id] = {
             'gym_id': gym_id,
-            'name': g['name'],
-            'description': g.get('description'),
-            'url': g['url']
+            'name': g.name,
+            'description': g.description,
+            'url': g.url
         }
 
         if args.webhooks:
             webhook_data = {
                 'id': b64encode(str(gym_id)),
-                'latitude': gym_state['pokemon_fort_proto']['latitude'],
-                'longitude': gym_state['pokemon_fort_proto']['longitude'],
-                'team': gym_state['pokemon_fort_proto'].get(
-                    'owned_by_team', 0),
-                'name': g['name'],
-                'description': g.get('description'),
-                'url': g['url'],
+                'latitude': gym_state.pokemon_fort_proto.latitude,
+                'longitude': gym_state.pokemon_fort_proto.longitude,
+                'team': gym_state.pokemon_fort_proto.owned_by_team,
+                'name': g.name,
+                'description': g.description,
+                'url': g.url,
                 'pokemon': [],
             }
 
-        for member in gym_state.get('gym_defender', []):
-            pokemon = member['motivated_pokemon']['pokemon']
+        for member in gym_state.gym_defender:
+            pokemon = member.motivated_pokemon.pokemon
             gym_members[i] = {
                 'gym_id':
                     gym_id,
                 'pokemon_uid':
-                    pokemon['id'],
+                    pokemon.id,
                 'cp_decayed':
-                    member['motivated_pokemon']['cp_now'],
+                    member.motivated_pokemon.cp_now,
                 'deployment_time':
                     datetime.utcnow() -
-                    timedelta(milliseconds=member['deployment_totals']
-                              ['deployment_duration_ms'])
+                    timedelta(milliseconds=member.deployment_totals
+                              .deployment_duration_ms)
             }
             gym_pokemon[i] = {
-                'pokemon_uid':
-                    pokemon['id'],
-                'pokemon_id':
-                    pokemon['pokemon_id'],
-                'cp':
-                    member['motivated_pokemon']['cp_when_deployed'],
-                'trainer_name':
-                    pokemon['owner_name'],
-                'num_upgrades':
-                    pokemon.get('num_upgrades', 0),
-                'move_1':
-                    pokemon.get('move_1'),
-                'move_2':
-                    pokemon.get('move_2'),
-                'height':
-                    pokemon.get('height_m'),
-                'weight':
-                    pokemon.get('weight_kg'),
-                'stamina':
-                    pokemon.get('stamina'),
-                'stamina_max':
-                    pokemon.get('stamina_max'),
-                'cp_multiplier':
-                    pokemon.get('cp_multiplier'),
-                'additional_cp_multiplier':
-                    pokemon.get('additional_cp_multiplier', 0),
-                'iv_defense':
-                    pokemon.get('individual_defense', 0),
-                'iv_stamina':
-                    pokemon.get('individual_stamina', 0),
-                'iv_attack':
-                    pokemon.get('individual_attack', 0),
-                'last_seen':
-                    datetime.utcnow(),
+                'pokemon_uid': pokemon.id,
+                'pokemon_id': pokemon.pokemon_id,
+                'cp': member.motivated_pokemon.cp_when_deployed,
+                'trainer_name': pokemon.owner_name,
+                'num_upgrades': pokemon.num_upgrades,
+                'move_1': pokemon.move_1,
+                'move_2': pokemon.move_2,
+                'height': pokemon.height_m,
+                'weight': pokemon.weight_kg,
+                'stamina': pokemon.stamina,
+                'stamina_max': pokemon.stamina_max,
+                'cp_multiplier': pokemon.cp_multiplier,
+                'additional_cp_multiplier': pokemon.additional_cp_multiplier,
+                'iv_defense': pokemon.individual_defense,
+                'iv_stamina': pokemon.individual_stamina,
+                'iv_attack': pokemon.individual_attack,
+                'last_seen': datetime.utcnow(),
             }
 
             trainers[i] = {
-                'name': member['trainer_public_profile']['name'],
-                'team': member['trainer_public_profile']['team_color'],
-                'level': member['trainer_public_profile']['level'],
+                'name': member.trainer_public_profile.name,
+                'team': member.trainer_public_profile.team_color,
+                'level': member.trainer_public_profile.level,
                 'last_seen': datetime.utcnow(),
             }
 
@@ -2584,9 +2559,9 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 del wh_pokemon['last_seen']
                 wh_pokemon.update({
                     'cp_decayed':
-                        member['motivated_pokemon']['cp_now'],
+                        member.motivated_pokemon.cp_now,
                     'trainer_level':
-                        member['trainer_public_profile']['level'],
+                        member.trainer_public_profile.level,
                     'deployment_time': calendar.timegm(
                         gym_members[i]['deployment_time'].timetuple())
                 })

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1088,19 +1088,17 @@ def search_worker_thread(args, account_queue, account_sets,
                             # Make sure the gym was in range. (Sometimes the
                             # API gets cranky about gyms that are ALMOST 1km
                             # away.)
-                            if response:
-                                if response['responses'][
-                                        'GYM_GET_INFO']['result'] == 2:
-                                    log.warning(
-                                        ('Gym @ %f/%f is out of range (%dkm),'
-                                         + ' skipping.'),
-                                        gym['latitude'], gym['longitude'],
-                                        distance)
-                                else:
-                                    gym_responses[gym['gym_id']] = response[
-                                        'responses']['GYM_GET_INFO']
-                                del response
-
+                            if response['responses'][
+                                    'GYM_GET_INFO'].result == 2:
+                                log.warning(
+                                    ('Gym @ %f/%f is out of range (%dkm), ' +
+                                     'skipping.'),
+                                    gym['latitude'], gym['longitude'],
+                                    distance)
+                            else:
+                                gym_responses[gym['gym_id']] = response[
+                                    'responses']['GYM_GET_INFO']
+                            del response
                             # Increment which gym we're on for status messages.
                             current_gym += 1
 
@@ -1214,7 +1212,7 @@ def map_request(api, account, position, no_jitter=False):
         req.check_awarded_badges()
         req.get_buddy_walked()
         req.get_inbox(is_history=True)
-        response = req.call()
+        response = req.call(False)
         parse_new_timestamp_ms(account, response)
         response = clear_dict_response(response)
         return response
@@ -1247,7 +1245,7 @@ def gym_request(api, account, position, gym, api_version):
         req.check_awarded_badges()
         req.get_buddy_walked()
         req.get_inbox(is_history=True)
-        response = req.call()
+        response = req.call(False)
         parse_new_timestamp_ms(account, response)
         response = clear_dict_response(response)
         return response

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -955,8 +955,7 @@ def extract_sprites(root_path):
 
 
 def clear_dict_response(response):
-    if 'platform_returns' in response:
-        del response['platform_returns']
+    del response['envelope'].platform_returns[:]
     if 'responses' not in response:
         return response
     responses = [


### PR DESCRIPTION
## Description
This PR does avoid converting all response data from host, ~~to work needs a pgoapi PR (https://github.com/pogodevorg/pgoapi/pull/200) to be merged but after 2 weeks waiting without reply there I think that maybe posting this here could speed up review there.~~
API changes have been merged now so to test it you need to checkout this PR and then:
```
pip uninstall pgoapi
pip install --upgrade -r requirements.txt
```

## Motivation and Context
There is no gain in converting all objects to dicts and there are some issues:

- Wasted CPU time: Responses are converted to protobuf objects and then to dicts, also accessing dicts it is slower than accesing regular object attributes (even if O(1) there is no need of hashing and comparing the key before retrieval)
- Increase memory usage:  Dicts use more memory than regular objects as there is no need to store keys.
- Protobuf2dict has problems with falsy values: There are a lot of code that needs to check against this issue like gym checks in map parsing or empty lists, in the object the value is there the problem is within the conversion.

## How Has This Been Tested?
This code has been working for 3 weeks in my server, but I did not test -tut or encounters so I am almost sure that there is some error in that part as a lot of code needs to be converted and I have probable missed some lines.

## Screenshots (if appropriate):
Memory consumption of a -st 41 280 worker instance with develop (it is test instance):
![pokemap tlp - pokemad neoseo es_22 - bitvise xterm_2017-05-09_14-03-00](https://cloud.githubusercontent.com/assets/487098/25873110/707f5db4-350d-11e7-8bfe-1dfd890a7371.png)

Memory consumption of a -st 41 280 worker instance with this branch (it is test instance):
![pokemap tlp - pokemad neoseo es_22 - bitvise xterm_2017-05-09_18-19-17](https://cloud.githubusercontent.com/assets/487098/25873146/989d49dc-350d-11e7-9538-1653670a9e08.png)

I timed the time spent parsing the response of every request with develop and with this pr against the pgoapi PR (it is backwards compatible). Tested with an instance of -st 5 and 1 thread to reduce cpu load noise and context switching problems:

Develop:
![pokemap tlp - pokemad neoseo es_22 - bitvise xterm_2017-05-09_22-41-18](https://cloud.githubusercontent.com/assets/487098/25873118/7a21aec6-350d-11e7-9b9f-0128335f04db.png)

Protobuf:
![pokemap tlp - pokemad neoseo es_22 - bitvise xterm_2017-05-09_22-33-19](https://cloud.githubusercontent.com/assets/487098/25874173/b10e417a-3511-11e7-94ec-0acacd3aa385.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
