### PR TITLE
API watchdog improvements

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1304,7 +1304,7 @@ def get_api_version(args):
         s = requests.Session()
         s.mount('https://',
                 HTTPAdapter(max_retries=Retry(total=3,
-                                              backoff_factor=0.1,
+                                              backoff_factor=0.4,
                                               status_forcelist=[500, 502,
                                                                 503, 504])))
         r = s.get(

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -493,7 +493,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
     while True:
 
         odt_triggered = (args.on_demand_timeout > 0 and
-                        (now() - args.on_demand_timeout) > heartb[0])
+                         (now() - args.on_demand_timeout) > heartb[0])
         if odt_triggered:
             pause_bit.set()
             log.info('Searching paused due to inactivity...')
@@ -1269,7 +1269,7 @@ def check_forced_version(args, api_version, api_check_time, pause_bit,
         forced_api = get_api_version(args)
 
         if not forced_api:
-            # Couldn't retrieve API version. Stop scanning.
+            # Couldn't retrieve API version. Pause scanning.
             pause_bit.set()
             log.warning('Forced API check got no or invalid response. ' +
                         'Possible bad proxy.')
@@ -1279,15 +1279,13 @@ def check_forced_version(args, api_version, api_check_time, pause_bit,
         # Got a response let's compare version numbers.
         try:
             if StrictVersion(api_version) < StrictVersion(forced_api):
-                # Installed API version is lower. Stop scanning.
+                # Installed API version is lower. Pause scanning.
                 pause_bit.set()
                 log.warning('Started with API: %s, ' +
                             'Niantic forced to API: %s',
                             api_version,
                             forced_api)
                 log.warning('Scanner paused due to forced Niantic API update.')
-                log.warning('Stop the scanner process until RocketMap ' +
-                            'has updated.')
             else:
                 # API check was successful and
                 # installed API version is newer or equal forced API.
@@ -1296,15 +1294,13 @@ def check_forced_version(args, api_version, api_check_time, pause_bit,
                     pause_bit.clear()
 
         except ValueError as e:
-            # Unknown version format. Stop scanning as well.
+            # Unknown version format. Pause scanning as well.
             pause_bit.set()
             log.warning('Niantic forced unknown API version format: %s',
                         forced_api)
             log.warning('Scanner paused due to unknown API version format.')
-            log.warning('Stop the scanner process until RocketMap ' +
-                        'has updated.')
         except Exception as e:
-            # Something else happened. Stop scanning as well.
+            # Something else happened. Pause scanning as well.
             pause_bit.set()
             log.warning('Unknown error on API version comparison: %s', repr(e))
             log.warning('Scanner paused due to unknown API check error.')

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1267,20 +1267,20 @@ def check_forced_version(args, api_version, api_check_time, pause_bit):
 
         try:
             if StrictVersion(api_version) < StrictVersion(forced_api):
+                # Installed api version is lower. Stop scanning.
                 pause_bit.set()
-                log.warning(('Started with API: {}, ' +
-                          'Niantic forced to API: {}').format(
+                log.warning('Started with API: %s, ' +
+                            'Niantic forced to API: %s',
                     api_version,
-                    forced_api))
+                    forced_api)
                 log.warning('Scanner paused due to forced Niantic API update.')
                 log.warning('Stop the scanner process until RocketMap ' +
                          'has updated.')
         except ValueError as e:
-            # unknown version format. Stop scanning as well.
+            # Unknown version format. Stop scanning as well.
             pause_bit.set()
-            log.warning(
-                ('Niantic forced unknown API version format: {}').format(
-                forced_api))
+            log.warning('Niantic forced unknown API version format: %s',
+                forced_api)
             log.warning('Scanner paused due to unknown API version format.')
             log.warning('Stop the scanner process until RocketMap ' +
                          'has updated.')
@@ -1314,5 +1314,5 @@ def get_api_version(args):
         return r.text[2:] if r.status_code == requests.codes.ok else '0.0'
     except Exception as e:
         log.warning('error on API check: %s', repr(e))
-        # do not stop scanning because check failed.
+        # Do not stop scanning because check failed.
         return '0.0'

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1268,12 +1268,12 @@ def check_forced_version(args, api_version, api_check_time, pause_bit):
         try:
             if StrictVersion(api_version) < StrictVersion(forced_api):
                 pause_bit.set()
-                log.info(('Started with API: {}, ' +
+                log.warning(('Started with API: {}, ' +
                           'Niantic forced to API: {}').format(
                     api_version,
                     forced_api))
-                log.info('Scanner paused due to forced Niantic API update.')
-                log.info('Stop the scanner process until RocketMap ' +
+                log.warning('Scanner paused due to forced Niantic API update.')
+                log.warning('Stop the scanner process until RocketMap ' +
                          'has updated.')
         except ValueError as e:
             # unknown version format. Stop scanning as well.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1296,13 +1296,14 @@ def check_forced_version(args, api_version, api_check_time, pause_bit,
         except ValueError as e:
             # Unknown version format. Pause scanning as well.
             pause_bit.set()
-            log.warning('Niantic forced unknown API version format: %s',
+            log.warning('Niantic forced unknown API version format: %s.',
                         forced_api)
             log.warning('Scanner paused due to unknown API version format.')
         except Exception as e:
             # Something else happened. Pause scanning as well.
             pause_bit.set()
-            log.warning('Unknown error on API version comparison: %s', repr(e))
+            log.warning('Unknown error on API version comparison: %s.',
+                        repr(e))
             log.warning('Scanner paused due to unknown API check error.')
 
     return api_check_time
@@ -1315,7 +1316,7 @@ def get_api_version(args):
         args: Command line arguments
 
     Returns:
-        API version string. None if request failed.
+        API version string. False if request failed.
     """
     proxies = {}
 
@@ -1330,14 +1331,14 @@ def get_api_version(args):
         s = requests.Session()
         s.mount('https://',
                 HTTPAdapter(max_retries=Retry(total=3,
-                                              backoff_factor=0.4,
+                                              backoff_factor=0.5,
                                               status_forcelist=[500, 502,
                                                                 503, 504])))
         r = s.get(
             'https://pgorelease.nianticlabs.com/plfe/version',
             proxies=proxies,
             verify=False)
-        return r.text[2:] if r.status_code == requests.codes.ok else None
+        return r.text[2:] if r.status_code == requests.codes.ok else False
     except Exception as e:
         log.warning('error on API check: %s', repr(e))
-        return None
+        return False

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1276,9 +1276,14 @@ def check_forced_version(args, api_version, api_check_time, pause_bit):
                 log.info('Stop the scanner process until RocketMap ' +
                          'has updated.')
         except ValueError as e:
+            # unknown version format. Stop scanning as well.
+            pause_bit.set()
             log.warning(
-                'API check returned invalid version number: %s',
-                forced_api)
+                ('Niantic forced unknown API version format: {}').format(
+                forced_api))
+            log.warning('Scanner paused due to unknown API version format.')
+            log.warning('Stop the scanner process until RocketMap ' +
+                         'has updated.')
         except Exception as e:
             log.warning('Unknown error on API version comparison: %s', repr(e))
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1271,19 +1271,19 @@ def check_forced_version(args, api_version, api_check_time, pause_bit):
                 pause_bit.set()
                 log.warning('Started with API: %s, ' +
                             'Niantic forced to API: %s',
-                    api_version,
-                    forced_api)
+                            api_version,
+                            forced_api)
                 log.warning('Scanner paused due to forced Niantic API update.')
                 log.warning('Stop the scanner process until RocketMap ' +
-                         'has updated.')
+                            'has updated.')
         except ValueError as e:
             # Unknown version format. Stop scanning as well.
             pause_bit.set()
             log.warning('Niantic forced unknown API version format: %s',
-                forced_api)
+                        forced_api)
             log.warning('Scanner paused due to unknown API version format.')
             log.warning('Stop the scanner process until RocketMap ' +
-                         'has updated.')
+                        'has updated.')
         except Exception as e:
             log.warning('Unknown error on API version comparison: %s', repr(e))
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1265,8 +1265,7 @@ def check_forced_version(args, api_version, api_check_time, pause_bit):
         api_check_time = int(time.time()) + args.version_check_interval
         forced_api = get_api_version(args)
 
-        if (StrictVersion(api_version) < StrictVersion(forced_api)
-                and forced_api != 0):
+        if StrictVersion(api_version) < StrictVersion(forced_api):
             pause_bit.set()
             log.info(('Started with API: {}, ' +
                       'Niantic forced to API: {}').format(
@@ -1301,7 +1300,7 @@ def get_api_version(args):
             proxies=proxies,
             verify=False)
         return r.text[2:] if (r.status_code == requests.codes.ok and
-                              r.text[2:].count('.') == 2) else 0
+                              r.text[2:].count('.') == 2) else '0.0'
     except Exception as e:
         log.warning('error on API check: %s', repr(e))
-        return 0
+        return '0.0'


### PR DESCRIPTION
## Description
Improving and fixing quick fix PR #2036
- [fix] exception if version check failed and returned int(0)
- [new] StrictVersion will handle the version format verification now
- [new] pause scanner if returned api version format is invalid
- [new] pause scanner if api version request failed
- [new] clear pause_bit (continue scanning) if the version check is successful again (api_version >= forced_version)
- [new] log messages are warning now instead of info
- improve log message syntax (don't use .format())

## Motivation and Context
- last PR was rushed and not 100% perfect
- found some "issues" with current watchdog logic

## How Has This Been Tested?
yes with various fake version numbers, see comments below
and with some bad proxies this time ;)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.