### PR TITLE
Cache Google Geolocator API results in DB

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -763,20 +763,18 @@ class PlayerLocale(BaseModel):
 
     @staticmethod
     def get_locale(location):
-        query = (PlayerLocale
-                 .select()
-                 .where(PlayerLocale.location == location)
-                 .dicts())
-
         locale = None
-        for l in query:
+        try:
+            query = PlayerLocale.get(PlayerLocale.location == location)
             locale = {
-                'country': l['country'],
-                'language': l['language'],
-                'timezone': l['timezone']
+                'country': query.country,
+                'language': query.language,
+                'timezone': query.timezone
             }
-
-        return locale
+        except PlayerLocale.DoesNotExist:
+            log.debug('This location is not yet in PlayerLocale DB table.')
+        finally:
+            return locale
 
 
 class ScannedLocation(BaseModel):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -755,6 +755,30 @@ class LocationAltitude(BaseModel):
         InsertQuery(cls, rows=[cls.new_loc(loc, altitude)]).upsert().execute()
 
 
+class PlayerLocale(BaseModel):
+    location = Utf8mb4CharField(primary_key=True, max_length=50, index=True)
+    country = Utf8mb4CharField(max_length=2)
+    language = Utf8mb4CharField(max_length=2)
+    timezone = Utf8mb4CharField(max_length=50)
+
+    @staticmethod
+    def get_locale(location):
+        query = (PlayerLocale
+                 .select()
+                 .where(PlayerLocale.location == location)
+                 .dicts())
+
+        locale = None
+        for l in query:
+            locale = {
+                'country': l['country'],
+                'language': l['language'],
+                'timezone': l['timezone']
+            }
+
+        return locale
+
+
 class ScannedLocation(BaseModel):
     cellid = Utf8mb4CharField(primary_key=True, max_length=50)
     latitude = DoubleField()
@@ -2654,7 +2678,7 @@ def create_tables(db):
     tables = [Pokemon, Pokestop, Gym, ScannedLocation, GymDetails,
               GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus,
               SpawnPoint, ScanSpawnPoint, SpawnpointDetectionData,
-              Token, LocationAltitude, HashKeys]
+              Token, LocationAltitude, PlayerLocale, HashKeys]
     for table in tables:
         if not table.table_exists():
             log.info('Creating table: %s', table.__name__)
@@ -2668,7 +2692,7 @@ def drop_tables(db):
     tables = [Pokemon, Pokestop, Gym, ScannedLocation, Versions,
               GymDetails, GymMember, GymPokemon, Trainer, MainWorker,
               WorkerStatus, SpawnPoint, ScanSpawnPoint,
-              SpawnpointDetectionData, LocationAltitude,
+              SpawnpointDetectionData, LocationAltitude, PlayerLocale,
               Token, HashKeys]
     db.connect()
     db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -221,9 +221,6 @@ def get_args():
                               '{} for more).').format(config['LOCALE'],
                                                       config['LOCALES_DIR']),
                         default='en')
-    parser.add_argument('-pl', '--player-locale',
-                        help='Simulated locale for searching workers.',
-                        default=[], action='append')
     parser.add_argument('-c', '--china',
                         help='Coordinates transformer for China.',
                         action='store_true')
@@ -675,17 +672,6 @@ def get_args():
         if args.enc_whitelist_file:
             with open(args.enc_whitelist_file) as f:
                 args.enc_whitelist = frozenset([int(l.strip()) for l in f])
-
-        # Check if manually set player locale is in correct format and use it.
-        if args.player_locale and len(args.player_locale) == 3:
-            player_locale = args.player_locale
-            args.player_locale = {
-                'country': player_locale[0],
-                'language': player_locale[1],
-                'timezone': player_locale[2]
-            }
-        else:
-            args.player_locale = {}  # Get it via Google API in runserver.
 
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -221,6 +221,9 @@ def get_args():
                               '{} for more).').format(config['LOCALE'],
                                                       config['LOCALES_DIR']),
                         default='en')
+    parser.add_argument('-pl', '--player-locale',
+                        help='Simulated locale for searching workers.',
+                        default=[], action='append')
     parser.add_argument('-c', '--china',
                         help='Coordinates transformer for China.',
                         action='store_true')
@@ -672,6 +675,14 @@ def get_args():
         if args.enc_whitelist_file:
             with open(args.enc_whitelist_file) as f:
                 args.enc_whitelist = frozenset([int(l.strip()) for l in f])
+
+        if args.player_locale and len(args.player_locale) == 3:
+            player_locale = args.player_locale
+            args.player_locale = {
+                'country': player_locale[0],
+                'language': player_locale[1],
+                'timezone': player_locale[2]
+            }
 
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -676,6 +676,7 @@ def get_args():
             with open(args.enc_whitelist_file) as f:
                 args.enc_whitelist = frozenset([int(l.strip()) for l in f])
 
+        # Check if manually set player locale is in correct format and use it.
         if args.player_locale and len(args.player_locale) == 3:
             player_locale = args.player_locale
             args.player_locale = {
@@ -683,6 +684,8 @@ def get_args():
                 'language': player_locale[1],
                 'timezone': player_locale[2]
             }
+        else:
+            args.player_locale = {}  # Get it via Google API in runserver.
 
         # Make max workers equal number of accounts if unspecified, and disable
         # account switching.

--- a/runserver.py
+++ b/runserver.py
@@ -23,7 +23,7 @@ from pogom.altitude import get_gmaps_altitude
 
 from pogom.search import search_overseer_thread
 from pogom.models import (init_database, create_tables, drop_tables,
-                          Pokemon, db_updater, clean_db_loop,
+                          Pokemon, PlayerLocale, db_updater, clean_db_loop,
                           verify_table_encoding, verify_database_schema)
 from pogom.webhook import wh_updater
 
@@ -313,11 +313,19 @@ def main():
             log.info('Periodical proxies refresh disabled.')
 
         # Update player locale if not set correctly, yet.
+        args.player_locale = PlayerLocale.get_locale(args.location)
         if not args.player_locale:
             args.player_locale = gmaps_reverse_geolocate(
                 args.gmaps_key,
                 args.locale,
                 str(position[0]) + ', ' + str(position[1]))
+            db_player_locale = {
+                'location': args.location,
+                'country': args.player_locale['country'],
+                'language': args.player_locale['country'],
+                'timezone': args.player_locale['timezone'],
+            }
+            db_updates_queue.put((PlayerLocale, {0: db_player_locale}))
 
         # Gather the Pokemon!
 

--- a/runserver.py
+++ b/runserver.py
@@ -313,10 +313,11 @@ def main():
             log.info('Periodical proxies refresh disabled.')
 
         # Update player locale.
-        args.player_locale = gmaps_reverse_geolocate(
-            args.gmaps_key,
-            args.locale,
-            str(position[0]) + ', ' + str(position[1]))
+        if not args.player_locale:
+            args.player_locale = gmaps_reverse_geolocate(
+                args.gmaps_key,
+                args.locale,
+                str(position[0]) + ', ' + str(position[1]))
 
         # Gather the Pokemon!
 

--- a/runserver.py
+++ b/runserver.py
@@ -326,6 +326,8 @@ def main():
                 'timezone': args.player_locale['timezone'],
             }
             db_updates_queue.put((PlayerLocale, {0: db_player_locale}))
+        else:
+            log.debug('Existing player locale has been retrieved from the DB.')
 
         # Gather the Pokemon!
 

--- a/runserver.py
+++ b/runserver.py
@@ -312,7 +312,7 @@ def main():
         else:
             log.info('Periodical proxies refresh disabled.')
 
-        # Update player locale.
+        # Update player locale if not set correctly, yet.
         if not args.player_locale:
             args.player_locale = gmaps_reverse_geolocate(
                 args.gmaps_key,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding a Google API caching via DB, since the limit is reached quickly.

## Description
<!--- Describe your changes in detail -->
Introducing PlayerLocale table to cache the player locales and prevent that the Google API key is loaded too much. This **only** happens in certain cases but we do not want ``America/Denver`` for them, though.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Google API resources are a ****.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On two setups in CLI, config and without anything just using Google API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
