### PR TITLE
Fix parsing of forts which are currently disabled.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2181,7 +2181,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     if args.webhooks and args.webhook_updates_only:
                         wh_update_queue.put(('pokestop', {
                             'pokestop_id': b64encode(str(f['id'])),
-                            'enabled': f['enabled'],
+                            'enabled': f.get('enabled', False),
                             'latitude': f['latitude'],
                             'longitude': f['longitude'],
                             'last_modified_time': f[
@@ -2205,7 +2205,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
                     wh_update_queue.put(('pokestop', {
                         'pokestop_id': b64encode(str(f['id'])),
-                        'enabled': f['enabled'],
+                        'enabled': f.get('enabled', False),
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
                         'last_modified_time': f['last_modified_timestamp_ms'],
@@ -2222,7 +2222,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
                 pokestops[f['id']] = {
                     'pokestop_id': f['id'],
-                    'enabled': f.get('enabled', 0),
+                    'enabled': f.get('enabled', False),
                     'latitude': f['latitude'],
                     'longitude': f['longitude'],
                     'last_modified': datetime.utcfromtimestamp(
@@ -2243,7 +2243,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'team_id': f.get('owned_by_team', 0),
                         'guard_pokemon_id': f.get('guard_pokemon_id', 0),
                         'gym_points': f.get('gym_points', 0),
-                        'enabled': f['enabled'],
+                        'enabled': f.get('enabled', False),
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
                         'last_modified': f['last_modified_timestamp_ms']
@@ -2254,7 +2254,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'team_id': f.get('owned_by_team', 0),
                     'guard_pokemon_id': f.get('guard_pokemon_id', 0),
                     'gym_points': f.get('gym_points', 0),
-                    'enabled': f['enabled'],
+                    'enabled': f.get('enabled', False),
                     'latitude': f['latitude'],
                     'longitude': f['longitude'],
                     'last_modified': datetime.utcfromtimestamp(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The ``models.py`` function ``parse_map`` tries to access a key which is not sent if a Pokéstop is disabled. Hence RocketMap spits out an exception.

## Description
<!--- Describe your changes in detail -->
Replaced direct access of the key with a ``.get('key', default)``

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I think fixing unneeded exceptions is a good thing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By you! Go on! You can also import a test GMO response with a missing ``enabled`` (key, val) pair of a fort.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
