### PR TITLE
Add second URL check to proxy checking logic

### DIFF
--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -63,31 +63,29 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
                                                        'X-Unity-Version':
                                                        '5.5.1f1'})
 
-            if proxy_response.status_code == 200 and \
-               proxy_response_ptc.status_code == 200:
+            niantic_status = proxy_response.status_code
+            ptc_status = proxy_response_ptc.status_code
+
+            banned_status_codes = [403, 409]
+
+            if niantic_status == 200 and ptc_status == 200:
                 log.debug('Proxy %s is ok.', proxy[1])
                 proxy_queue.task_done()
                 proxies.append(proxy[1])
                 check_results[check_result_ok] += 1
                 return True
 
-            elif proxy_response.status_code == 403 or \
-                    proxy_response_ptc.status_code == 403:
+            elif (niantic_status in banned_status_codes or
+                  ptc_status in banned_status_codes):
                 proxy_error = ("Proxy " + proxy[1] +
-                               " is banned - got status code: " +
-                               str(proxy_response.status_code))
-                check_result = check_result_banned
-
-            elif proxy_response_ptc.status_code == 409:
-                proxy_error = ("Proxy " + proxy[1] +
-                               " is banned - got status code: " +
-                               str(proxy_response_ptc.status_code))
+                               " is banned - got Niantic status code: " +
+                               str(niantic_status) + ", PTC status code: " +
+                               str(ptc_status))
                 check_result = check_result_banned
 
             else:
-                proxy_error = ("Wrong status codes - " +
-                               str(proxy_response.status_code) + ", " +
-                               str(proxy_response_ptc.status_code))
+                proxy_error = ("Wrong status codes - " + str(niantic_status) +
+                               ", " + str(ptc_status))
                 check_result = check_result_wrong
 
         except requests.ConnectTimeout:

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -32,7 +32,10 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
 
     # Url for proxy testing.
     proxy_test_url = 'https://pgorelease.nianticlabs.com/plfe/rpc'
-    proxy_test_ptc_url = 'https://sso.pokemon.com/sso/oauth2.0/authorize?client_id=mobile-app_pokemon-go&redirect_uri=https%3A%2F%2Fwww.nianticlabs.com%2Fpokemongo%2Ferror'
+    proxy_test_ptc_url = 'https://sso.pokemon.com/sso/oauth2.0/authorize?' \
+                         'client_id=mobile-app_pokemon-go&redirect_uri=' \
+                         'https%3A%2F%2Fwww.nianticlabs.com%2Fpokemongo' \
+                         '%2Ferror'
     proxy = proxy_queue.get()
 
     check_result = check_result_ok
@@ -48,28 +51,31 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
                                            timeout=timeout)
 
             proxy_response_ptc = requests.get(proxy_test_ptc_url, '',
-                                           proxies={'http': proxy[1],
-                                                    'https': proxy[1]},
-                                           timeout=timeout,
-                                           headers={'User-Agent': 'pokemongo/1 CFNetwork/811.4.18 Darwin/16.5.0', 'Host': 'sso.pokemon.com', 'X-Unity-Version': '5.5.1f1'})
+                                              proxies={'http': proxy[1],
+                                                       'https': proxy[1]},
+                                              timeout=timeout,
+                                              headers={'User-Agent':
+                                                       'pokemongo/1 '
+                                                       'CFNetwork/811.4.18 '
+                                                       'Darwin/16.5.0',
+                                                       'Host':
+                                                       'sso.pokemon.com',
+                                                       'X-Unity-Version':
+                                                       '5.5.1f1'})
 
-            if proxy_response.status_code == 200 and proxy_response_ptc.status_code == 200:
+            if proxy_response.status_code == 200 and \
+               proxy_response_ptc.status_code == 200:
                 log.debug('Proxy %s is ok.', proxy[1])
                 proxy_queue.task_done()
                 proxies.append(proxy[1])
                 check_results[check_result_ok] += 1
                 return True
 
-            elif proxy_response.status_code == 403:
+            if proxy_response.status_code == 403 or \
+               proxy_response_ptc.status_code == 403:
                 proxy_error = ("Proxy " + proxy[1] +
                                " is banned - got status code: " +
                                str(proxy_response.status_code))
-                check_result = check_result_banned
- 
-            elif proxy_response_ptc.status_code == 403:
-                proxy_error = ("Proxy " + proxy[1] +
-                               " is banned - got status code: " +
-                               str(proxy_response_ptc.status_code))
                 check_result = check_result_banned
 
             elif proxy_response_ptc.status_code == 409:

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -187,7 +187,7 @@ def check_proxies(args):
                  check_results[check_result_timeout],
                  other_fails,
                  proxies)
-        return new_proxies
+        return proxies
 
 
 # Thread function for periodical proxy updating.

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -91,6 +91,7 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
     check_results[check_result] += 1
     return False
 
+
 # Simple function to do a call to Pokemon's system for
 # testing proxy connectivity.
 def check_proxy2(proxy_queue, timeout, proxies, show_warnings, check_results):
@@ -106,9 +107,9 @@ def check_proxy2(proxy_queue, timeout, proxies, show_warnings, check_results):
         log.debug('Checking proxy: %s', proxy[1])
         try:
             proxy_response = requests.get(proxy_test_url, '',
-                                           proxies={'http': proxy[1],
-                                                    'https': proxy[1]},
-                                           timeout=timeout)
+                                          proxies={'http': proxy[1],
+                                                   'https': proxy[1]},
+                                          timeout=timeout)
 
             if proxy_response.status_code == 200:
                 log.debug('Proxy %s is ok.', proxy[1])
@@ -154,6 +155,7 @@ def check_proxy2(proxy_queue, timeout, proxies, show_warnings, check_results):
 
     check_results[check_result] += 1
     return False
+
 
 # Check all proxies and return a working list with proxies.
 def check_proxies(args):
@@ -215,8 +217,8 @@ def check_proxies(args):
     proxy_queue.join()
 
     step1_proxies = len(proxies)
-	
-	# Now we test the second URL
+
+    # Now we test the second URL
     new_proxy_queue = Queue()
 
     log.info('Checking %d proxies...', step1_proxies)
@@ -239,7 +241,7 @@ def check_proxies(args):
     # completed so we have a working list of proxies.
     new_proxy_queue.join()
 
-    working_proxies = len(new_proxies)	
+    working_proxies = len(new_proxies)
 
     if working_proxies == 0:
         log.error('Proxy was configured but no working ' +

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -71,8 +71,8 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
                 check_results[check_result_ok] += 1
                 return True
 
-            if proxy_response.status_code == 403 or \
-               proxy_response_ptc.status_code == 403:
+            elif proxy_response.status_code == 403 or \
+                    proxy_response_ptc.status_code == 403:
                 proxy_error = ("Proxy " + proxy[1] +
                                " is banned - got status code: " +
                                str(proxy_response.status_code))
@@ -84,7 +84,7 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
                                str(proxy_response_ptc.status_code))
                 check_result = check_result_banned
 
-            else:   
+            else:
                 proxy_error = ("Wrong status codes - " +
                                str(proxy_response.status_code) + ", " +
                                str(proxy_response_ptc.status_code))

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -170,7 +170,7 @@ def check_proxies(args):
     # completed so we have a working list of proxies.
     proxy_queue.join()
 
-    working_proxies = len(new_proxies)
+    working_proxies = len(proxies)
 
     if working_proxies == 0:
         log.error('Proxy was configured but no working ' +

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -186,7 +186,7 @@ def check_proxies(args):
                  working_proxies, check_results[check_result_banned],
                  check_results[check_result_timeout],
                  other_fails,
-                 proxies)
+                 total_proxies)
         return proxies
 
 

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -32,6 +32,7 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
 
     # Url for proxy testing.
     proxy_test_url = 'https://pgorelease.nianticlabs.com/plfe/rpc'
+    proxy_test_ptc_url = 'https://sso.pokemon.com/sso/oauth2.0/authorize?client_id=mobile-app_pokemon-go&redirect_uri=https%3A%2F%2Fwww.nianticlabs.com%2Fpokemongo%2Ferror'
     proxy = proxy_queue.get()
 
     check_result = check_result_ok
@@ -46,7 +47,13 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
                                                     'https': proxy[1]},
                                            timeout=timeout)
 
-            if proxy_response.status_code == 200:
+            proxy_response_ptc = requests.get(proxy_test_ptc_url, '',
+                                           proxies={'http': proxy[1],
+                                                    'https': proxy[1]},
+                                           timeout=timeout,
+                                           headers={'User-Agent': 'pokemongo/1 CFNetwork/811.4.18 Darwin/16.5.0', 'Host': 'sso.pokemon.com', 'X-Unity-Version': '5.5.1f1'})
+
+            if proxy_response.status_code == 200 and proxy_response_ptc.status_code == 200:
                 log.debug('Proxy %s is ok.', proxy[1])
                 proxy_queue.task_done()
                 proxies.append(proxy[1])
@@ -58,75 +65,23 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
                                " is banned - got status code: " +
                                str(proxy_response.status_code))
                 check_result = check_result_banned
-
-            else:
-                proxy_error = ("Wrong status code - " +
-                               str(proxy_response.status_code))
-                check_result = check_result_wrong
-
-        except requests.ConnectTimeout:
-            proxy_error = ("Connection timeout (" + str(timeout) +
-                           " second(s) ) via proxy " + proxy[1])
-            check_result = check_result_timeout
-
-        except requests.ConnectionError:
-            proxy_error = "Failed to connect to proxy " + proxy[1]
-            check_result = check_result_failed
-
-        except Exception as e:
-            proxy_error = e
-            check_result = check_result_exception
-
-    else:
-        proxy_error = "Empty proxy server."
-        check_result = check_result_empty
-
-    # Decrease output amount if there are lot of proxies.
-    if show_warnings:
-        log.warning('%s', repr(proxy_error))
-    else:
-        log.debug('%s', repr(proxy_error))
-    proxy_queue.task_done()
-
-    check_results[check_result] += 1
-    return False
-
-
-# Simple function to do a call to Pokemon's system for
-# testing proxy connectivity.
-def check_proxy2(proxy_queue, timeout, proxies, show_warnings, check_results):
-
-    # Url for proxy testing.
-    proxy_test_url = 'https://sso.pokemon.com'
-    proxy = proxy_queue.get()
-
-    check_result = check_result_ok
-
-    if proxy and proxy[1]:
-
-        log.debug('Checking proxy: %s', proxy[1])
-        try:
-            proxy_response = requests.get(proxy_test_url, '',
-                                          proxies={'http': proxy[1],
-                                                   'https': proxy[1]},
-                                          timeout=timeout)
-
-            if proxy_response.status_code == 200:
-                log.debug('Proxy %s is ok.', proxy[1])
-                proxy_queue.task_done()
-                proxies.append(proxy[1])
-                check_results[check_result_ok] += 1
-                return True
-
-            elif proxy_response.status_code == 409:
+ 
+            elif proxy_response_ptc.status_code == 403:
                 proxy_error = ("Proxy " + proxy[1] +
                                " is banned - got status code: " +
-                               str(proxy_response.status_code))
+                               str(proxy_response_ptc.status_code))
                 check_result = check_result_banned
 
-            else:
-                proxy_error = ("Wrong status code - " +
-                               str(proxy_response.status_code))
+            elif proxy_response_ptc.status_code == 409:
+                proxy_error = ("Proxy " + proxy[1] +
+                               " is banned - got status code: " +
+                               str(proxy_response_ptc.status_code))
+                check_result = check_result_banned
+
+            else:   
+                proxy_error = ("Wrong status codes - " +
+                               str(proxy_response.status_code) + ", " +
+                               str(proxy_response_ptc.status_code))
                 check_result = check_result_wrong
 
         except requests.ConnectTimeout:
@@ -163,7 +118,6 @@ def check_proxies(args):
     source_proxies = []
 
     check_results = [0] * (check_result_max + 1)
-    check_results2 = [0] * (check_result_max + 1)
 
     # Load proxies from the file. Override args.proxy if specified.
     if args.proxy_file is not None:
@@ -216,31 +170,6 @@ def check_proxies(args):
     # completed so we have a working list of proxies.
     proxy_queue.join()
 
-    step1_proxies = len(proxies)
-
-    # Now we test the second URL
-    new_proxy_queue = Queue()
-
-    log.info('Checking %d proxies...', step1_proxies)
-    if (step1_proxies > 10):
-        log.info('Enable "-v or -vv" to see checking details.')
-
-    new_proxies = []
-
-    for proxy in enumerate(proxies):
-        new_proxy_queue.put(proxy)
-
-        t = Thread(target=check_proxy2,
-                   name='check_proxy2',
-                   args=(new_proxy_queue, args.proxy_timeout, new_proxies,
-                         step1_proxies <= 10, check_results2))
-        t.daemon = True
-        t.start()
-
-    # This is painful but we need to wait here until proxy_queue is
-    # completed so we have a working list of proxies.
-    new_proxy_queue.join()
-
     working_proxies = len(new_proxies)
 
     if working_proxies == 0:
@@ -248,16 +177,16 @@ def check_proxies(args):
                   'proxies were found. Aborting.')
         sys.exit(1)
     else:
-        other_fails = (check_results2[check_result_failed] +
-                       check_results2[check_result_wrong] +
-                       check_results2[check_result_exception] +
-                       check_results2[check_result_empty])
+        other_fails = (check_results[check_result_failed] +
+                       check_results[check_result_wrong] +
+                       check_results[check_result_exception] +
+                       check_results[check_result_empty])
         log.info('Proxy check completed. Working: %d, banned: %d, ' +
                  'timeout: %d, other fails: %d of total %d configured.',
-                 working_proxies, check_results2[check_result_banned],
-                 check_results2[check_result_timeout],
+                 working_proxies, check_results[check_result_banned],
+                 check_results[check_result_timeout],
                  other_fails,
-                 step1_proxies)
+                 proxies)
         return new_proxies
 
 


### PR DESCRIPTION
As PTC web started banning IP, we need to check for proxy ban not only on Niantic side, but on Pokemon side too.

## Description
Added a second proxy check and implemented in check_proxies function

## Motivation and Context
We need to check Pokemon URL, solves issue #2112 

## How Has This Been Tested?
Local repository

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.