### PR TITLE
Fix scanned location range in UI when no-pokemon is True

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "Store": true,
     "centerLat": true,
     "centerLng": true,
+	"showConfig": true,	
     "pageLoaded": true,
     "countMarkers": true,
     "skel": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
     "Store": true,
     "centerLat": true,
     "centerLng": true,
-	"showConfig": true,	
+    "showConfig": true,	
     "pageLoaded": true,
     "countMarkers": true,
     "skel": true,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -948,13 +948,13 @@ function setupScannedMarker(item) {
         map: map,
         clickable: false,
         center: circleCenter,
-        radius: 70, // metres
+        radius: (showConfig.pokemons === true ? 70 : 450), // metres
         fillColor: getColorByDate(item['last_modified']),
         fillOpacity: 0.1,
         strokeWeight: 1,
         strokeOpacity: 0.5
     })
-
+    
     return marker
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -954,7 +954,7 @@ function setupScannedMarker(item) {
         strokeWeight: 1,
         strokeOpacity: 0.5
     })
-    
+
     return marker
 }
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -422,7 +422,7 @@
     <script>
       var centerLat = {{lat}};
       var centerLng = {{lng}};
-	  var showConfig = {{show|tojson|safe}};	  
+      var showConfig = {{show|tojson|safe}};	  
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>

--- a/templates/map.html
+++ b/templates/map.html
@@ -422,6 +422,7 @@
     <script>
       var centerLat = {{lat}};
       var centerLng = {{lng}};
+	  var showConfig = {{show|tojson|safe}};	  
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We now pass all show configuration to map.js and choose the scanned location range with that information.

## Motivation and Context
Currently the visual information of scanned location in maps with no-pokemons is wrong and it is not easy to see if a gym or pokestop is in one or another scan location

## How Has This Been Tested?
Tested in local instance

## Screenshots (if appropriate):
Before:
![rocket map_2017-05-29_08-50-16](https://cloud.githubusercontent.com/assets/487098/26539349/4a677366-444c-11e7-9674-cfe99e90831e.png)

After:
![rocket map_2017-05-29_08-14-24](https://cloud.githubusercontent.com/assets/487098/26539354/53f053da-444c-11e7-8a45-dafa8f0ab249.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
