### PR TITLE
Support passwords in account csv files that contain a comma

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -461,31 +461,13 @@ def get_args():
         if args.accountcsv is not None:
             # Giving num_fields something it would usually not get.
             num_fields = -1
+            csv_input = []
+            csv_input.append('')
+            csv_input.append('<username>')
+            csv_input.append('<username>,<password>')
+            csv_input.append('<ptc/google>,<username>,<password>')
             with open(args.accountcsv, 'r') as f:
                 for num, line in enumerate(f, 1):
-
-                    fields = []
-
-                    # First time around populate num_fields with current field
-                    # count.
-                    if num_fields < 0:
-                        num_fields = line.count(',') + 1
-
-                    csv_input = []
-                    csv_input.append('')
-                    csv_input.append('<username>')
-                    csv_input.append('<username>,<password>')
-                    csv_input.append('<ptc/google>,<username>,<password>')
-
-                    # If the number of fields is differend this is not a CSV.
-                    if num_fields != line.count(',') + 1:
-                        print(sys.argv[0] +
-                              ": Error parsing CSV file on line " + str(num) +
-                              ". Your file started with the following " +
-                              "input, '" + csv_input[num_fields] +
-                              "' but now you gave us '" +
-                              csv_input[line.count(',') + 1] + "'.")
-                        sys.exit(1)
 
                     field_error = ''
                     line = line.strip()
@@ -494,11 +476,13 @@ def get_args():
                     if len(line) == 0 or line.startswith('#'):
                         continue
 
-                    # If number of fields is more than 1 split the line into
-                    # fields and strip them.
-                    if num_fields > 1:
-                        fields = line.split(",")
-                        fields = map(str.strip, fields)
+                    if (line.lower().startswith('ptc,') or
+                            line.lower().startswith('google,')):
+                        fields = line.split(',', 2)
+                    else:
+                        fields = line.split(',', 1)
+                    fields = map(str.strip, fields)
+                    num_fields = len(fields)
 
                     # If the number of fields is one then assume this is
                     # "username". As requested.
@@ -546,12 +530,6 @@ def get_args():
                             args.password.append(fields[2])
                         else:
                             field_error = 'password'
-
-                    if num_fields > 3:
-                        print(('Too many fields in accounts file: max ' +
-                               'supported are 3 fields. ' +
-                               'Found {} fields').format(num_fields))
-                        sys.exit(1)
 
                     # If something is wrong display error.
                     if field_error != '':
@@ -643,7 +621,7 @@ def get_args():
                     if not line.strip():
                         continue
 
-                    line = line.split(',')
+                    line = line.split(',', 2)
 
                     # We need "service, user, pass".
                     if len(line) < 3:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -459,8 +459,6 @@ def get_args():
         # CSV file should have lines like "ptc,username,password",
         # "username,password" or "username".
         if args.accountcsv is not None:
-            # Giving num_fields something it would usually not get.
-            num_fields = -1
             csv_input = []
             csv_input.append('')
             csv_input.append('<username>')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this pull request we support the usage of passwords that contain a comma in the account csv files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, when using account csv files with passwords that contain a comma, the parsing fails with an error.
Furthermore, when using high level account csv files with passwords that contain a comma, the passwords are read wrong, since the part starting with the comma is cut off.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on own instance with multiple passwords containing a comma.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
