### PR TITLE
Add Cries for better notifications

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -922,6 +922,10 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
+    'playCries': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
     'geoLocate': {
         default: false,
         type: StoreTypes.Boolean

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -363,6 +363,7 @@ function initSidebar() {
     $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
     $('#ranges-switch').prop('checked', Store.get('showRanges'))
     $('#sound-switch').prop('checked', Store.get('playSound'))
+    $('#cries-switch').prop('checked', Store.get('playCries'))
     var searchBox = new google.maps.places.Autocomplete(document.getElementById('next-location'))
     $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
 
@@ -764,8 +765,18 @@ function customizePokemonMarker(marker, item, skipNotification) {
 
     if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
         if (!skipNotification) {
-            if (Store.get('playSound')) {
+            if (Store.get('playSound') && !Store.get('playCries')) {
+                var audio = new Audio('static/sounds/ding.mp3')
                 audio.play()
+            } else if (Store.get('playSound') && Store.get('playCries')) {
+                var audio = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
+                audio.play().catch(function (err) {
+                    if (err) {
+                        console.log('sound for this pokemon is missing, using ding instead')
+                        var audio = new Audio('static/sounds/ding.mp3')
+                        audio.play()
+                    }
+                })
             }
             sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
         }
@@ -778,8 +789,18 @@ function customizePokemonMarker(marker, item, skipNotification) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
-                if (Store.get('playSound')) {
+                if (Store.get('playSound') && !Store.get('playCries')) {
+                    var audio = new Audio('static/sounds/ding.mp3')
                     audio.play()
+                } else if (Store.get('playSound') && Store.get('playCries')) {
+                    var audio = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
+                    audio.play().catch(function (err) {
+                        if (err) {
+                            console.log('sound for this pokemon is missing, using ding instead')
+                            var audio = new Audio('static/sounds/ding.mp3')
+                            audio.play()
+                        }
+                    })
                 }
                 sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
             }
@@ -2357,6 +2378,10 @@ $(function () {
 
     $('#sound-switch').change(function () {
         Store.set('playSound', this.checked)
+    })
+
+    $('#cries-switch').change(function () {
+        Store.set('playCries', this.checked)
     })
 
     $('#geoloc-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -766,11 +766,10 @@ function customizePokemonMarker(marker, item, skipNotification) {
     if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
         if (!skipNotification) {
             if (Store.get('playSound') && !Store.get('playCries')) {
-                var audio = new Audio('static/sounds/ding.mp3')
                 audio.play()
             } else if (Store.get('playSound') && Store.get('playCries')) {
-                var audio = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
-                audio.play().catch(function (err) {
+                var audiocry = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
+                audiocry.play().catch(function (err) {
                     if (err) {
                         console.log('sound for this pokemon is missing, using ding instead')
                         var audio = new Audio('static/sounds/ding.mp3')
@@ -790,14 +789,12 @@ function customizePokemonMarker(marker, item, skipNotification) {
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
             if (!skipNotification) {
                 if (Store.get('playSound') && !Store.get('playCries')) {
-                    var audio = new Audio('static/sounds/ding.mp3')
                     audio.play()
                 } else if (Store.get('playSound') && Store.get('playCries')) {
-                    var audio = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
-                    audio.play().catch(function (err) {
+                    var audiocryiv = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
+                    audiocryiv.play().catch(function (err) {
                         if (err) {
                             console.log('sound for this pokemon is missing, using ding instead')
-                            var audio = new Audio('static/sounds/ding.mp3')
                             audio.play()
                         }
                     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -749,7 +749,22 @@ function getNotifyText(item) {
     }
 }
 
+function playPokemonSound(pokemonID) {
+    var audioCry = new Audio('static/sounds/cries/' + pokemonID + '.wav')
+    if (Store.get('playSound') && !Store.get('playCries')) {
+        audio.play()
+    } else if (Store.get('playSound') && Store.get('playCries')) {
+        audioCry.play().catch(function (err) {
+            if (err) {
+                console.log('Sound for Pokémon ' + pokemonID + ' is missing, using generic sound instead.')
+                audio.play()
+            }
+        })
+    }
+}
+
 function customizePokemonMarker(marker, item, skipNotification) {
+    var notifyText = getNotifyText(item)
     marker.addListener('click', function () {
         this.setAnimation(null)
         this.animationDisabled = true
@@ -766,18 +781,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
 
     if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
         if (!skipNotification) {
-            if (Store.get('playSound') && !Store.get('playCries')) {
-                audio.play()
-            } else if (Store.get('playSound') && Store.get('playCries')) {
-                var audioCry = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
-                audioCry.play().catch(function (err) {
-                    if (err) {
-                        console.log('Sound for Pokémon ' + item['pokemon_id'] + ' is missing, using generic sound instead')
-                        audio.play()
-                    }
-                })
-            }
-            var notifyText = getNotifyText(item)
+            playPokemonSound(item['pokemon_id'])
             sendNotification(notifyText.fav_title, notifyText.fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
         }
         if (marker.animationDisabled !== true) {
@@ -788,17 +792,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
     if (item['individual_attack'] != null) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
-            if (!skipNotification) {
-                if (Store.get('playSound') && !Store.get('playCries')) {
-                    audio.play()
-                } else if (Store.get('playSound') && Store.get('playCries')) {
-                    audioCry.play().catch(function (err) {
-                        if (err) {
-                            console.log('Sound for Pokémon ' + item['pokemon_id'] + ' is missing, using generic sound instead')
-                            audio.play()
-                        }
-                    })
-                }
+                playPokemonSound(item['pokemon_id'])
                 sendNotification(notifyText.fav_title, notifyText.fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
             }
             if (marker.animationDisabled !== true) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -768,16 +768,16 @@ function customizePokemonMarker(marker, item, skipNotification) {
             if (Store.get('playSound') && !Store.get('playCries')) {
                 audio.play()
             } else if (Store.get('playSound') && Store.get('playCries')) {
-                var audiocry = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
-                audiocry.play().catch(function (err) {
+                var audioCry = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
+                audioCry.play().catch(function (err) {
                     if (err) {
-                        console.log('sound for this pokemon is missing, using ding instead')
-                        var audio = new Audio('static/sounds/ding.mp3')
+                        console.log('Sound for Pokémon ' + item['pokemon_id'] + ' is missing, using generic sound instead')
                         audio.play()
                     }
                 })
             }
-            sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+            var notifyText = getNotifyText(item)
+            sendNotification(notifyText.fav_title, notifyText.fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
         }
         if (marker.animationDisabled !== true) {
             marker.setAnimation(google.maps.Animation.BOUNCE)
@@ -791,15 +791,14 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 if (Store.get('playSound') && !Store.get('playCries')) {
                     audio.play()
                 } else if (Store.get('playSound') && Store.get('playCries')) {
-                    var audiocryiv = new Audio('static/sounds/cries/' + item['pokemon_id'] + '.wav')
-                    audiocryiv.play().catch(function (err) {
+                    audioCry.play().catch(function (err) {
                         if (err) {
-                            console.log('sound for this pokemon is missing, using ding instead')
+                            console.log('Sound for Pokémon ' + item['pokemon_id'] + ' is missing, using generic sound instead'))
                             audio.play()
                         }
                     })
                 }
-                sendNotification(getNotifyText(item).fav_title, getNotifyText(item).fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+                sendNotification(notifyText.fav_title, notifyText.fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
             }
             if (marker.animationDisabled !== true) {
                 marker.setAnimation(google.maps.Animation.BOUNCE)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -363,6 +363,7 @@ function initSidebar() {
     $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
     $('#ranges-switch').prop('checked', Store.get('showRanges'))
     $('#sound-switch').prop('checked', Store.get('playSound'))
+    $('#pokemoncries').toggle(Store.get('playSound'))
     $('#cries-switch').prop('checked', Store.get('playCries'))
     var searchBox = new google.maps.places.Autocomplete(document.getElementById('next-location'))
     $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
@@ -2374,6 +2375,12 @@ $(function () {
 
     $('#sound-switch').change(function () {
         Store.set('playSound', this.checked)
+        var criesWrapper = $('#pokemoncries')
+        if (this.checked) {
+            criesWrapper.show()
+        } else {
+            criesWrapper.hide()
+        }
     })
 
     $('#cries-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -792,6 +792,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
     if (item['individual_attack'] != null) {
         var perfection = getIv(item['individual_attack'], item['individual_defense'], item['individual_stamina'])
         if (notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection) {
+            if (!skipNotification) {
                 playPokemonSound(item['pokemon_id'])
                 sendNotification(notifyText.fav_title, notifyText.fav_text, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
             }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2370,11 +2370,14 @@ $(function () {
 
     $('#sound-switch').change(function () {
         Store.set('playSound', this.checked)
+        var options = {
+            'duration': 500
+        }
         var criesWrapper = $('#pokemoncries')
         if (this.checked) {
-            criesWrapper.show()
+            criesWrapper.show(options)
         } else {
-            criesWrapper.hide()
+            criesWrapper.hide(options)
         }
     })
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -755,7 +755,7 @@ function playPokemonSound(pokemonID) {
     } else {
         if (!Store.get('playCries')) {
             audio.play()
-        } else if (Store.get('playCries')) {
+        } else {
             var audioCry = new Audio('static/sounds/cries/' + pokemonID + '.wav')
             audioCry.play().catch(function (err) {
                 if (err) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -793,7 +793,7 @@ function customizePokemonMarker(marker, item, skipNotification) {
                 } else if (Store.get('playSound') && Store.get('playCries')) {
                     audioCry.play().catch(function (err) {
                         if (err) {
-                            console.log('Sound for Pokémon ' + item['pokemon_id'] + ' is missing, using generic sound instead'))
+                            console.log('Sound for Pokémon ' + item['pokemon_id'] + ' is missing, using generic sound instead')
                             audio.play()
                         }
                     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -750,16 +750,20 @@ function getNotifyText(item) {
 }
 
 function playPokemonSound(pokemonID) {
-    var audioCry = new Audio('static/sounds/cries/' + pokemonID + '.wav')
-    if (Store.get('playSound') && !Store.get('playCries')) {
-        audio.play()
-    } else if (Store.get('playSound') && Store.get('playCries')) {
-        audioCry.play().catch(function (err) {
-            if (err) {
-                console.log('Sound for Pokémon ' + pokemonID + ' is missing, using generic sound instead.')
-                audio.play()
-            }
-        })
+    if (!Store.get('playSound')) {
+        return
+    } else {
+        if (!Store.get('playCries')) {
+            audio.play()
+        } else if (Store.get('playCries')) {
+            var audioCry = new Audio('static/sounds/cries/' + pokemonID + '.wav')
+            audioCry.play().catch(function (err) {
+                if (err) {
+                    console.log('Sound for Pokémon ' + pokemonID + ' is missing, using generic sound instead.')
+                    audio.play()
+                }
+            })
+        }
     }
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -752,18 +752,17 @@ function getNotifyText(item) {
 function playPokemonSound(pokemonID) {
     if (!Store.get('playSound')) {
         return
+    }
+    if (!Store.get('playCries')) {
+        audio.play()
     } else {
-        if (!Store.get('playCries')) {
-            audio.play()
-        } else {
-            var audioCry = new Audio('static/sounds/cries/' + pokemonID + '.wav')
-            audioCry.play().catch(function (err) {
-                if (err) {
-                    console.log('Sound for Pokémon ' + pokemonID + ' is missing, using generic sound instead.')
-                    audio.play()
-                }
-            })
-        }
+        var audioCry = new Audio('static/sounds/cries/' + pokemonID + '.wav')
+        audioCry.play().catch(function (err) {
+            if (err) {
+                console.log('Sound for Pokémon ' + pokemonID + ' is missing, using generic sound instead.')
+                audio.play()
+            }
+        })
     }
 }
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -323,6 +323,14 @@
                 <span class="switch-label" data-on="On" data-off="Off"></span>
                 <span class="switch-handle"></span>
                 </label>
+              </div><br><br>
+              <h3>Use Cries</h3>
+              <div class="onoffswitch">
+                <input id="cries-switch" type="checkbox" name="cries-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="cries-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
               </div>
             </div>
           </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -326,14 +326,15 @@
               </div>
               <div id="pokemoncries" style="display:none">
               <h3>Use Pokémon cries</h3>
-              <div class="onoffswitch">
+                <div class="onoffswitch">
                 <input id="cries-switch" type="checkbox" name="cries-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="cries-switch">
                 <span class="switch-label" data-on="On" data-off="Off"></span>
                 <span class="switch-handle"></span>
                 </label>
+                </div>
               </div>
-            </div>
+             </div>
           </div>
             {% endif %}
           <h3>Style Settings</h3>

--- a/templates/map.html
+++ b/templates/map.html
@@ -323,8 +323,9 @@
                 <span class="switch-label" data-on="On" data-off="Off"></span>
                 <span class="switch-handle"></span>
                 </label>
-              </div><br><br>
-              <h3>Use Cries</h3>
+              </div>
+              <div id="pokemoncries" style="display:none">
+              <h3>Use Pokémon cries</h3>
               <div class="onoffswitch">
                 <input id="cries-switch" type="checkbox" name="cries-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="cries-switch">

--- a/templates/map.html
+++ b/templates/map.html
@@ -320,18 +320,18 @@
               <div class="onoffswitch">
                 <input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="sound-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
                 </label>
               </div><br><br>
               <div id="pokemoncries" style="display:none">
               <h3>Use Pokémon cries</h3>
                 <div class="onoffswitch">
                 <input id="cries-switch" type="checkbox" name="cries-switch" class="onoffswitch-checkbox" checked>
-                <label class="onoffswitch-label" for="cries-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
+                  <label class="onoffswitch-label" for="cries-switch">
+                    <span class="switch-label" data-on="On" data-off="Off"></span>
+                    <span class="switch-handle"></span>
+                  </label>
                 </div>
               </div>
              </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -323,7 +323,7 @@
                 <span class="switch-label" data-on="On" data-off="Off"></span>
                 <span class="switch-handle"></span>
                 </label>
-              </div>
+              </div><br><br>
               <div id="pokemoncries" style="display:none">
               <h3>Use Pokémon cries</h3>
                 <div class="onoffswitch">


### PR DESCRIPTION
This PR adds the ability to play cries (or other sounds) for notifications rather than the usual `ding`.
## Description
A switch for cries is added to the side bar to switch it on or off.
If you turn on cries but fail to put any in the folder it will revert to the `ding`
If a sound for a pokemon is not found it will play the normal `Ding`

Since cries are probably copywrite, I can not provide them but if you ask me on discord I can probably help you search.

The cries should be placed in static/sounds/cries/
they should be `pokemon id.wav` eg 1.wav for bulbasaur

## Motivation and Context
The map feels alive with the sound of anime voices

## How Has This Been Tested?
Tested on my map with anime voices

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
