### PR TITLE
Updated Google API documentation and fixed link in status page

### DIFF
--- a/docs/basic-install/google-maps.md
+++ b/docs/basic-install/google-maps.md
@@ -25,25 +25,31 @@ This project uses Google Maps. Each instance of Google Maps requires an API key 
    ![API Browser Key](../_static/img/csEFWKd.png)
    ![API Browser Key](../_static/img/6upJVIr.png)
 
-5. Enable three Google Maps APIs
+5. Enable five Google Maps APIs
    - Google Maps Javascript API - Enables Displaying of Map
      - Click on 'Library'
-     - Click on Google Maps Javascript API
+	 - Type 'JavaScript' in the search box
+     - Choose 'Google Maps Javascript API'
      - Click 'ENABLE'
    - Google Places API Web Service - Enables Location Searching
      - Click on 'Library'
-     - Type 'Places' into the search box ' Search all 100+ APIs'
-     - Choose Google Places API Web Service
+     - Type 'Places' in the search box
+     - Choose 'Google Places API Web Service'
      - Click 'ENABLE'
    - Google Maps Elevation API - Enables fetching of altitude
      - Click on 'Library'
-     - Type 'Elevation' into the search box ' Search all 100+ APIs'
-     - Choose Google Maps Elevation API
+     - Type 'Elevation' in the search box
+     - Choose 'Google Maps Elevation API'
      - Click 'ENABLE'
-    - Google Maps Time Zone API - Enables time zone for a location
+   - Google Maps Geocoding API - Enables geocoding and reverse geocoding
      - Click on 'Library'
-     - Type 'Time Zone' into the search box ' Search all 100+ APIs'
-     - Choose Google Maps Time Zone API
+     - Type 'Geocoding' in the search box
+     - Choose 'Google Maps Geocoding API'
+     - Click 'ENABLE'
+   - Google Maps Time Zone API - Enables time zone for a location
+     - Click on 'Library'
+     - Type 'Time Zone' in the search box
+     - Choose 'Google Maps Time Zone API'
      - Click 'ENABLE'
 
 ## Using the API Key

--- a/docs/basic-install/google-maps.md
+++ b/docs/basic-install/google-maps.md
@@ -28,7 +28,7 @@ This project uses Google Maps. Each instance of Google Maps requires an API key 
 5. Enable five Google Maps APIs
    - Google Maps Javascript API - Enables Displaying of Map
      - Click on 'Library'
-	 - Type 'JavaScript' in the search box
+     - Type 'JavaScript' in the search box
      - Choose 'Google Maps Javascript API'
      - Click 'ENABLE'
    - Google Places API Web Service - Enables Location Searching

--- a/templates/status.html
+++ b/templates/status.html
@@ -39,7 +39,7 @@
 <!-- Header -->
 <header id="header">
     <a href="#nav"><span class="label">Options</span></a>
-    <h1><a href="#">RocketMap<i class="fa fa-rocket fa-fw"></i></a></h1>
+    <h1><a href="./">RocketMap<i class="fa fa-rocket fa-fw"></i></a></h1>
 </header>
 <nav id="nav">
   <div id="nav-accordion">


### PR DESCRIPTION
## Description
The geocoding API is used after #2057, enabling the geocoding API was misssing in the documentation. The RocketMap link in the status page was not working, this is fixed now.

## Motivation and Context
Documentation is important and links should work :)

## How Has This Been Tested?
On my home setup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
