### PR TITLE
Fixed Gym Info and added Check Inbox

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -336,7 +336,7 @@ def spin_pokestop_request(api, fort, step_location):
         req.check_awarded_badges()
         req.download_settings()
         req.get_buddy_walked()
-        req.request.get_inbox(is_history=True)
+        req.get_inbox(is_history=True)
         spin_pokestop_response = req.call()
 
         return spin_pokestop_response

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -336,6 +336,7 @@ def spin_pokestop_request(api, fort, step_location):
         req.check_awarded_badges()
         req.download_settings()
         req.get_buddy_walked()
+        req.request.get_inbox(is_history=True)
         spin_pokestop_response = req.call()
 
         return spin_pokestop_response
@@ -360,6 +361,7 @@ def encounter_pokemon_request(api, encounter_id, spawnpoint_id, scan_location):
         req.check_awarded_badges()
         req.download_settings()
         req.get_buddy_walked()
+        req.get_inbox(is_history=True)
         encounter_result = req.call()
 
         return encounter_result

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1748,12 +1748,12 @@ class HashKeys(BaseModel):
     @staticmethod
     # Retrieve the last stored 'peak' value for each hashing key.
     def getStoredPeak(key):
-            result = HashKeys.select(HashKeys.peak).where(HashKeys.key == key)
-            if result:
-                # only one row can be returned
-                return result[0].peak
-            else:
-                return 0
+        result = HashKeys.select(HashKeys.peak).where(HashKeys.key == key)
+        if result:
+            # only one row can be returned
+            return result[0].peak
+        else:
+            return 0
 
 
 def hex_bounds(center, steps=None, radius=None):
@@ -2351,17 +2351,15 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
     gym_members = {}
     gym_pokemon = {}
     trainers = {}
-
     i = 0
     for g in gym_responses.values():
-        gym_state = g['gym_state']
-        gym_id = gym_state['fort_data']['id']
+        gym_state = g['gym_status_and_defenders']
+        gym_id = gym_state['pokemon_fort_proto']['id']
 
         gym_details[gym_id] = {
             'gym_id': gym_id,
             'name': g['name'],
-            'description': g.get('description'),
-            'url': g['urls'][0],
+            'url': g['url']
         }
 
         if args.webhooks:
@@ -2371,73 +2369,99 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'longitude': gym_state['fort_data']['longitude'],
                 'team': gym_state['fort_data'].get('owned_by_team', 0),
                 'name': g['name'],
-                'description': g.get('description'),
-                'url': g['urls'][0],
+                'url': g['url'],
                 'pokemon': [],
             }
 
-        for member in gym_state.get('memberships', []):
+        for member in gym_state.get('gym_defender', []):
+            pokemon = member['motivated_pokemon']['pokemon']
             gym_members[i] = {
-                'gym_id': gym_id,
-                'pokemon_uid': member['pokemon_data']['id'],
+                'gym_id':
+                    gym_id,
+                'pokemon_uid':
+                    pokemon['id']
             }
 
             gym_pokemon[i] = {
-                'pokemon_uid': member['pokemon_data']['id'],
-                'pokemon_id': member['pokemon_data']['pokemon_id'],
-                'cp': member['pokemon_data']['cp'],
-                'trainer_name': member['trainer_public_profile']['name'],
-                'num_upgrades': member['pokemon_data'].get('num_upgrades', 0),
-                'move_1': member['pokemon_data'].get('move_1'),
-                'move_2': member['pokemon_data'].get('move_2'),
-                'height': member['pokemon_data'].get('height_m'),
-                'weight': member['pokemon_data'].get('weight_kg'),
-                'stamina': member['pokemon_data'].get('stamina'),
-                'stamina_max': member['pokemon_data'].get('stamina_max'),
-                'cp_multiplier': member['pokemon_data'].get('cp_multiplier'),
-                'additional_cp_multiplier': member['pokemon_data'].get(
-                    'additional_cp_multiplier', 0),
-                'iv_defense': member['pokemon_data'].get(
-                    'individual_defense', 0),
-                'iv_stamina': member['pokemon_data'].get(
-                    'individual_stamina', 0),
-                'iv_attack': member['pokemon_data'].get(
-                    'individual_attack', 0),
-                'last_seen': datetime.utcnow(),
+                'pokemon_uid':
+                    pokemon['id'],
+                'pokemon_id':
+                    pokemon['pokemon_id'],
+                'cp':
+                    pokemon['cp'],
+                'trainer_name':
+                    pokemon['owner_name'],
+                'num_upgrades':
+                    pokemon.get('num_upgrades', 0),
+                'move_1':
+                    pokemon.get('move_1'),
+                'move_2':
+                    pokemon.get('move_2'),
+                'height':
+                    pokemon.get('height_m'),
+                'weight':
+                    pokemon.get('weight_kg'),
+                'stamina':
+                    pokemon.get('stamina'),
+                'stamina_max':
+                    pokemon.get('stamina_max'),
+                'cp_multiplier':
+                    pokemon.get('cp_multiplier'),
+                'additional_cp_multiplier':
+                    pokemon.get('additional_cp_multiplier', 0),
+                'iv_defense':
+                    pokemon.get('individual_defense', 0),
+                'iv_stamina':
+                    pokemon.get('individual_stamina', 0),
+                'iv_attack':
+                    pokemon.get('individual_attack', 0),
+                'last_seen':
+                    datetime.utcnow(),
             }
 
             trainers[i] = {
                 'name': member['trainer_public_profile']['name'],
-                'team': gym_state['fort_data']['owned_by_team'],
+                'team': member['trainer_public_profile']['team_color'],
                 'level': member['trainer_public_profile']['level'],
                 'last_seen': datetime.utcnow(),
             }
 
             if args.webhooks:
                 webhook_data['pokemon'].append({
-                    'pokemon_uid': member['pokemon_data']['id'],
-                    'pokemon_id': member['pokemon_data']['pokemon_id'],
-                    'cp': member['pokemon_data']['cp'],
-                    'num_upgrades': member['pokemon_data'].get(
-                        'num_upgrades', 0),
-                    'move_1': member['pokemon_data'].get('move_1'),
-                    'move_2': member['pokemon_data'].get('move_2'),
-                    'height': member['pokemon_data'].get('height_m'),
-                    'weight': member['pokemon_data'].get('weight_kg'),
-                    'stamina': member['pokemon_data'].get('stamina'),
-                    'stamina_max': member['pokemon_data'].get('stamina_max'),
-                    'cp_multiplier': member['pokemon_data'].get(
-                        'cp_multiplier'),
-                    'additional_cp_multiplier': member['pokemon_data'].get(
-                        'additional_cp_multiplier', 0),
-                    'iv_defense': member['pokemon_data'].get(
-                        'individual_defense', 0),
-                    'iv_stamina': member['pokemon_data'].get(
-                        'individual_stamina', 0),
-                    'iv_attack': member['pokemon_data'].get(
-                        'individual_attack', 0),
-                    'trainer_name': member['trainer_public_profile']['name'],
-                    'trainer_level': member['trainer_public_profile']['level'],
+                    'pokemon_uid':
+                        pokemon['id'],
+                    'pokemon_id':
+                        pokemon['pokemon_id'],
+                    'cp':
+                        pokemon['cp'],
+                    'num_upgrades':
+                        pokemon.get('num_upgrades', 0),
+                    'move_1':
+                        pokemon.get('move_1'),
+                    'move_2':
+                        pokemon.get('move_2'),
+                    'height':
+                        pokemon.get('height_m'),
+                    'weight':
+                        pokemon.get('weight_kg'),
+                    'stamina':
+                        pokemon.get('stamina'),
+                    'stamina_max':
+                        pokemon.get('stamina_max'),
+                    'cp_multiplier':
+                        pokemon.get('cp_multiplier'),
+                    'additional_cp_multiplier':
+                        pokemon.get('additional_cp_multiplier', 0),
+                    'iv_defense':
+                        pokemon.get('individual_defense', 0),
+                    'iv_stamina':
+                        pokemon.get('individual_stamina', 0),
+                    'iv_attack':
+                        pokemon.get('individual_attack', 0),
+                    'trainer_name':
+                        member['trainer_public_profile']['name'],
+                    'trainer_level':
+                        member['trainer_public_profile']['level'],
                 })
 
             i += 1

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2359,6 +2359,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
         gym_details[gym_id] = {
             'gym_id': gym_id,
             'name': g['name'],
+            'description': g.get('description'),
             'url': g['url']
         }
 
@@ -2370,18 +2371,14 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'team': gym_state['pokemon_fort_proto'].get(
                     'owned_by_team', 0),
                 'name': g['name'],
+                'description': g.get('description'),
                 'url': g['url'],
                 'pokemon': [],
             }
 
         for member in gym_state.get('gym_defender', []):
             pokemon = member['motivated_pokemon']['pokemon']
-            gym_members[i] = {
-                'gym_id':
-                    gym_id,
-                'pokemon_uid':
-                    pokemon['id']
-            }
+            gym_members[i] = {'gym_id': gym_id, 'pokemon_uid': pokemon['id']}
 
             gym_pokemon[i] = {
                 'pokemon_uid':
@@ -2389,7 +2386,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'pokemon_id':
                     pokemon['pokemon_id'],
                 'cp':
-                    pokemon['cp'],
+                    member['motivated_pokemon']['cp_when_deployed'],
                 'trainer_name':
                     pokemon['owner_name'],
                 'num_upgrades':
@@ -2434,7 +2431,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                     'pokemon_id':
                         pokemon['pokemon_id'],
                     'cp':
-                        pokemon['cp'],
+                        member['motivated_pokemon']['cp_when_deployed'],
                     'num_upgrades':
                         pokemon.get('num_upgrades', 0),
                     'move_1':

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2365,9 +2365,10 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
         if args.webhooks:
             webhook_data = {
                 'id': b64encode(str(gym_id)),
-                'latitude': gym_state['fort_data']['latitude'],
-                'longitude': gym_state['fort_data']['longitude'],
-                'team': gym_state['fort_data'].get('owned_by_team', 0),
+                'latitude': gym_state['pokemon_fort_proto']['latitude'],
+                'longitude': gym_state['pokemon_fort_proto']['longitude'],
+                'team': gym_state['pokemon_fort_proto'].get(
+                    'owned_by_team', 0),
                 'name': g['name'],
                 'url': g['url'],
                 'pokemon': [],

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -875,8 +875,8 @@ var StoreOptions = {
         type: StoreTypes.Boolean
     },
     'showOpenGymsOnly': {
-        default: 0,
-        type: StoreTypes.Number
+        default: false,
+        type: StoreTypes.Boolean
     },
     'showTeamGymsOnly': {
         default: 0,
@@ -891,7 +891,7 @@ var StoreOptions = {
         type: StoreTypes.Number
     },
     'maxGymLevel': {
-        default: 10,
+        default: 6,
         type: StoreTypes.Number
     },
     'showPokemon': {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1771,7 +1771,7 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
         var freeSlots = 6 - result.pokemon.length
         var gymLevelStr = ''
         if (result.team_id !== 0 && result.pokemon.length !== 0) {
-            gymLevelStr =`<div>
+            gymLevelStr = `<div>
                             <b>${freeSlots} Free Slots</b>
                         </div>`
         }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -823,7 +823,7 @@ function setupGymMarker(item) {
         },
         map: map,
         icon: {
-            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['team_id'] !== 0 ? '_' + item['pokemon'].length : '') + '.png',
+            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['pokemon'].length !== 0 ? '_' + item['pokemon'].length : '') + '.png',
             scaledSize: new google.maps.Size(48, 48)
         }
     })
@@ -873,7 +873,7 @@ function setupGymMarker(item) {
 
 function updateGymMarker(item, marker) {
     marker.setIcon({
-        url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['team_id'] !== 0 ? '_' + item['pokemon'].length : '') + '.png',
+        url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['pokemon'].length !== 0 ? '_' + item['pokemon'].length : '') + '.png',
         scaledSize: new google.maps.Size(48, 48)
     })
     marker.infoWindow.setContent(gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude'], item['last_scanned'], item['last_modified'], item['name'], item['pokemon'], item['gym_id']))
@@ -883,7 +883,7 @@ function updateGymMarker(item, marker) {
 function updateGymIcons() {
     $.each(mapData.gyms, function (key, value) {
         mapData.gyms[key]['marker'].setIcon({
-            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[mapData.gyms[key]['team_id']] + (mapData.gyms[key]['team_id'] !== 0 ? '_' + mapData.gyms[key]['pokemon'].length : '') + '.png',
+            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[mapData.gyms[key]['team_id']] + (mapData.gyms[key]['pokemon'].length !== 0 ? '_' + mapData.gyms[key]['pokemon'].length : '') + '.png',
             scaledSize: new google.maps.Size(48, 48)
         })
     })
@@ -1769,9 +1769,12 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
         var lastScannedDateStr = getDateStr(result.last_scanned)
         var lastModifiedDateStr = getDateStr(result.last_modified)
         var freeSlots = 6 - result.pokemon.length
-        var gymLevelStr = `<div>
-                <b>${freeSlots} Free Slots</b>
-            </div>`
+        var gymLevelStr = ''
+        if (result.team_id !== 0 && result.pokemon.length !== 0) {
+            gymLevelStr =`<div>
+                            <b>${freeSlots} Free Slots</b>
+                        </div>`
+        }
         var pokemonHtml = ''
         var headerHtml = `
             <center>

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -63,7 +63,6 @@ var updateWorker
 var lastUpdateTime
 
 var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
-var gymPrestige = [2000, 4000, 8000, 12000, 16000, 20000, 30000, 40000, 50000]
 var audio = new Audio('static/sounds/ding.mp3')
 
 var genderType = ['♂', '♀', '⚲']
@@ -1338,7 +1337,7 @@ function processGyms(i, item) {
     }
 
     if (Store.get('showOpenGymsOnly')) {
-        if (item.pokemon.length === 6 ) {
+        if (item.pokemon.length === 6) {
             removeGymFromMap(item['gym_id'])
             return true
         }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -8,7 +8,7 @@ var $selectRarityNotify
 var $textPerfectionNotify
 var $selectStyle
 var $selectIconSize
-var $selectOpenGymsOnly
+var $switchOpenGymsOnly
 var $selectTeamGymsOnly
 var $selectLastUpdateGymsOnly
 var $selectMinGymLevel
@@ -345,7 +345,7 @@ function initSidebar() {
     $('#gym-sidebar-wrapper').toggle(Store.get('showGyms'))
     $('#gyms-filter-wrapper').toggle(Store.get('showGyms'))
     $('#team-gyms-only-switch').val(Store.get('showTeamGymsOnly'))
-    $('#open-gyms-only-switch').val(Store.get('showOpenGymsOnly'))
+    $('#open-gyms-only-switch').prop('checked', Store.get('showOpenGymsOnly'))
     $('#min-level-gyms-filter-switch').val(Store.get('minGymLevel'))
     $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
     $('#last-update-gyms-switch').val(Store.get('showLastUpdatedGymsOnly'))
@@ -447,7 +447,7 @@ function pokemonLabel(item) {
             var pokemonLevel = getPokemonLevel(cpMultiplier)
             details += `
             <div>
-                CP: ${cp} | Level: ${pokemonLevel} 
+                CP: ${cp} | Level: ${pokemonLevel}
             </div>
             `
         }
@@ -546,7 +546,6 @@ function gymLabel(teamName, teamId, gymPoints, latitude, longitude, lastScanned 
                 </center>
             </div>`
     } else {
-        var gymLevel = getGymLevel(gymPoints)
         str = `
             <div>
                 <center>
@@ -559,9 +558,6 @@ function gymLabel(teamName, teamId, gymPoints, latitude, longitude, lastScanned 
                     </div>
                     <div>
                         ${nameStr}
-                    </div>
-                    <div>
-                        Level: ${gymLevel} | Prestige: ${gymPoints}/${gymPrestige[gymLevel - 1] || 50000}
                     </div>
                     <div>
                         ${memberStr}
@@ -581,15 +577,6 @@ function gymLabel(teamName, teamId, gymPoints, latitude, longitude, lastScanned 
     }
 
     return str
-}
-
-function getGymLevel(points) {
-    var level = 1
-    while (points >= gymPrestige[level - 1]) {
-        level++
-    }
-
-    return level
 }
 
 function pokestopLabel(expireTime, latitude, longitude) {
@@ -837,7 +824,7 @@ function setupGymMarker(item) {
         },
         map: map,
         icon: {
-            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['team_id'] !== 0 ? '_' + getGymLevel(item['gym_points']) : '') + '.png',
+            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['team_id'] !== 0 ? '_' + item['pokemon'].length : '') + '.png',
             scaledSize: new google.maps.Size(48, 48)
         }
     })
@@ -887,7 +874,7 @@ function setupGymMarker(item) {
 
 function updateGymMarker(item, marker) {
     marker.setIcon({
-        url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['team_id'] !== 0 ? '_' + getGymLevel(item['gym_points']) : '') + '.png',
+        url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[item['team_id']] + (item['team_id'] !== 0 ? '_' + item['pokemon'].length : '') + '.png',
         scaledSize: new google.maps.Size(48, 48)
     })
     marker.infoWindow.setContent(gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude'], item['last_scanned'], item['last_modified'], item['name'], item['pokemon'], item['gym_id']))
@@ -897,7 +884,7 @@ function updateGymMarker(item, marker) {
 function updateGymIcons() {
     $.each(mapData.gyms, function (key, value) {
         mapData.gyms[key]['marker'].setIcon({
-            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[mapData.gyms[key]['team_id']] + (mapData.gyms[key]['team_id'] !== 0 ? '_' + getGymLevel(mapData.gyms[key]['gym_points']) : '') + '.png',
+            url: 'static/forts/' + Store.get('gymMarkerStyle') + '/' + gymTypes[mapData.gyms[key]['team_id']] + (mapData.gyms[key]['team_id'] !== 0 ? '_' + mapData.gyms[key]['pokemon'].length : '') + '.png',
             scaledSize: new google.maps.Size(48, 48)
         })
     })
@@ -1335,11 +1322,11 @@ function updatePokestops() {
 }
 
 function processGyms(i, item) {
+    var gymLevel = item.pokemon.length
     if (!Store.get('showGyms')) {
         return false // in case the checkbox was unchecked in the meantime.
     }
 
-    var gymLevel = getGymLevel(item.gym_points)
     var removeGymFromMap = function (gymid) {
         if (mapData.gyms[gymid] && mapData.gyms[gymid].marker) {
             if (mapData.gyms[gymid].marker.rangeCircle) {
@@ -1350,32 +1337,8 @@ function processGyms(i, item) {
         }
     }
 
-    var gymHasOpenSpot = function (gymLevel, pokemonInGym) {
-        return gymLevel > item.pokemon.length && item.pokemon.length !== 0
-    }
-
-    if (Store.get('showOpenGymsOnly') === 1) {
-        if (!gymHasOpenSpot(gymLevel, item.pokemon.length)) {
-            removeGymFromMap(item['gym_id'])
-            return true
-        }
-    }
-
-    if (Store.get('showOpenGymsOnly') > 1) {
-        var closePrestige = 0
-        switch (Store.get('showOpenGymsOnly')) {
-            case 2:
-                closePrestige = 1000
-                break
-            case 3:
-                closePrestige = 2500
-                break
-            case 4:
-                closePrestige = 5000
-                break
-        }
-
-        if (!gymHasOpenSpot(gymLevel, item.pokemon.length) && (gymPrestige[gymLevel - 1] > closePrestige + item.gym_points || gymLevel === 10)) {
+    if (Store.get('showOpenGymsOnly')) {
+        if (item.pokemon.length === 6 ) {
             removeGymFromMap(item['gym_id'])
             return true
         }
@@ -1804,25 +1767,12 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
     })
 
     data.done(function (result) {
-        var gymLevel = getGymLevel(result.gym_points)
-        var nextLvlPrestige = gymPrestige[gymLevel - 1] || 50000
-        var prestigePercentage = (result.gym_points / nextLvlPrestige) * 100
         var lastScannedDateStr = getDateStr(result.last_scanned)
         var lastModifiedDateStr = getDateStr(result.last_modified)
-        var freeSlots = result.pokemon.length ? gymLevel - result.pokemon.length : 0
-        var freeSlotsStr = freeSlots ? ` - ${freeSlots} Free Slots` : ''
-        var gymLevelStr = ''
-
-        if (result.team_id === 0) {
-            gymLevelStr = `
-                <center>
-                    <b>Uncontested - 1 Free Slot</b>
-                </center>`
-        } else {
-            gymLevelStr = `<div>
-                <b>Level ${gymLevel}${freeSlotsStr}</b>
+        var freeSlots = 6 - result.pokemon.length
+        var gymLevelStr = `<div>
+                <b>${freeSlots} Free Slots</b>
             </div>`
-        }
         var pokemonHtml = ''
         var headerHtml = `
             <center>
@@ -1830,13 +1780,6 @@ function showGymDetails(id) { // eslint-disable-line no-unused-vars
                     <b>${result.name || ''}</b>
                 </div>
                 <img height="100px" style="padding: 5px;" src="static/forts/${gymTypes[result.team_id]}_large.png">
-                <div class="prestige-bar team-${result.team_id}">
-                    <div class="prestige team-${result.team_id}" style="width: ${prestigePercentage}%">
-                    </div>
-                </div>
-                <div>
-                    ${result.gym_points}/${nextLvlPrestige}
-                </div>
                 ${gymLevelStr}
                 <div style="font-size: .7em;">
                     Last Scanned: ${lastScannedDateStr}
@@ -2034,15 +1977,10 @@ $(function () {
         redrawPokemon(mapData.lurePokemons)
     })
 
-    $selectOpenGymsOnly = $('#open-gyms-only-switch')
+    $switchOpenGymsOnly = $('#open-gyms-only-switch')
 
-    $selectOpenGymsOnly.select2({
-        placeholder: 'Only Show Open Gyms',
-        minimumResultsForSearch: Infinity
-    })
-
-    $selectOpenGymsOnly.on('change', function () {
-        Store.set('showOpenGymsOnly', this.value)
+    $switchOpenGymsOnly.on('change', function () {
+        Store.set('showOpenGymsOnly', this.checked)
         lastgyms = false
         updateMap()
     })

--- a/templates/map.html
+++ b/templates/map.html
@@ -100,13 +100,13 @@
               </div>
               <div class="form-control switch-container" id="open-gyms-only-wrapper">
                 <h3>Open Spot</h3>
-                <select name="open-gyms-only-switch" id="open-gyms-only-switch">
-                  <option value="0">All</option>
-                  <option value="1">Open Spot</option>
-                  <option value="2">&lt;= 1000 Prestige Until Open Spot</option>
-                  <option value="3">&lt;= 2500 Prestige Until Open Spot</option>
-                  <option value="4">&lt;= 5000 Prestige Until Open Spot</option>
-                </select>
+                <div class="onoffswitch">
+                  <input id="open-gyms-only-switch" type="checkbox" name="open-gyms-only-switch" class="onoffswitch-checkbox" checked>
+                  <label class="onoffswitch-label" for="open-gyms-only-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                  </label>
+                </div>
               </div>
               <div class="form-control switch-container" id="min-level-gyms-filter-wrapper">
                 <h3>Minimum Level</h3>
@@ -118,10 +118,6 @@
                   <option value="4">4</option>
                   <option value="5">5</option>
                   <option value="6">6</option>
-                  <option value="7">7</option>
-                  <option value="8">8</option>
-                  <option value="9">9</option>
-                  <option value="10">10</option>
                 </select>
               </div>
               <div class="form-control switch-container" id="max-level-gyms-filter-wrapper">
@@ -134,10 +130,6 @@
                   <option value="4">4</option>
                   <option value="5">5</option>
                   <option value="6">6</option>
-                  <option value="7">7</option>
-                  <option value="8">8</option>
-                  <option value="9">9</option>
-                  <option value="10">10</option>
                 </select>
               </div>
                <div class="form-control switch-container" id="last-update-gyms-wrapper">
@@ -428,7 +420,7 @@
     <script>
       var centerLat = {{lat}};
       var centerLng = {{lng}};
-      var showConfig = {{show|tojson|safe}};	  
+      var showConfig = {{show|tojson|safe}};
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR tries to recover the features lost with the api update and add the new check Inbox 

- Added the new Check Inbox method to all requests needding it.
- Recovered gym info feature, adjusting map for the differences

This PR do not add Raids as I would like to merge this fast and then work on raids.

To make it compatible with the new system I adjusted gym level to number of pokes deployed, also slots are correctly calculated based on pokes.

Show open gyms select changed to a switch.
Reduced min and max level filter for gyms to 0-6
Removed prestige bar

## Motivation and Context
API change 

## How Has This Been Tested?
Local instance, not tested gym WH even if I tried to make them work.

## Screenshots (if appropriate):
![rocketmap_2017-06-26_20-10-58](https://user-images.githubusercontent.com/487098/27553908-0affcc4c-5aad-11e7-8183-6476b03caa6b.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
