### PR TITLE
Offering More Interesting Gym Info from GMO

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2238,6 +2238,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     # Explicitly set 'webhook_data', in case we want to change
                     # the information pushed to webhooks.  Similar to above
                     # and previous commits.
+                    gym_display = f.get('gym_display', {})
                     wh_update_queue.put(('gym', {
                         'gym_id': b64encode(str(f['id'])),
                         'team_id': f.get('owned_by_team', 0),
@@ -2246,6 +2247,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'enabled': f.get('enabled', False),
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
+                        'total_gym_cp': gym_display.get('total_gym_cp', 0),
+                        'lowest_pokemon_motivation': gym_display.get(
+                            'lowest_pokemon_motivation', 0),
+                        'occupied_seconds': gym_display.get(
+                            'occupied_millis', 0) / 1000,
                         'last_modified': f['last_modified_timestamp_ms']
                     }))
 

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -189,8 +189,9 @@ def __get_key_fields(whtype):
                     'disappear_time', 'move_1', 'move_2',
                     'individual_stamina', 'individual_defense',
                     'individual_attack', 'form', 'cp', 'pokemon_level'],
-        'gym': ['team_id', 'guard_pokemon_id',
-                'gym_points', 'enabled', 'latitude', 'longitude'],
+        'gym': ['team_id', 'guard_pokemon_id', 'gym_points', 'enabled',
+                'latitude', 'longitude', 'total_gym_cp',
+                'lowest_pokemon_motivation', 'occupied_seconds'],
         'gym_details': ['latitude', 'longitude', 'team', 'pokemon']
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
GMO delivers a lot of interesting information nowadays, related to all the gym changes. There are some dynamic ones right tied to the gym part of GMO which have been added to the webhook but not to the DB, being quite dynamic.

## Description
<!--- Describe your changes in detail -->
Added webhook gym keys
- ``total_gym_cp`` - defining the visual height of gyms
- ``lowest_pokemon_motivation`` - defining the (not) filled heart on top of gyms
- ``occupied_seconds`` - important information about turnover, when averaged across areas.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We like to know what these gyms are doing while we don't watch closely.
Also I do like Telegram 🙈 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Some random webhook prints.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small addition

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
