### PR TITLE
Continue to check API version if scanning is paused

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -503,11 +503,10 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
             for i in range(0, len(scheduler_array)):
                 scheduler_array[i].scanning_paused()
             # API Watchdog - Continue to check API version.
-            if not args.no_version_check:
+            if not args.no_version_check and not odt_triggered:
                 api_check_time = check_forced_version(args, api_version,
                                                       api_check_time,
-                                                      pause_bit,
-                                                      odt_triggered)
+                                                      pause_bit)
             time.sleep(1)
 
         # If a new location has been passed to us, get the most recent one.
@@ -581,10 +580,9 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
                              scheduler_array[0])
 
         # API Watchdog - Check if Niantic forces a new API.
-        if not args.no_version_check:
+        if not args.no_version_check and not odt_triggered:
             api_check_time = check_forced_version(args, api_version,
-                                                  api_check_time, pause_bit,
-                                                  odt_triggered)
+                                                  api_check_time, pause_bit)
 
         # Now we just give a little pause here.
         time.sleep(1)
@@ -1268,10 +1266,9 @@ def stat_delta(current_status, last_status, stat_name):
     return current_status.get(stat_name, 0) - last_status.get(stat_name, 0)
 
 
-def check_forced_version(args, api_version, api_check_time, pause_bit,
-                         odt_triggered):
+def check_forced_version(args, api_version, api_check_time, pause_bit):
     if int(time.time()) > api_check_time:
-        log.debug("Checking forced API version")
+        log.debug("Checking forced API version.")
         api_check_time = int(time.time()) + args.version_check_interval
         forced_api = get_api_version(args)
 
@@ -1296,10 +1293,9 @@ def check_forced_version(args, api_version, api_check_time, pause_bit,
             else:
                 # API check was successful and
                 # installed API version is newer or equal forced API.
-                # Continue scanning if on_demand_timout isn't triggered.
-                if not odt_triggered:
-                    log.debug("API check was successful. Continue scanning.")
-                    pause_bit.clear()
+                # Continue scanning.
+                log.debug("API check was successful. Continue scanning.")
+                pause_bit.clear()
 
         except ValueError as e:
             # Unknown version format. Pause scanning as well.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -502,6 +502,12 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         while pause_bit.is_set():
             for i in range(0, len(scheduler_array)):
                 scheduler_array[i].scanning_paused()
+            # API Watchdog - Continue to check API version.
+            if not args.no_version_check:
+                api_check_time = check_forced_version(args, api_version,
+                                                      api_check_time,
+                                                      pause_bit,
+                                                      odt_triggered)
             time.sleep(1)
 
         # If a new location has been passed to us, get the most recent one.
@@ -1265,6 +1271,7 @@ def stat_delta(current_status, last_status, stat_name):
 def check_forced_version(args, api_version, api_check_time, pause_bit,
                          odt_triggered):
     if int(time.time()) > api_check_time:
+        log.debug("Checking forced API version")
         api_check_time = int(time.time()) + args.version_check_interval
         forced_api = get_api_version(args)
 
@@ -1291,6 +1298,7 @@ def check_forced_version(args, api_version, api_check_time, pause_bit,
                 # installed API version is newer or equal forced API.
                 # Continue scanning if on_demand_timout isn't triggered.
                 if not odt_triggered:
+                    log.debug("API check was successful. Continue scanning.")
                     pause_bit.clear()
 
         except ValueError as e:


### PR DESCRIPTION
## Description
- continue to check API version if scanning is paused (fix #2047)
- Don't check API version if on-demand-timeout is triggered and scanning is paused anyways (cosmetic change)

## Motivation and Context
All good things come by threes.

## How Has This Been Tested?
with a bunch of bad proxies.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.