### PR TITLE
device_info

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -22,12 +22,13 @@ class TooManyLoginAttempts(Exception):
 
 
 # Create the API object that'll be used to scan.
-def setup_api(args, status):
+def setup_api(args, status, device_info):
     # Create the API instance this will use.
     if args.mock != '':
         api = FakePogoApi(args.mock)
     else:
-        device_info = generate_device_info()
+        if device_info.get('device_id', None) is None:
+            device_info.update(generate_device_info())
         api = PGoApi(device_info=device_info)
 
     # New account - new proxy.
@@ -50,7 +51,8 @@ def setup_api(args, status):
             'http': status['proxy_url'],
             'https': status['proxy_url']})
 
-    return api
+    #return api
+    return api, device_info
 
 
 # Use API to check the login status, and retry the login if possible.

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -51,7 +51,7 @@ def setup_api(args, status, device_info):
             'http': status['proxy_url'],
             'https': status['proxy_url']})
 
-    #return api
+    # return api and device info
     return api, device_info
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1170,7 +1170,7 @@ class AccountDevice(BaseModel):
                 traceback.print_exc(file=sys.stdout)
                 time.sleep(1)
 
-        return result
+        return result, result['device_id']
 
 
 class WorkerStatus(BaseModel):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1116,6 +1116,7 @@ class MainWorker(BaseModel):
 
         return dict
 
+
 class AccountDevice(BaseModel):
     username = Utf8mb4CharField(primary_key=True, max_length=50)
     firmware_type = Utf8mb4CharField(null=True)
@@ -1129,7 +1130,7 @@ class AccountDevice(BaseModel):
 
     @staticmethod
     def db_format(device_info, username):
-        account_device = {'username' : username}
+        account_device = {'username': username}
         account_device.update(device_info)
 
         return account_device
@@ -1170,6 +1171,7 @@ class AccountDevice(BaseModel):
                 time.sleep(1)
 
         return result
+
 
 class WorkerStatus(BaseModel):
     username = Utf8mb4CharField(primary_key=True, max_length=50)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -810,7 +810,8 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
             # one each time we login
             device_info = AccountDevice.get_device_info(account['username'])
             api, device_info = setup_api(args, status, device_info)
-            dbq.put((AccountDevice, {0: AccountDevice.db_format(device_info,account['username'])}))
+            dbq.put((AccountDevice, {0: AccountDevice.db_format(
+                                        device_info, account['username'])}))
 
             # The forever loop for the searches.
             while True:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -44,7 +44,7 @@ from pgoapi import utilities as util
 from pgoapi.hash_server import (HashServer, BadHashRequestException,
                                 HashingOfflineException)
 from .models import (parse_map, GymDetails, parse_gyms, MainWorker,
-                     WorkerStatus, HashKeys)
+                     WorkerStatus, HashKeys, AccountDevice)
 from .utils import now, clear_dict_response
 from .transform import get_new_coords, jitter_location
 from .account import (setup_api, check_login, get_tutorial_state,
@@ -805,7 +805,12 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
             # for stat purposes.
             consecutive_noitems = 0
 
-            api = setup_api(args, status)
+            # So the idea is to store the device that gets generated. This way
+            # we can keep using the same device rather than using a random
+            # one each time we login
+            device_info = AccountDevice.get_device_info(account['username'])
+            api, device_info = setup_api(args, status, device_info)
+            dbq.put((AccountDevice, {0: AccountDevice.db_format(device_info,account['username'])}))
 
             # The forever loop for the searches.
             while True:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -808,10 +808,17 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
             # So the idea is to store the device that gets generated. This way
             # we can keep using the same device rather than using a random
             # one each time we login
-            device_info = AccountDevice.get_device_info(account['username'])
+            device_info, device_id = AccountDevice.get_device_info(
+                                                        account['username'])
             api, device_info = setup_api(args, status, device_info)
-            dbq.put((AccountDevice, {0: AccountDevice.db_format(
+            if device_id is None:
+                dbq.put((AccountDevice, {0: AccountDevice.db_format(
                                         device_info, account['username'])}))
+                log.debug('New device added to account {} with id {}'.format(
+                            account['username'], device_info['device_id']))
+            else:
+                log.debug('Device found for account {} with id {}'.format(
+                            account['username'], device_info['device_id']))
 
             # The forever loop for the searches.
             while True:


### PR DESCRIPTION
New table to store devices associated with an account

## Description
Added a new table to store the generated device info, rather than regenerating it every login.

## Motivation and Context
I am hoping this may help a bit with shadow bans. I don't think normal gamers switch phones everytime they log in.

## How Has This Been Tested?
I have tested the code to ensure it functions and stores device details along with the account.
As for results, too early to really tell if it helps with shadow bans.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/24545326/26582072/928cca38-4537-11e7-8304-156111fa7638.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
