### PR TITLE
Stop using Denver as default location for accounts

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -180,3 +180,6 @@
 #version-check-interval:        # Interval to check API version in seconds (Default: in range [60, 300]).
 #mock:                          # Mock mode - point to a fpgo endpoint instead of using the real PogoApi,
                                 # ec: http://127.0.0.1:9090 (default='')
+#account-country:               # Country code used for API on all accounts (default: US)
+#account-language:              # Language code used for API on all accounts (default: en)
+#account-timezone:              # Timezone code used for API on all accounts  (default: America/Denver)

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -180,6 +180,3 @@
 #version-check-interval:        # Interval to check API version in seconds (Default: in range [60, 300]).
 #mock:                          # Mock mode - point to a fpgo endpoint instead of using the real PogoApi,
                                 # ec: http://127.0.0.1:9090 (default='')
-#account-country:               # Country code used for API on all accounts (default: US)
-#account-language:              # Language code used for API on all accounts (default: en)
-#account-timezone:              # Timezone code used for API on all accounts  (default: America/Denver)

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -103,14 +103,17 @@ def check_login(args, account, api, position, proxy_url):
 
 # Check if all important tutorial steps have been completed.
 # API argument needs to be a logged in API instance.
-def get_tutorial_state(api, account):
+def get_tutorial_state(args, api, account):
     log.debug('Checking tutorial state for %s.', account['username'])
     request = api.create_request()
+    print {
+        'country': args.account_country,
+        'language': args.account_language,
+        'timezone': args.account_timezone}
     request.get_player(
-        player_locale={'country': 'US',
-                       'language': 'en',
-                       'timezone': 'America/Denver'})
-
+        player_locale={'country': args.account_country,
+                       'language': args.account_language,
+                       'timezone': args.account_timezone})
     response = request.call().get('responses', {})
 
     get_player = response.get('GET_PLAYER', {})
@@ -123,7 +126,7 @@ def get_tutorial_state(api, account):
 # Complete minimal tutorial steps.
 # API argument needs to be a logged in API instance.
 # TODO: Check if game client bundles these requests, or does them separately.
-def complete_tutorial(api, account, tutorial_state):
+def complete_tutorial(args, api, account, tutorial_state):
     if 0 not in tutorial_state:
         time.sleep(random.uniform(1, 5))
         request = api.create_request()
@@ -186,9 +189,9 @@ def complete_tutorial(api, account, tutorial_state):
         request = api.create_request()
         request.get_player(
             player_locale={
-                'country': 'US',
-                'language': 'en',
-                'timezone': 'America/Denver'})
+                'country': args.account_country,
+                'language': args.account_language,
+                'timezone': args.account_timezone})
         responses = request.call().get('responses', {})
 
         inventory = responses.get('GET_INVENTORY', {}).get(
@@ -215,9 +218,9 @@ def complete_tutorial(api, account, tutorial_state):
         request = api.create_request()
         request.get_player(
             player_locale={
-                'country': 'US',
-                'language': 'en',
-                'timezone': 'America/Denver'})
+                'country': args.account_country,
+                'language': args.account_language,
+                'timezone': args.account_timezone})
         request.call()
 
     if 7 not in tutorial_state:

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -106,10 +106,6 @@ def check_login(args, account, api, position, proxy_url):
 def get_tutorial_state(args, api, account):
     log.debug('Checking tutorial state for %s.', account['username'])
     request = api.create_request()
-    print {
-        'country': args.account_country,
-        'language': args.account_language,
-        'timezone': args.account_timezone}
     request.get_player(
         player_locale={'country': args.account_country,
                        'language': args.account_language,

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -107,9 +107,7 @@ def get_tutorial_state(args, api, account):
     log.debug('Checking tutorial state for %s.', account['username'])
     request = api.create_request()
     request.get_player(
-        player_locale={'country': args.account_country,
-                       'language': args.account_language,
-                       'timezone': args.account_timezone})
+        player_locale=args.player_locale)
     response = request.call().get('responses', {})
 
     get_player = response.get('GET_PLAYER', {})
@@ -184,10 +182,7 @@ def complete_tutorial(args, api, account, tutorial_state):
         time.sleep(random.uniform(0.5, 0.6))
         request = api.create_request()
         request.get_player(
-            player_locale={
-                'country': args.account_country,
-                'language': args.account_language,
-                'timezone': args.account_timezone})
+            player_locale=args.player_locale)
         responses = request.call().get('responses', {})
 
         inventory = responses.get('GET_INVENTORY', {}).get(
@@ -213,10 +208,7 @@ def complete_tutorial(args, api, account, tutorial_state):
         time.sleep(0.1)
         request = api.create_request()
         request.get_player(
-            player_locale={
-                'country': args.account_country,
-                'language': args.account_language,
-                'timezone': args.account_timezone})
+            player_locale=args.player_locale)
         request.call()
 
     if 7 not in tutorial_state:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -940,13 +940,14 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
 
                     # Check tutorial completion.
                     if args.complete_tutorial:
-                        tutorial_state = get_tutorial_state(api, account)
+                        tutorial_state = get_tutorial_state(args, api, account)
 
                         if not all(x in tutorial_state
                                    for x in (0, 1, 3, 4, 7)):
                             log.info('Completing tutorial steps for %s.',
                                      account['username'])
-                            complete_tutorial(api, account, tutorial_state)
+                            complete_tutorial(args, api, account,
+                                              tutorial_state)
                         else:
                             log.info('Account %s already completed tutorial.',
                                      account['username'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -957,6 +957,7 @@ def calc_pokemon_level(cp_multiplier):
     return pokemon_level
 
 
+@memoize
 def gmaps_reverse_geolocate(gmaps_key, locale, location):
     # Find the reverse geolocation
     geolocator = GoogleV3(api_key=gmaps_key)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -15,6 +15,7 @@ import zipfile
 import requests
 from uuid import uuid4
 from s2sphere import CellId, LatLng
+from geopy.geocoders import GoogleV3
 
 from . import config
 
@@ -954,3 +955,36 @@ def calc_pokemon_level(cp_multiplier):
         pokemon_level = 171.0112688 * cp_multiplier - 95.20425243
     pokemon_level = int((round(pokemon_level) * 2) / 2)
     return pokemon_level
+
+
+def gmaps_reverse_geolocate(gmaps_key, locale, location):
+    # Find the reverse geolocation
+    geolocator = GoogleV3(api_key=gmaps_key)
+
+    player_locale = {
+        'country': 'US',
+        'language': locale,
+        'timezone': 'America/Denver'
+    }
+
+    try:
+        location = geolocator.reverse(location)
+        country_code = location[-1].raw['address_components'][-1]['short_name']
+
+        try:
+            timezone = geolocator.timezone(location)
+            player_locale.update({
+                'country': country_code,
+                'timezone': str(timezone)
+            })
+        except Exception as e:
+            log.exception('Exception on Google Timezone API. '
+                          + 'Please check that you have Google Timezone API'
+                          + 'enabled for your API key '
+                          + '(https://developers.google.com/maps/documentation'
+                          + '/timezone/intro): %s.', e)
+    except Exception as e:
+        log.exception('Exception while obtaining player locale: %s.'
+                      + ' Using default locale.', e)
+
+    return player_locale

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -969,8 +969,8 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
     }
 
     try:
-        location = geolocator.reverse(location)
-        country_code = location[-1].raw['address_components'][-1]['short_name']
+        reverse = geolocator.reverse(location)
+        country_code = reverse[-1].raw['address_components'][-1]['short_name']
 
         try:
             timezone = geolocator.timezone(location)
@@ -981,9 +981,9 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
         except Exception as e:
             log.exception('Exception on Google Timezone API. '
                           + 'Please check that you have Google Timezone API'
-                          + 'enabled for your API key '
-                          + '(https://developers.google.com/maps/documentation'
-                          + '/timezone/intro): %s.', e)
+                          + ' enabled for your API key'
+                          + ' (https://developers.google.com/maps/'
+                          + 'documentation/timezone/intro): %s.', e)
     except Exception as e:
         log.exception('Exception while obtaining player locale: %s.'
                       + ' Using default locale.', e)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -53,6 +53,18 @@ def get_args():
         auto_env_var_prefix='POGOMAP_')
     parser.add_argument('-cf', '--config',
                         is_config_file=True, help='Set configuration file')
+    parser.add_argument('-acc', '--account-country',
+                        default='US',
+                        help=('Country code used for API on all accounts ' +
+                              '(default: US)'))
+    parser.add_argument('-acl', '--account-language',
+                        default='en',
+                        help=('Language code used for API on all accounts ' +
+                              '(default: en)'))
+    parser.add_argument('-act', '--account-timezone',
+                        default='America/Denver',
+                        help=('Timezone code used for API on all accounts ' +
+                              '(default: America/Denver)'))
     parser.add_argument('-a', '--auth-service', type=str.lower,
                         action='append', default=[],
                         help=('Auth Services, either one for all accounts ' +

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -53,18 +53,6 @@ def get_args():
         auto_env_var_prefix='POGOMAP_')
     parser.add_argument('-cf', '--config',
                         is_config_file=True, help='Set configuration file')
-    parser.add_argument('-acc', '--account-country',
-                        default='US',
-                        help=('Country code used for API on all accounts ' +
-                              '(default: US)'))
-    parser.add_argument('-acl', '--account-language',
-                        default='en',
-                        help=('Language code used for API on all accounts ' +
-                              '(default: en)'))
-    parser.add_argument('-act', '--account-timezone',
-                        default='America/Denver',
-                        help=('Timezone code used for API on all accounts ' +
-                              '(default: America/Denver)'))
     parser.add_argument('-a', '--auth-service', type=str.lower,
                         action='append', default=[],
                         help=('Auth Services, either one for all accounts ' +

--- a/runserver.py
+++ b/runserver.py
@@ -307,7 +307,7 @@ def main():
         args.player_locale = gmaps_reverse_geolocate(
             args.gmaps_key,
             args.locale,
-            position[1] + ', ' + position[2])
+            position[0] + ', ' + position[1])
 
         # Gather the Pokemon!
 

--- a/runserver.py
+++ b/runserver.py
@@ -307,7 +307,7 @@ def main():
         args.player_locale = gmaps_reverse_geolocate(
             args.gmaps_key,
             args.locale,
-            position[0] + ', ' + position[1])
+            str(position[0]) + ', ' + str(position[1]))
 
         # Gather the Pokemon!
 

--- a/runserver.py
+++ b/runserver.py
@@ -307,7 +307,7 @@ def main():
         args.player_locale = gmaps_reverse_geolocate(
             args.gmaps_key,
             args.locale,
-            args.location)
+            position[1] + ', ' + position[2])
 
         # Gather the Pokemon!
 

--- a/runserver.py
+++ b/runserver.py
@@ -317,12 +317,12 @@ def main():
             try:
                 timezone = geolocator.timezone(args.location)
                 args.player_locale.update({
-                    'timezone': str(timezone),
-                    'country': country
+                    'country': country,
+                    'timezone': str(timezone)
                 })
             except Exception as e:
-                log.warning('Exception while obtaining Google Timezone, ' +
-                            'key not enabled: %s.', repr(e))
+                log.warning('Exception while obtaining Google Timezone. ' +
+                            'Key probably not enabled: %s.', repr(e))
                 pass
         except Exception as e:
             log.warning('Exception while obtaining player locale: %s.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With a proper API simulation, we want to submit a valid player location for our scanned locations.
Side-change: Encoded the ``config.ini.example`` to proper line-endings via unix LF UTF-8

## Description
<!--- Describe your changes in detail -->
Instead of passing a constant location for get_player API-Request, we now define a soft-coded one by defaulting it to current default and altering it afterwards according to geopy GoogleV3 reverse geolocation.
While ``country`` and ``timezone`` is somewhat specific to the scan location, ``language`` is not. So this remains at the default ``en`` if not the flag ``--locale`` is adjusted in the config.
Make sure you enable the Google timezone API on your already used API-Key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the aim of a better app emulation of requests, this provides at least a valid get_player request.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local test setup with my own API-Key
This might need testing in not-obvious locations, since we do not know if any possible combination is regarded as valid from PoGO.

## Screenshots (if appropriate):
```
{'country': 'US', 'language': 'en', 'timezone': 'America/Denver'}
```
```
{'country': u'DE', 'language': 'de', 'timezone': 'Europe/Berlin'}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
