### PR TITLE
Fix empty queue issue + set timeout for all requests

### DIFF
--- a/pogom/altitude.py
+++ b/pogom/altitude.py
@@ -17,7 +17,8 @@ def get_gmaps_altitude(lat, lng, gmaps_key):
         r_session = requests.Session()
         response = r_session.get((
             'https://maps.googleapis.com/maps/api/elevation/json?' +
-            'locations={},{}&key={}').format(lat, lng, gmaps_key))
+            'locations={},{}&key={}').format(lat, lng, gmaps_key),
+            timeout=5)
         response = response.json()
         status = response['status']
         results = response.get('results', [])

--- a/pogom/captcha.py
+++ b/pogom/captcha.py
@@ -303,7 +303,7 @@ def token_request(args, status, url):
             'http://2captcha.com/in.php?key={}&method=userrecaptcha' +
             '&googlekey={}&pageurl={}').format(args.captcha_key,
                                                args.captcha_dsk, url)
-        captcha_id = s.post(request_url).text.split('|')[1]
+        captcha_id = s.post(request_url, timeout=5).text.split('|')[1]
         captcha_id = str(captcha_id)
     # IndexError implies that the retuned response was a 2captcha error.
     except IndexError:
@@ -314,12 +314,12 @@ def token_request(args, status, url):
     # Get the response, retry every 5 seconds if it's not ready.
     recaptcha_response = s.get(
         'http://2captcha.com/res.php?key={}&action=get&id={}'.format(
-            args.captcha_key, captcha_id)).text
+            args.captcha_key, captcha_id), timeout=5).text
     while 'CAPCHA_NOT_READY' in recaptcha_response:
         log.info('Captcha token is not ready, retrying in 5 seconds...')
         time.sleep(5)
         recaptcha_response = s.get(
             'http://2captcha.com/res.php?key={}&action=get&id={}'.format(
-                args.captcha_key, captcha_id)).text
+                args.captcha_key, captcha_id), timeout=5).text
     token = str(recaptcha_response.split('|')[1])
     return token

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1298,7 +1298,7 @@ def get_api_version(args):
             'https://pgorelease.nianticlabs.com/plfe/version',
             proxies=proxies,
             verify=False,
-            timeout=10)
+            timeout=5)
 
         return r.text[2:] if (r.status_code == requests.codes.ok and
                               r.text[2:].count('.') == 2) else 0

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1299,6 +1299,7 @@ def get_api_version(args):
             proxies=proxies,
             verify=False,
             timeout=10)
+
         return r.text[2:] if (r.status_code == requests.codes.ok and
                               r.text[2:].count('.') == 2) else 0
     except Exception as e:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1297,7 +1297,8 @@ def get_api_version(args):
         r = s.get(
             'https://pgorelease.nianticlabs.com/plfe/version',
             proxies=proxies,
-            verify=False)
+            verify=False,
+            timeout=10)
         return r.text[2:] if (r.status_code == requests.codes.ok and
                               r.text[2:].count('.') == 2) else 0
     except Exception as e:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -863,7 +863,7 @@ def dottedQuadToNum(ip):
 def get_blacklist():
     try:
         url = 'https://blist.devkat.org/blacklist.json'
-        blacklist = requests.get(url).json()
+        blacklist = requests.get(url, timeout=5).json()
         log.debug('Entries in blacklist: %s.', len(blacklist))
         return blacklist
     except (requests.exceptions.RequestException, IndexError, KeyError):


### PR DESCRIPTION
## Description
This PR adds a 5s timeout to the API version check to fix the empty queue issue.
In some rare cases with some bad proxies the API version check might hang there forever and blocks all search queue updates. Therefore after some time the queue runs out of items and your instance stops scanning.

Furthermore it adds a 5s to all GET and POST requests.

## Motivation and Context
running without a version check wasn't the best solution for me ;)

## How Has This Been Tested?
my map + a map from another discord user

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.