### PR TITLE
Added new checks to statics assets

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -89,6 +89,45 @@ def handle_exception(exc_type, exc_value, exc_traceback):
         exc_type, exc_value, exc_traceback))
 
 
+def server_checks(args):
+    root_path = os.path.dirname(__file__)
+    if not os.path.exists(os.path.join(root_path, 'static/dist')):
+        log.critical(
+            'Missing front-end assets (static/dist) -- please run ' +
+            '"npm install && npm run build" before starting the server.')
+        sys.exit()
+
+    static_path = os.path.join(root_path, 'static/js')
+    for file in os.listdir(static_path):
+        if file.endswith(".js"):
+            generated_path = os.path.join(static_path, '../dist/js/',
+                                          file.replace(".js", ".min.js"))
+            source_path = os.path.join(static_path, file)
+            if not os.path.exists(generated_path) or (
+                    os.path.getmtime(source_path) >
+                    os.path.getmtime(generated_path)):
+                log.critical(
+                    'Front-end assets not up to date -- please run "npm ' +
+                    'install && npm run build" before starting the server.')
+                sys.exit()
+
+    # You need custom image files now.
+    if not os.path.isfile(
+            os.path.join(root_path, 'static/icons-sprite.png')):
+        log.info('Sprite files not present, extracting bundled ones...')
+        extract_sprites(root_path)
+        log.info('Done!')
+
+    # Check if custom.css is used otherwise fall back to default.
+    if os.path.exists(os.path.join(root_path, 'static/css/custom.css')):
+        args.custom_css = True
+        log.info(
+            'File \"custom.css\" found, applying user-defined settings.')
+    else:
+        args.custom_css = False
+        log.info('No file \"custom.css\" found, using default settings.')
+
+
 def main():
     # Patch threading to make exceptions catchable.
     install_thread_excepthook()
@@ -119,30 +158,7 @@ def main():
 
     # Let's not forget to run Grunt / Only needed when running with webserver.
     if not args.no_server:
-        root_path = os.path.dirname(__file__)
-        if not os.path.exists(
-                os.path.join(root_path, 'static/dist')):
-            log.critical(
-                'Missing front-end assets (static/dist) -- please run ' +
-                '"npm install && npm run build" before starting the server.')
-            sys.exit()
-
-        # You need custom image files now.
-        if not os.path.isfile(
-                os.path.join(root_path, 'static/icons-sprite.png')):
-            log.info('Sprite files not present, extracting bundled ones...')
-            extract_sprites(root_path)
-            log.info('Done!')
-
-        # Check if custom.css is used otherwise fall back to default.
-        if os.path.exists(os.path.join(root_path, 'static/css/custom.css')):
-            args.custom_css = True
-            log.info(
-                'File \"custom.css\" found, applying user-defined settings.')
-        else:
-            args.custom_css = False
-            log.info('No file \"custom.css\" found, using default settings.')
-
+        server_checks(args)
     # These are very noisy, let's shush them up a bit.
     logging.getLogger('peewee').setLevel(logging.INFO)
     logging.getLogger('requests').setLevel(logging.WARNING)


### PR DESCRIPTION

## Description
It is a very usual problem for people to update map or map.common.js and forget to build assets, there was a check to see that there are assets compiled but it was easy to add also that the build files have been modified after the .js files to avoid running on old assets.

## Motivation and Context
Solves users issues that pop ups frequently in help channel

## How Has This Been Tested?
Tested modifying js files without building and running without modifying.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
