### PR TITLE
Adjust Pokemon default details

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1925,13 +1925,12 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             disappear_time = now_date + \
                 timedelta(seconds=seconds_until_despawn)
 
-            printPokemon(p['pokemon_data']['pokemon_id'], p[
-                         'latitude'], p['longitude'], disappear_time)
+            pokemon_id = p['pokemon_data']['pokemon_id']
+            printPokemon(pokemon_id, p['latitude'], p['longitude'],
+                         disappear_time)
 
             # Scan for IVs/CP and moves.
-            pokemon_id = p['pokemon_data']['pokemon_id']
             encounter_result = None
-
             if args.encounter and (pokemon_id in args.enc_whitelist):
                 time.sleep(args.encounter_delay)
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2056,7 +2056,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             pokemon[p['encounter_id']] = {
                 'encounter_id': b64encode(str(p['encounter_id'])),
                 'spawnpoint_id': p['spawn_point_id'],
-                'pokemon_id': p['pokemon_data']['pokemon_id'],
+                'pokemon_id': pokemon_id,
                 'latitude': p['latitude'],
                 'longitude': p['longitude'],
                 'disappear_time': disappear_time,
@@ -2068,9 +2068,14 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'cp': None,
                 'height': None,
                 'weight': None,
-                'gender': None,
+                'gender': p['pokemon_data']['pokemon_display']['gender'],
                 'form': None
             }
+
+            # Check for Unown's alphabetic character.
+            if pokemon_id == 201:
+                pokemon[p['encounter_id']]['form'] = p['pokemon_data'][
+                    'pokemon_display'].get('form', None)
 
             if (encounter_result is not None and 'wild_pokemon'
                     in encounter_result['responses']['ENCOUNTER']):
@@ -2102,21 +2107,14 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'move_1': pokemon_info['move_1'],
                     'move_2': pokemon_info['move_2'],
                     'height': pokemon_info['height_m'],
-                    'weight': pokemon_info['weight_kg'],
-                    'gender': pokemon_info['pokemon_display']['gender']
+                    'weight': pokemon_info['weight_kg']
                 })
 
                 # Only add CP if we're level 30+.
                 if encounter_level >= 30:
                     pokemon[p['encounter_id']]['cp'] = cp
 
-                # Check for Unown's alphabetic character.
-                if pokemon_info['pokemon_id'] == 201:
-                    pokemon[p['encounter_id']]['form'] = pokemon_info[
-                        'pokemon_display'].get('form', None)
-
             if args.webhooks:
-                pokemon_id = p['pokemon_data']['pokemon_id']
                 if (pokemon_id in args.webhook_whitelist or
                     (not args.webhook_whitelist and pokemon_id
                      not in args.webhook_blacklist)):

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -454,12 +454,17 @@ function pokemonLabel(item) {
             </div>
             `
     }
-    if (gender !== null && weight !== null && height !== null) {
+    if (gender !== null) {
         details += `
             <div>
-                Gender: ${genderType[gender - 1]} | Weight: ${weight.toFixed(2)}kg | Height: ${height.toFixed(2)}m
-            </div>
+                Gender: ${genderType[gender - 1]}
             `
+        if (weight !== null && height !== null) {
+            details += `| Weight: ${weight.toFixed(2)}kg | Height: ${height.toFixed(2)}m`
+        }
+        details += `
+                </div>
+                `
     }
     var contentstring = `
         <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Making available information available without encountering.

## Description
<!--- Describe your changes in detail -->
The API currently sends ``gender`` as well as Unown's ``form`` inside the ``pokemon_display`` list even when the Pokémon is not encountered. (Even when just seen in ``nearby`` and not in ``wild_pokemon`` but we do not parse ``nearby``, yet)
This PR parses the information, which is already available, instead of limiting it to encountered Pokémon. The front-end was changed accordingly so that Gender is displayed even when no height/weight is known, which contrarily needs an encounter.
Additional small fix by using ``pokemon_id`` variable instead accessing the dict again for it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Show what is retrievable, why not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my local setup.

## Screenshots
*Location has been cropped out by intent.*

<img width="286" alt="bildschirmfoto 2017-05-15 um 18 31 13" src="https://cloud.githubusercontent.com/assets/22680515/26068143/d4922d3e-399c-11e7-924f-2f0e03309bde.png">

<img width="283" alt="bildschirmfoto 2017-05-15 um 18 31 07" src="https://cloud.githubusercontent.com/assets/22680515/26068148/d7d5b858-399c-11e7-9e95-a1dcb4953b10.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
