### PR TITLE
Added call to fort-details to make spin pokestop more realistic

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -606,6 +606,7 @@ def fort_details_request(api, account, fort):
         req.get_buddy_walked()
         req.get_inbox(is_history=True)
         response = req.call()
+        parse_new_timestamp_ms(account, response)
         return response
     except Exception as e:
         log.exception('Exception while getting Pokestop details: %s.', repr(e))

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -537,9 +537,9 @@ def spin_pokestop(api, account, fort, step_location):
 
         time.sleep(random.uniform(0.8, 1.8))
         fort_details_request(api, fort)
-        time.sleep(random.uniform(0.8, 1.8))  # Do not let Niantic throttle
+        time.sleep(random.uniform(0.8, 1.8))  # Don't let Niantic throttle
         response = spin_pokestop_request(api, account, fort, step_location)
-        time.sleep(random.uniform(2, 4))  # Do not let Niantic throttle
+        time.sleep(random.uniform(2, 4))  # Don't let Niantic throttle.
 
         # Check for reCaptcha
         captcha_url = response['responses'][

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -536,7 +536,7 @@ def spin_pokestop(api, account, fort, step_location):
         log.debug('Attempt to spin Pokestop (ID %s)', fort['id'])
 
         time.sleep(random.uniform(0.8, 1.8))
-        fort_details_request(api, fort)
+        fort_details_request(api, account, fort)
         time.sleep(random.uniform(0.8, 1.8))  # Don't let Niantic throttle
         response = spin_pokestop_request(api, account, fort, step_location)
         time.sleep(random.uniform(2, 4))  # Don't let Niantic throttle.
@@ -592,13 +592,19 @@ def spin_pokestop_request(api, account, fort, step_location):
         return False
 
 
-def fort_details_request(api, fort):
+def fort_details_request(api, account, fort):
     try:
         req = api.create_request()
         req.fort_details(
             fort_id=fort['id'],
             latitude=fort['latitude'],
             longitude=fort['longitude'])
+        req.check_challenge()
+        req.get_hatched_eggs()
+        req.get_inventory(last_timestamp_ms=account['last_timestamp_ms'])
+        req.check_awarded_badges()
+        req.get_buddy_walked()
+        req.get_inbox(is_history=True)
         response = req.call()
         return response
     except Exception as e:

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -534,6 +534,9 @@ def spin_pokestop(api, account, fort, step_location):
     if in_radius((fort['latitude'], fort['longitude']), step_location,
                  spinning_radius):
         log.debug('Attempt to spin Pokestop (ID %s)', fort['id'])
+
+        time.sleep(random.uniform(0.8, 1.8))
+        fort_details_request(api, fort)
         time.sleep(random.uniform(0.8, 1.8))  # Do not let Niantic throttle
         response = spin_pokestop_request(api, account, fort, step_location)
         time.sleep(random.uniform(2, 4))  # Do not let Niantic throttle
@@ -586,6 +589,20 @@ def spin_pokestop_request(api, account, fort, step_location):
 
     except Exception as e:
         log.exception('Exception while spinning Pokestop: %s.', repr(e))
+        return False
+
+
+def fort_details_request(api, fort):
+    try:
+        req = api.create_request()
+        req.fort_details(
+            fort_id=fort['id'],
+            latitude=fort['latitude'],
+            longitude=fort['longitude'])
+        response = req.call()
+        return response
+    except Exception as e:
+        log.exception('Exception while getting Pokestop details: %s.', repr(e))
         return False
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The application appears to be pretty adamant about calling fort_details before spinning the pokestop.

## Motivation and Context
Make the application more like the real client

## How Has This Been Tested?
Code compiles :)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
