### PR TITLE
Reworked proxy tests to use requests_futures instead of custom threads.

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -127,7 +127,10 @@
 #proxy:                         # Proxy URL e.g. socks5://127.0.0.1:9050 or a list of proxies
                                 # e.g. [socks5://127.0.0.1:9050,socks5://127.0.0.1:9050]
 #proxy-skip-check               # Disable checking of proxies before start.
-#proxy-timeout:                 # Timeout before proceeding with next proxy while checking if the proxy works. (default=5)
+#proxy-test-timeout:            # Timeout before proceeding with next proxy while checking if the proxy works. (default=5)
+#proxy-test-retries:            # Number of times to retry sending proxy test requests on failure. (default=0)
+#proxy-test-backoff-factor:     # Factor (in seconds) by which the delay until next retry will increase. (default=0.25)
+#proxy-test-concurrency:        # Async requests pool size. (default=0 for automatic optimal sizing)
 #proxy-display:                 # Used with -ps, full = display complete proxy address. Index = displays just the index for that proxy. (default='index')
 #proxy-file:                    # Load proxy list from text file (one proxy per line), overrides #proxy.
 #proxy-refresh:                 # Period of proxy file reloading, in seconds. Works only with proxy-file. (default=0, 0 to disable)

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -1,374 +1,387 @@
 # Command Line
 
     usage: runserver.py [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
-                    [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
-                    [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV]
-                    [-hlvl HIGH_LVL_ACCOUNTS] [-bh] [-wph WORKERS_PER_HIVE]
-                    [-l LOCATION] [-alt ALTITUDE] [-altv ALTITUDE_VARIANCE]
-                    [-uac] [-nj] [-al] [-st STEP_LIMIT] [-sd SCAN_DELAY]
-                    [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
-                    [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
-                    [-mcr MANUAL_CAPTCHA_REFRESH]
-                    [-mct MANUAL_CAPTCHA_TIMEOUT] [-ed ENCOUNTER_DELAY]
-                    [-encwf ENC_WHITELIST_FILE]
-                    [-nostore]
-                    [-wwht WEBHOOK_WHITELIST | -wblk WEBHOOK_BLACKLIST | -wwhtf WEBHOOK_WHITELIST_FILE | -wblkf WEBHOOK_BLACKLIST_FILE]
-                    [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
-                    [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
-                    [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
-                    [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-sc] [-nfl] -k
-                    GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np] [-ng]
-                    [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH]
-                    [-hkph HLVL_KPH] [-ldur LURE_DURATION]
-                    [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY] [-pxsc]
-                    [-pxt PROXY_TIMEOUT] [-pxd PROXY_DISPLAY]
-                    [-pxf PROXY_FILE] [-pxr PROXY_REFRESH]
-                    [-pxo PROXY_ROTATION] [--db-type DB_TYPE]
-                    [--db-name DB_NAME] [--db-user DB_USER]
-                    [--db-pass DB_PASS] [--db-host DB_HOST]
-                    [--db-port DB_PORT]
-                    [--db-max_connections DB_MAX_CONNECTIONS]
-                    [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi]
-                    [--disable-clean] [--webhook-updates-only]
-                    [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
-                    [-whr WH_RETRIES] [-wht WH_TIMEOUT]
-                    [-whbf WH_BACKOFF_FACTOR] [-whlfu WH_LFU_SIZE] [-whsu]
-                    [--ssl-certificate SSL_CERTIFICATE]
-                    [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]]
-                    [-slt STATS_LOG_TIMER] [-sn STATUS_NAME]
-                    [-spp STATUS_PAGE_PASSWORD] [-hk HASH_KEY] [-tut] [-novc]
-                    [-vci VERSION_CHECK_INTERVAL] [-el ENCRYPT_LIB]
-                    [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
-                    [-tp TRUSTED_PROXIES] [-v [filename.log] | -vv
-                    [filename.log]]
+                        [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
+                        [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV]
+                        [-hlvl HIGH_LVL_ACCOUNTS] [-bh] [-wph WORKERS_PER_HIVE]
+                        [-l LOCATION] [-alt ALTITUDE] [-altv ALTITUDE_VARIANCE]
+                        [-uac] [-nj] [-al] [-st STEP_LIMIT] [-sd SCAN_DELAY]
+                        [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
+                        [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
+                        [-mcr MANUAL_CAPTCHA_REFRESH]
+                        [-mct MANUAL_CAPTCHA_TIMEOUT] [-ed ENCOUNTER_DELAY]
+                        [-encwf ENC_WHITELIST_FILE] [-nostore]
+                        [-wwht WEBHOOK_WHITELIST | -wblk WEBHOOK_BLACKLIST | -wwhtf WEBHOOK_WHITELIST_FILE | -wblkf WEBHOOK_BLACKLIST_FILE]
+                        [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
+                        [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
+                        [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
+                        [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-sc] [-nfl] -k
+                        GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np] [-ng]
+                        [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH]
+                        [-hkph HLVL_KPH] [-ldur LURE_DURATION]
+                        [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY] [-pxsc]
+                        [-pxt PROXY_TIMEOUT] [-pxre PROXY_RETRIES]
+                        [-pxbf PROXY_BACKOFF_FACTOR] [-pxc PROXY_CONCURRENCY]
+                        [-pxd PROXY_DISPLAY] [-pxf PROXY_FILE]
+                        [-pxr PROXY_REFRESH] [-pxo PROXY_ROTATION]
+                        [--db-type DB_TYPE] [--db-name DB_NAME]
+                        [--db-user DB_USER] [--db-pass DB_PASS]
+                        [--db-host DB_HOST] [--db-port DB_PORT]
+                        [--db-max_connections DB_MAX_CONNECTIONS]
+                        [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi]
+                        [--disable-clean] [--webhook-updates-only]
+                        [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
+                        [-whr WH_RETRIES] [-wht WH_TIMEOUT]
+                        [-whbf WH_BACKOFF_FACTOR] [-whlfu WH_LFU_SIZE] [-whsu]
+                        [--ssl-certificate SSL_CERTIFICATE]
+                        [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]]
+                        [-slt STATS_LOG_TIMER] [-sn STATUS_NAME]
+                        [-spp STATUS_PAGE_PASSWORD] [-hk HASH_KEY] [-tut] [-novc]
+                        [-vci VERSION_CHECK_INTERVAL] [-el ENCRYPT_LIB]
+                        [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
+                        [-tp TRUSTED_PROXIES] [--api-version API_VERSION]
+                        [-v [filename.log] | -vv [filename.log]]
 
-    Args that start with '--' (eg. -a) can also be set in a config file.
-    The recognized syntax for setting (key, value) pairs is based on the INI and
-    YAML formats (e.g. key=value or foo=TRUE). For full documentation of the
-    differences from the standards please refer to the ConfigArgParse
-    documentation. If an arg is specified in more than one place, then commandline
-    values override environment variables which override config file values which
-    override defaults.
+    Args that start with '--' (eg. -a) can also be set in a config file
+    or specified via -cf). The recognized syntax for setting (key, value) pairs
+    is based on the INI and YAML formats (e.g. key=value or foo=TRUE). For full
+    documentation of the differences from the standards please refer to the
+    ConfigArgParse documentation. If an arg is specified in more than one place,
+    then commandline values override environment variables which override config
+    file values which override defaults.
 
     optional arguments:
-    -h, --help            show this help message and exit [env var:
-                        POGOMAP_HELP]
-    -cf CONFIG, --config CONFIG
-                        Set configuration file
-    -a AUTH_SERVICE, --auth-service AUTH_SERVICE
-                        Auth Services, either one for all accounts or one per
-                        account: ptc or google. Defaults all to ptc. [env var:
-                        POGOMAP_AUTH_SERVICE]
-    -u USERNAME, --username USERNAME
-                        Usernames, one per account. [env var:
-                        POGOMAP_USERNAME]
-    -p PASSWORD, --password PASSWORD
-                        Passwords, either single one for all accounts or one
-                        per account. [env var: POGOMAP_PASSWORD]
-    -w WORKERS, --workers WORKERS
-                        Number of search worker threads to start. Defaults to
-                        the number of accounts specified. [env var:
-                        POGOMAP_WORKERS]
-    -asi ACCOUNT_SEARCH_INTERVAL, --account-search-interval ACCOUNT_SEARCH_INTERVAL
-                        Seconds for accounts to search before switching to a
-                        new account. 0 to disable. [env var:
-                        POGOMAP_ACCOUNT_SEARCH_INTERVAL]
-    -ari ACCOUNT_REST_INTERVAL, --account-rest-interval ACCOUNT_REST_INTERVAL
-                        Seconds for accounts to rest when they fail or are
-                        switched out. [env var: POGOMAP_ACCOUNT_REST_INTERVAL]
-    -ac ACCOUNTCSV, --accountcsv ACCOUNTCSV
-                        Load accounts from CSV file containing
-                        "auth_service,username,passwd" lines. [env var:
-                        POGOMAP_ACCOUNTCSV]
-    -hlvl HIGH_LVL_ACCOUNTS, --high-lvl-accounts HIGH_LVL_ACCOUNTS
-                        Load high level accounts from CSV file containing
-                        "auth_service,username,passwd" lines. [env var:
-                        POGOMAP_HIGH_LVL_ACCOUNTS]
-    -bh, --beehive        Use beehive configuration for multiple accounts, one
-                        account per hex. Make sure to keep -st under 5, and -w
-                        under the total amount of accounts available. [env
-                        var: POGOMAP_BEEHIVE]
-    -wph WORKERS_PER_HIVE, --workers-per-hive WORKERS_PER_HIVE
-                        Only referenced when using --beehive. Sets number of
-                        workers per hive. Default value is 1. [env var:
-                        POGOMAP_WORKERS_PER_HIVE]
-    -l LOCATION, --location LOCATION
-                        Location, can be an address or coordinates. [env var:
-                        POGOMAP_LOCATION]
-    -alt ALTITUDE, --altitude ALTITUDE
-                        Default altitude in meters. [env var:
-                        POGOMAP_ALTITUDE]
-    -altv ALTITUDE_VARIANCE, --altitude-variance ALTITUDE_VARIANCE
-                        Variance for --altitude in meters [env var:
-                        POGOMAP_ALTITUDE_VARIANCE]
-    -uac, --use-altitude-cache
-                        Query the Elevation API for each step, rather than
-                        only once, and store results in the database. [env
-                        var: POGOMAP_USE_ALTITUDE_CACHE]
-    -nj, --no-jitter      Don't apply random -9m to +9m jitter to location. [env
-                        var: POGOMAP_NO_JITTER]
-    -al, --access-logs    Write web logs to access.log. [env var:
-                        POGOMAP_ACCESS_LOGS]
-    -st STEP_LIMIT, --step-limit STEP_LIMIT
-                        Steps. [env var: POGOMAP_STEP_LIMIT]
-    -sd SCAN_DELAY, --scan-delay SCAN_DELAY
-                        Time delay between requests in scan threads. [env var:
-                        POGOMAP_SCAN_DELAY]
-    --spawn-delay SPAWN_DELAY
-                        Number of seconds after spawn time to wait before
-                        scanning to be sure the Pokemon is there. [env var:
-                        POGOMAP_SPAWN_DELAY]
-    -enc, --encounter     Start an encounter to gather IVs and moves. [env var:
-                        POGOMAP_ENCOUNTER]
-    -cs, --captcha-solving
-                        Enables captcha solving. [env var:
-                        POGOMAP_CAPTCHA_SOLVING]
-    -ck CAPTCHA_KEY, --captcha-key CAPTCHA_KEY
-                        2Captcha API key. [env var: POGOMAP_CAPTCHA_KEY]
-    -cds CAPTCHA_DSK, --captcha-dsk CAPTCHA_DSK
-                        Pokemon Go captcha data-sitekey. [env var:
-                        POGOMAP_CAPTCHA_DSK]
-    -mcd MANUAL_CAPTCHA_DOMAIN, --manual-captcha-domain MANUAL_CAPTCHA_DOMAIN
-                        Domain to where captcha tokens will be sent. [env var:
-                        POGOMAP_MANUAL_CAPTCHA_DOMAIN]
-    -mcr MANUAL_CAPTCHA_REFRESH, --manual-captcha-refresh MANUAL_CAPTCHA_REFRESH
-                        Time available before captcha page refreshes. [env
-                        var: POGOMAP_MANUAL_CAPTCHA_REFRESH]
-    -mct MANUAL_CAPTCHA_TIMEOUT, --manual-captcha-timeout MANUAL_CAPTCHA_TIMEOUT
-                        Maximum time captchas will wait for manual captcha
-                        solving. On timeout, if enabled, 2Captcha will be used
-                        to solve captcha. Default is 0. [env var:
-                        POGOMAP_MANUAL_CAPTCHA_TIMEOUT]
-    -ed ENCOUNTER_DELAY, --encounter-delay ENCOUNTER_DELAY
-                        Time delay between encounter pokemon in scan threads.
-                        [env var: POGOMAP_ENCOUNTER_DELAY]
-    -encwf ENC_WHITELIST_FILE, --enc-whitelist-file ENC_WHITELIST_FILE
-                        File containing a list of Pokemon IDs to encounter for
-                        IV/CP scanning. [env var: POGOMAP_IV_WHITELIST_FILE]
-    -nostore, --no-api-store
-                        Don't store the API objects used by the high level
-                        accounts in memory. This will increase the number of
-                        logins per account, but decreases memory usage. [env
-                        var: POGOMAP_NO_API_STORE]
-    -wwht WEBHOOK_WHITELIST, --webhook-whitelist WEBHOOK_WHITELIST
-                        List of Pokemon to send to webhooks. Specified as
-                        Pokemon ID. [env var: POGOMAP_WEBHOOK_WHITELIST]
-    -wblk WEBHOOK_BLACKLIST, --webhook-blacklist WEBHOOK_BLACKLIST
-                        List of Pokemon NOT to send to webhooks. Specified as
-                        Pokemon ID. [env var: POGOMAP_WEBHOOK_BLACKLIST]
-    -wwhtf WEBHOOK_WHITELIST_FILE, --webhook-whitelist-file WEBHOOK_WHITELIST_FILE
-                        File containing a list of Pokemon IDs to be sent to
-                        webhooks. [env var: POGOMAP_WEBHOOK_WHITELIST_FILE]
-    -wblkf WEBHOOK_BLACKLIST_FILE, --webhook-blacklist-file WEBHOOK_BLACKLIST_FILE
-                        File containing a list of Pokemon IDs NOT to be sent to
-                        webhooks. [env var: POGOMAP_WEBHOOK_BLACKLIST_FILE]
-    -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
-                        Time delay between each login attempt. [env var:
-                        POGOMAP_LOGIN_DELAY]
-    -lr LOGIN_RETRIES, --login-retries LOGIN_RETRIES
-                        Number of times to retry the login before refreshing a
-                        thread. [env var: POGOMAP_LOGIN_RETRIES]
-    -mf MAX_FAILURES, --max-failures MAX_FAILURES
-                        Maximum number of failures to parse locations before
-                        an account will go into a sleep for -ari/--account-
-                        rest-interval seconds. [env var: POGOMAP_MAX_FAILURES]
-    -me MAX_EMPTY, --max-empty MAX_EMPTY
-                        Maximum number of empty scans before an account will
-                        go into a sleep for -ari/--account-rest-interval
-                        seconds.Reasonable to use with proxies. [env var:
-                        POGOMAP_MAX_EMPTY]
-    -bsr BAD_SCAN_RETRY, --bad-scan-retry BAD_SCAN_RETRY
-                        Number of bad scans before giving up on a step.
-                        Default 2, 0 to disable. [env var:
-                        POGOMAP_BAD_SCAN_RETRY]
-    -msl MIN_SECONDS_LEFT, --min-seconds-left MIN_SECONDS_LEFT
-                        Time that must be left on a spawn before considering
-                        it too late and skipping it. For example 600 would
-                        skip anything with < 10 minutes remaining. Default 0.
-                        [env var: POGOMAP_MIN_SECONDS_LEFT]
-    -dc, --display-in-console
-                        Display Found Pokemon in Console. [env var:
-                        POGOMAP_DISPLAY_IN_CONSOLE]
-    -H HOST, --host HOST  Set web server listening host. [env var: POGOMAP_HOST]
-    -P PORT, --port PORT  Set web server listening port. [env var: POGOMAP_PORT]
-    -L LOCALE, --locale LOCALE
-                        Locale for Pokemon names (default: en, check
-                        static/dist/locales for more). [env var:
-                        POGOMAP_LOCALE]
-    -c, --china           Coordinates transformer for China. [env var:
-                        POGOMAP_CHINA]
-    -m MOCK, --mock MOCK  Mock mode - point to a fpgo endpoint instead of using
-                        the real PogoApi, ec: http://127.0.0.1:9090 [env var:
-                        POGOMAP_MOCK]
-    -ns, --no-server      No-Server Mode. Starts the searcher but not the
-                        Webserver. [env var: POGOMAP_NO_SERVER]
-    -os, --only-server    Server-Only Mode. Starts only the Webserver without
-                        the searcher. [env var: POGOMAP_ONLY_SERVER]
-    -sc, --search-control
-                        Enables search control. [env var:
-                        POGOMAP_SEARCH_CONTROL]
-    -nfl, --no-fixed-location
-                        Disables a fixed map location and shows the search bar
-                        for use in shared maps. [env var:
-                        POGOMAP_NO_FIXED_LOCATION]
-    -k GMAPS_KEY, --gmaps-key GMAPS_KEY
-                        Google Maps Javascript API Key. [env var:
-                        POGOMAP_GMAPS_KEY]
-    --skip-empty          Enables skipping of empty cells in normal scans -
-                        requires previously populated database (not to be used
-                        with -ss) [env var: POGOMAP_SKIP_EMPTY]
-    -C, --cors            Enable CORS on web server. [env var: POGOMAP_CORS]
-    -D DB, --db DB        Database filename for SQLite. [env var: POGOMAP_DB]
-    -cd, --clear-db       Deletes the existing database before starting the
-                        Webserver. [env var: POGOMAP_CLEAR_DB]
-    -np, --no-pokemon     Disables Pokemon from the map (including parsing them
-                        into local db.) [env var: POGOMAP_NO_POKEMON]
-    -ng, --no-gyms        Disables Gyms from the map (including parsing them
-                        into local db). [env var: POGOMAP_NO_GYMS]
-    -nk, --no-pokestops   Disables PokeStops from the map (including parsing
-                        them into local db). [env var: POGOMAP_NO_POKESTOPS]
-    -ss [SPAWNPOINT_SCANNING], --spawnpoint-scanning [SPAWNPOINT_SCANNING]
-                        Use spawnpoint scanning (instead of hex grid). Scans
-                        in a circle based on step_limit when on DB. [env var:
-                        POGOMAP_SPAWNPOINT_SCANNING]
-    -speed, --speed-scan  Use speed scanning to identify spawn points and then
-                        scan closest spawns. [env var: POGOMAP_SPEED_SCAN]
-    -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
-                        [env var: POGOMAP_KPH]
-    -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
-                        Set a maximum speed in km/hour for scanner movement,
-                        for high-level (L30) accounts. [env var:
-                        POGOMAP_HLVL_KPH]
-    -ldur LURE_DURATION, --lure-duration LURE_DURATION
-                        Change duration for lures set on pokestops. This is
-                        useful for events that extend lure duration. [env var:
-                        POGOMAP_LURE_DURATION]
-    --dump-spawnpoints    Dump the spawnpoints from the db to json (only for use
-                        with -ss). [env var: POGOMAP_DUMP_SPAWNPOINTS]
-    -pd PURGE_DATA, --purge-data PURGE_DATA
-                        Clear Pokemon from database this many hours after they
-                        disappear (0 to disable). [env var:
-                        POGOMAP_PURGE_DATA]
-    -px PROXY, --proxy PROXY
-                        Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
-                        POGOMAP_PROXY]
-    -pxsc, --proxy-skip-check
-                        Disable checking of proxies before start. [env var:
-                        POGOMAP_PROXY_SKIP_CHECK]
-    -pxt PROXY_TIMEOUT, --proxy-timeout PROXY_TIMEOUT
-                        Timeout settings for proxy checker in seconds. [env
-                        var: POGOMAP_PROXY_TIMEOUT]
-    -pxd PROXY_DISPLAY, --proxy-display PROXY_DISPLAY
-                        Display info on which proxy being used (index or
-                        full). To be used with -ps. [env var:
-                        POGOMAP_PROXY_DISPLAY]
-    -pxf PROXY_FILE, --proxy-file PROXY_FILE
-                        Load proxy list from text file (one proxy per line),
-                        overrides -px/--proxy. [env var: POGOMAP_PROXY_FILE]
-    -pxr PROXY_REFRESH, --proxy-refresh PROXY_REFRESH
-                        Period of proxy file reloading, in seconds. Works only
-                        with -pxf/--proxy-file. (0 to disable). [env var:
-                        POGOMAP_PROXY_REFRESH]
-    -pxo PROXY_ROTATION, --proxy-rotation PROXY_ROTATION
-                        Enable proxy rotation with account changing for search
-                        threads (none/round/random). [env var:
-                        POGOMAP_PROXY_ROTATION]
-    --db-type DB_TYPE     Type of database to be used (default: sqlite). [env
-                        var: POGOMAP_DB_TYPE]
-    --db-name DB_NAME     Name of the database to be used. [env var:
-                        POGOMAP_DB_NAME]
-    --db-user DB_USER     Username for the database. [env var: POGOMAP_DB_USER]
-    --db-pass DB_PASS     Password for the database. [env var: POGOMAP_DB_PASS]
-    --db-host DB_HOST     IP or hostname for the database. [env var:
-                        POGOMAP_DB_HOST]
-    --db-port DB_PORT     Port for the database. [env var: POGOMAP_DB_PORT]
-    --db-max_connections DB_MAX_CONNECTIONS
-                        Max connections (per thread) for the database. [env
-                        var: POGOMAP_DB_MAX_CONNECTIONS]
-    --db-threads DB_THREADS
-                        Number of db threads; increase if the db queue falls
-                        behind. [env var: POGOMAP_DB_THREADS]
-    -wh WEBHOOKS, --webhook WEBHOOKS
-                        Define URL(s) to POST webhook information to. [env
-                        var: POGOMAP_WEBHOOK]
-    -gi, --gym-info       Get all details about gyms (causes an additional API
-                        hit for every gym). [env var: POGOMAP_GYM_INFO]
-    --disable-clean       Disable clean db loop. [env var:
-                        POGOMAP_DISABLE_CLEAN]
-    --webhook-updates-only
-                        Only send updates (Pokemon & lured pokestops). [env
-                        var: POGOMAP_WEBHOOK_UPDATES_ONLY]
-    --wh-threads WH_THREADS
-                        Number of webhook threads; increase if the webhook
-                        queue falls behind. [env var: POGOMAP_WH_THREADS]
-    -whc WH_CONCURRENCY, --wh-concurrency WH_CONCURRENCY
-                        Async requests pool size. [env var:
-                        POGOMAP_WH_CONCURRENCY]
-    -whr WH_RETRIES, --wh-retries WH_RETRIES
-                        Number of times to retry sending webhook data on
-                        failure. [env var: POGOMAP_WH_RETRIES]
-    -wht WH_TIMEOUT, --wh-timeout WH_TIMEOUT
-                        Timeout (in seconds) for webhook requests. [env var:
-                        POGOMAP_WH_TIMEOUT]
-    -whbf WH_BACKOFF_FACTOR, --wh-backoff-factor WH_BACKOFF_FACTOR
-                        Factor (in seconds) by which the delay until next
-                        retry will increase. [env var:
-                        POGOMAP_WH_BACKOFF_FACTOR]
-    -whlfu WH_LFU_SIZE, --wh-lfu-size WH_LFU_SIZE
-                        Webhook LFU cache max size. [env var:
-                        POGOMAP_WH_LFU_SIZE]
-    -whsu, --webhook-scheduler-updates
-                        Send webhook updates with scheduler status (use with
-                        -wh). [env var: POGOMAP_WEBHOOK_SCHEDULER_UPDATES]
-    --ssl-certificate SSL_CERTIFICATE
-                        Path to SSL certificate file. [env var:
-                        POGOMAP_SSL_CERTIFICATE]
-    --ssl-privatekey SSL_PRIVATEKEY
-                        Path to SSL private key file. [env var:
-                        POGOMAP_SSL_PRIVATEKEY]
-    -ps [logs], --print-status [logs]
-                        Show a status screen instead of log messages. Can
-                        switch between status and logs by pressing enter.
-                        Optionally specify "logs" to startup in logging mode.
-                        [env var: POGOMAP_PRINT_STATUS]
-    -slt STATS_LOG_TIMER, --stats-log-timer STATS_LOG_TIMER
-                        In log view, list per hr stats every X seconds [env
-                        var: POGOMAP_STATS_LOG_TIMER]
-    -sn STATUS_NAME, --status-name STATUS_NAME
-                        Enable status page database update using STATUS_NAME
-                        as main worker name. [env var: POGOMAP_STATUS_NAME]
-    -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
-                        Set the status page password. [env var:
-                        POGOMAP_STATUS_PAGE_PASSWORD]
-    -hk HASH_KEY, --hash-key HASH_KEY
-                        Key for hash server [env var: POGOMAP_HASH_KEY]
-    -tut, --complete-tutorial
-                        Complete ToS and tutorial steps on accounts if they
-                        haven't already. [env var: POGOMAP_COMPLETE_TUTORIAL]
-    -novc, --no-version-check
-                        Disable API version check. [env var:
-                        POGOMAP_NO_VERSION_CHECK]
-    -vci VERSION_CHECK_INTERVAL, --version-check-interval VERSION_CHECK_INTERVAL
-                        Interval to check API version in seconds (Default: in
-                        [60, 300]). [env var: POGOMAP_VERSION_CHECK_INTERVAL]
-    -el ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
-                        Path to encrypt lib to be used instead of the shipped
-                        ones. [env var: POGOMAP_ENCRYPT_LIB]
-    -odt ON_DEMAND_TIMEOUT, --on-demand_timeout ON_DEMAND_TIMEOUT
-                        Pause searching while web UI is inactive for this
-                        timeout (in seconds). [env var:
-                        POGOMAP_ON_DEMAND_TIMEOUT]
-    --disable-blacklist   Disable the global anti-scraper IP blacklist. [env
-                        var: POGOMAP_DISABLE_BLACKLIST]
-    -tp TRUSTED_PROXIES, --trusted-proxies TRUSTED_PROXIES
-                        Enables the use of X-FORWARDED-FOR headers to identify
-                        the IP of clients connecting through these trusted
-                        proxies. [env var: POGOMAP_TRUSTED_PROXIES]
-    -v [filename.log], --verbose [filename.log]
-                        Show debug messages from RocketMap and pgoapi.
-                        Optionally specify file to log to. [env var:
-                        POGOMAP_VERBOSE]
-    -vv [filename.log], --very-verbose [filename.log]
-                        Like verbose, but show debug messages from all modules
-                        as well. Optionally specify file to log to. [env var:
-                        POGOMAP_VERY_VERBOSE]
+      -h, --help            show this help message and exit [env var:
+                            POGOMAP_HELP]
+      -cf CONFIG, --config CONFIG
+                            Set configuration file
+      -a AUTH_SERVICE, --auth-service AUTH_SERVICE
+                            Auth Services, either one for all accounts or one per
+                            account: ptc or google. Defaults all to ptc. [env var:
+                            POGOMAP_AUTH_SERVICE]
+      -u USERNAME, --username USERNAME
+                            Usernames, one per account. [env var:
+                            POGOMAP_USERNAME]
+      -p PASSWORD, --password PASSWORD
+                            Passwords, either single one for all accounts or one
+                            per account. [env var: POGOMAP_PASSWORD]
+      -w WORKERS, --workers WORKERS
+                            Number of search worker threads to start. Defaults to
+                            the number of accounts specified. [env var:
+                            POGOMAP_WORKERS]
+      -asi ACCOUNT_SEARCH_INTERVAL, --account-search-interval ACCOUNT_SEARCH_INTERVAL
+                            Seconds for accounts to search before switching to a
+                            new account. 0 to disable. [env var:
+                            POGOMAP_ACCOUNT_SEARCH_INTERVAL]
+      -ari ACCOUNT_REST_INTERVAL, --account-rest-interval ACCOUNT_REST_INTERVAL
+                            Seconds for accounts to rest when they fail or are
+                            switched out. [env var: POGOMAP_ACCOUNT_REST_INTERVAL]
+      -ac ACCOUNTCSV, --accountcsv ACCOUNTCSV
+                            Load accounts from CSV file containing
+                            "auth_service,username,passwd" lines. [env var:
+                            POGOMAP_ACCOUNTCSV]
+      -hlvl HIGH_LVL_ACCOUNTS, --high-lvl-accounts HIGH_LVL_ACCOUNTS
+                            Load high level accounts from CSV file containing
+                            "auth_service,username,passwd" lines. [env var:
+                            POGOMAP_HIGH_LVL_ACCOUNTS]
+      -bh, --beehive        Use beehive configuration for multiple accounts, one
+                            account per hex. Make sure to keep -st under 5, and -w
+                            under the total amount of accounts available. [env
+                            var: POGOMAP_BEEHIVE]
+      -wph WORKERS_PER_HIVE, --workers-per-hive WORKERS_PER_HIVE
+                            Only referenced when using --beehive. Sets number of
+                            workers per hive. Default value is 1. [env var:
+                            POGOMAP_WORKERS_PER_HIVE]
+      -l LOCATION, --location LOCATION
+                            Location, can be an address or coordinates. [env var:
+                            POGOMAP_LOCATION]
+      -alt ALTITUDE, --altitude ALTITUDE
+                            Default altitude in meters. [env var:
+                            POGOMAP_ALTITUDE]
+      -altv ALTITUDE_VARIANCE, --altitude-variance ALTITUDE_VARIANCE
+                            Variance for --altitude in meters [env var:
+                            POGOMAP_ALTITUDE_VARIANCE]
+      -uac, --use-altitude-cache
+                            Query the Elevation API for each step, rather than
+                            only once, and store results in the database. [env
+                            var: POGOMAP_USE_ALTITUDE_CACHE]
+      -nj, --no-jitter      Don't apply random -9m to +9m jitter to location. [env
+                            var: POGOMAP_NO_JITTER]
+      -al, --access-logs    Write web logs to access.log. [env var:
+                            POGOMAP_ACCESS_LOGS]
+      -st STEP_LIMIT, --step-limit STEP_LIMIT
+                            Steps. [env var: POGOMAP_STEP_LIMIT]
+      -sd SCAN_DELAY, --scan-delay SCAN_DELAY
+                            Time delay between requests in scan threads. [env var:
+                            POGOMAP_SCAN_DELAY]
+      --spawn-delay SPAWN_DELAY
+                            Number of seconds after spawn time to wait before
+                            scanning to be sure the Pokemon is there. [env var:
+                            POGOMAP_SPAWN_DELAY]
+      -enc, --encounter     Start an encounter to gather IVs and moves. [env var:
+                            POGOMAP_ENCOUNTER]
+      -cs, --captcha-solving
+                            Enables captcha solving. [env var:
+                            POGOMAP_CAPTCHA_SOLVING]
+      -ck CAPTCHA_KEY, --captcha-key CAPTCHA_KEY
+                            2Captcha API key. [env var: POGOMAP_CAPTCHA_KEY]
+      -cds CAPTCHA_DSK, --captcha-dsk CAPTCHA_DSK
+                            Pokemon Go captcha data-sitekey. [env var:
+                            POGOMAP_CAPTCHA_DSK]
+      -mcd MANUAL_CAPTCHA_DOMAIN, --manual-captcha-domain MANUAL_CAPTCHA_DOMAIN
+                            Domain to where captcha tokens will be sent. [env var:
+                            POGOMAP_MANUAL_CAPTCHA_DOMAIN]
+      -mcr MANUAL_CAPTCHA_REFRESH, --manual-captcha-refresh MANUAL_CAPTCHA_REFRESH
+                            Time available before captcha page refreshes. [env
+                            var: POGOMAP_MANUAL_CAPTCHA_REFRESH]
+      -mct MANUAL_CAPTCHA_TIMEOUT, --manual-captcha-timeout MANUAL_CAPTCHA_TIMEOUT
+                            Maximum time captchas will wait for manual captcha
+                            solving. On timeout, if enabled, 2Captcha will be used
+                            to solve captcha. Default is 0. [env var:
+                            POGOMAP_MANUAL_CAPTCHA_TIMEOUT]
+      -ed ENCOUNTER_DELAY, --encounter-delay ENCOUNTER_DELAY
+                            Time delay between encounter pokemon in scan threads.
+                            [env var: POGOMAP_ENCOUNTER_DELAY]
+      -encwf ENC_WHITELIST_FILE, --enc-whitelist-file ENC_WHITELIST_FILE
+                            File containing a list of Pokemon IDs to encounter for
+                            IV/CP scanning. [env var: POGOMAP_ENC_WHITELIST_FILE]
+      -nostore, --no-api-store
+                            Don't store the API objects used by the high level
+                            accounts in memory. This will increase the number of
+                            logins per account, but decreases memory usage. [env
+                            var: POGOMAP_NO_API_STORE]
+      -wwht WEBHOOK_WHITELIST, --webhook-whitelist WEBHOOK_WHITELIST
+                            List of Pokemon to send to webhooks. Specified as
+                            Pokemon ID. [env var: POGOMAP_WEBHOOK_WHITELIST]
+      -wblk WEBHOOK_BLACKLIST, --webhook-blacklist WEBHOOK_BLACKLIST
+                            List of Pokemon NOT to send to webhooks. Specified as
+                            Pokemon ID. [env var: POGOMAP_WEBHOOK_BLACKLIST]
+      -wwhtf WEBHOOK_WHITELIST_FILE, --webhook-whitelist-file WEBHOOK_WHITELIST_FILE
+                            File containing a list of Pokemon IDs to be sent to
+                            webhooks. [env var: POGOMAP_WEBHOOK_WHITELIST_FILE]
+      -wblkf WEBHOOK_BLACKLIST_FILE, --webhook-blacklist-file WEBHOOK_BLACKLIST_FILE
+                            File containing a list of Pokemon IDs NOT to be sent
+                            towebhooks. [env var: POGOMAP_WEBHOOK_BLACKLIST_FILE]
+      -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
+                            Time delay between each login attempt. [env var:
+                            POGOMAP_LOGIN_DELAY]
+      -lr LOGIN_RETRIES, --login-retries LOGIN_RETRIES
+                            Number of times to retry the login before refreshing a
+                            thread. [env var: POGOMAP_LOGIN_RETRIES]
+      -mf MAX_FAILURES, --max-failures MAX_FAILURES
+                            Maximum number of failures to parse locations before
+                            an account will go into a sleep for -ari/--account-
+                            rest-interval seconds. [env var: POGOMAP_MAX_FAILURES]
+      -me MAX_EMPTY, --max-empty MAX_EMPTY
+                            Maximum number of empty scans before an account will
+                            go into a sleep for -ari/--account-rest-interval
+                            seconds.Reasonable to use with proxies. [env var:
+                            POGOMAP_MAX_EMPTY]
+      -bsr BAD_SCAN_RETRY, --bad-scan-retry BAD_SCAN_RETRY
+                            Number of bad scans before giving up on a step.
+                            Default 2, 0 to disable. [env var:
+                            POGOMAP_BAD_SCAN_RETRY]
+      -msl MIN_SECONDS_LEFT, --min-seconds-left MIN_SECONDS_LEFT
+                            Time that must be left on a spawn before considering
+                            it too late and skipping it. For example 600 would
+                            skip anything with < 10 minutes remaining. Default 0.
+                            [env var: POGOMAP_MIN_SECONDS_LEFT]
+      -dc, --display-in-console
+                            Display Found Pokemon in Console. [env var:
+                            POGOMAP_DISPLAY_IN_CONSOLE]
+      -H HOST, --host HOST  Set web server listening host. [env var: POGOMAP_HOST]
+      -P PORT, --port PORT  Set web server listening port. [env var: POGOMAP_PORT]
+      -L LOCALE, --locale LOCALE
+                            Locale for Pokemon names (default: en, check
+                            static/dist/locales for more). [env var:
+                            POGOMAP_LOCALE]
+      -c, --china           Coordinates transformer for China. [env var:
+                            POGOMAP_CHINA]
+      -m MOCK, --mock MOCK  Mock mode - point to a fpgo endpoint instead of using
+                            the real PogoApi, ec: http://127.0.0.1:9090 [env var:
+                            POGOMAP_MOCK]
+      -ns, --no-server      No-Server Mode. Starts the searcher but not the
+                            Webserver. [env var: POGOMAP_NO_SERVER]
+      -os, --only-server    Server-Only Mode. Starts only the Webserver without
+                            the searcher. [env var: POGOMAP_ONLY_SERVER]
+      -sc, --search-control
+                            Enables search control. [env var:
+                            POGOMAP_SEARCH_CONTROL]
+      -nfl, --no-fixed-location
+                            Disables a fixed map location and shows the search bar
+                            for use in shared maps. [env var:
+                            POGOMAP_NO_FIXED_LOCATION]
+      -k GMAPS_KEY, --gmaps-key GMAPS_KEY
+                            Google Maps Javascript API Key. [env var:
+                            POGOMAP_GMAPS_KEY]
+      --skip-empty          Enables skipping of empty cells in normal scans -
+                            requires previously populated database (not to be used
+                            with -ss) [env var: POGOMAP_SKIP_EMPTY]
+      -C, --cors            Enable CORS on web server. [env var: POGOMAP_CORS]
+      -D DB, --db DB        Database filename for SQLite. [env var: POGOMAP_DB]
+      -cd, --clear-db       Deletes the existing database before starting the
+                            Webserver. [env var: POGOMAP_CLEAR_DB]
+      -np, --no-pokemon     Disables Pokemon from the map (including parsing them
+                            into local db.) [env var: POGOMAP_NO_POKEMON]
+      -ng, --no-gyms        Disables Gyms from the map (including parsing them
+                            into local db). [env var: POGOMAP_NO_GYMS]
+      -nk, --no-pokestops   Disables PokeStops from the map (including parsing
+                            them into local db). [env var: POGOMAP_NO_POKESTOPS]
+      -ss [SPAWNPOINT_SCANNING], --spawnpoint-scanning [SPAWNPOINT_SCANNING]
+                            Use spawnpoint scanning (instead of hex grid). Scans
+                            in a circle based on step_limit when on DB. [env var:
+                            POGOMAP_SPAWNPOINT_SCANNING]
+      -speed, --speed-scan  Use speed scanning to identify spawn points and then
+                            scan closest spawns. [env var: POGOMAP_SPEED_SCAN]
+      -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
+                            [env var: POGOMAP_KPH]
+      -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
+                            Set a maximum speed in km/hour for scanner movement,
+                            for high-level (L30) accounts. [env var:
+                            POGOMAP_HLVL_KPH]
+      -ldur LURE_DURATION, --lure-duration LURE_DURATION
+                            Change duration for lures set on pokestops. This is
+                            useful for events that extend lure duration. [env var:
+                            POGOMAP_LURE_DURATION]
+      --dump-spawnpoints    Dump the spawnpoints from the db to json (only for use
+                            with -ss). [env var: POGOMAP_DUMP_SPAWNPOINTS]
+      -pd PURGE_DATA, --purge-data PURGE_DATA
+                            Clear Pokemon from database this many hours after they
+                            disappear (0 to disable). [env var:
+                            POGOMAP_PURGE_DATA]
+      -px PROXY, --proxy PROXY
+                            Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
+                            POGOMAP_PROXY]
+      -pxsc, --proxy-skip-check
+                            Disable checking of proxies before start. [env var:
+                            POGOMAP_PROXY_SKIP_CHECK]
+      -pxt PROXY_TIMEOUT, --proxy-timeout PROXY_TIMEOUT
+                            Timeout settings for proxy checker in seconds. [env
+                            var: POGOMAP_PROXY_TIMEOUT]
+      -pxre PROXY_RETRIES, --proxy-retries PROXY_RETRIES
+                            Number of times to retry sending proxy test requests
+                            on failure. [env var: POGOMAP_PROXY_RETRIES]
+      -pxbf PROXY_BACKOFF_FACTOR, --proxy-backoff-factor PROXY_BACKOFF_FACTOR
+                            Factor (in seconds) by which the delay until next
+                            retry will increase. [env var:
+                            POGOMAP_PROXY_BACKOFF_FACTOR]
+      -pxc PROXY_CONCURRENCY, --proxy-concurrency PROXY_CONCURRENCY
+                            Async requests pool size. [env var:
+                            POGOMAP_PROXY_CONCURRENCY]
+      -pxd PROXY_DISPLAY, --proxy-display PROXY_DISPLAY
+                            Display info on which proxy being used (index or
+                            full). To be used with -ps. [env var:
+                            POGOMAP_PROXY_DISPLAY]
+      -pxf PROXY_FILE, --proxy-file PROXY_FILE
+                            Load proxy list from text file (one proxy per line),
+                            overrides -px/--proxy. [env var: POGOMAP_PROXY_FILE]
+      -pxr PROXY_REFRESH, --proxy-refresh PROXY_REFRESH
+                            Period of proxy file reloading, in seconds. Works only
+                            with -pxf/--proxy-file. (0 to disable). [env var:
+                            POGOMAP_PROXY_REFRESH]
+      -pxo PROXY_ROTATION, --proxy-rotation PROXY_ROTATION
+                            Enable proxy rotation with account changing for search
+                            threads (none/round/random). [env var:
+                            POGOMAP_PROXY_ROTATION]
+      --db-type DB_TYPE     Type of database to be used (default: sqlite). [env
+                            var: POGOMAP_DB_TYPE]
+      --db-name DB_NAME     Name of the database to be used. [env var:
+                            POGOMAP_DB_NAME]
+      --db-user DB_USER     Username for the database. [env var: POGOMAP_DB_USER]
+      --db-pass DB_PASS     Password for the database. [env var: POGOMAP_DB_PASS]
+      --db-host DB_HOST     IP or hostname for the database. [env var:
+                            POGOMAP_DB_HOST]
+      --db-port DB_PORT     Port for the database. [env var: POGOMAP_DB_PORT]
+      --db-max_connections DB_MAX_CONNECTIONS
+                            Max connections (per thread) for the database. [env
+                            var: POGOMAP_DB_MAX_CONNECTIONS]
+      --db-threads DB_THREADS
+                            Number of db threads; increase if the db queue falls
+                            behind. [env var: POGOMAP_DB_THREADS]
+      -wh WEBHOOKS, --webhook WEBHOOKS
+                            Define URL(s) to POST webhook information to. [env
+                            var: POGOMAP_WEBHOOK]
+      -gi, --gym-info       Get all details about gyms (causes an additional API
+                            hit for every gym). [env var: POGOMAP_GYM_INFO]
+      --disable-clean       Disable clean db loop. [env var:
+                            POGOMAP_DISABLE_CLEAN]
+      --webhook-updates-only
+                            Only send updates (Pokemon & lured pokestops). [env
+                            var: POGOMAP_WEBHOOK_UPDATES_ONLY]
+      --wh-threads WH_THREADS
+                            Number of webhook threads; increase if the webhook
+                            queue falls behind. [env var: POGOMAP_WH_THREADS]
+      -whc WH_CONCURRENCY, --wh-concurrency WH_CONCURRENCY
+                            Async requests pool size. [env var:
+                            POGOMAP_WH_CONCURRENCY]
+      -whr WH_RETRIES, --wh-retries WH_RETRIES
+                            Number of times to retry sending webhook data on
+                            failure. [env var: POGOMAP_WH_RETRIES]
+      -wht WH_TIMEOUT, --wh-timeout WH_TIMEOUT
+                            Timeout (in seconds) for webhook requests. [env var:
+                            POGOMAP_WH_TIMEOUT]
+      -whbf WH_BACKOFF_FACTOR, --wh-backoff-factor WH_BACKOFF_FACTOR
+                            Factor (in seconds) by which the delay until next
+                            retry will increase. [env var:
+                            POGOMAP_WH_BACKOFF_FACTOR]
+      -whlfu WH_LFU_SIZE, --wh-lfu-size WH_LFU_SIZE
+                            Webhook LFU cache max size. [env var:
+                            POGOMAP_WH_LFU_SIZE]
+      -whsu, --webhook-scheduler-updates
+                            Send webhook updates with scheduler status (use with
+                            -wh). [env var: POGOMAP_WEBHOOK_SCHEDULER_UPDATES]
+      --ssl-certificate SSL_CERTIFICATE
+                            Path to SSL certificate file. [env var:
+                            POGOMAP_SSL_CERTIFICATE]
+      --ssl-privatekey SSL_PRIVATEKEY
+                            Path to SSL private key file. [env var:
+                            POGOMAP_SSL_PRIVATEKEY]
+      -ps [logs], --print-status [logs]
+                            Show a status screen instead of log messages. Can
+                            switch between status and logs by pressing enter.
+                            Optionally specify "logs" to startup in logging mode.
+                            [env var: POGOMAP_PRINT_STATUS]
+      -slt STATS_LOG_TIMER, --stats-log-timer STATS_LOG_TIMER
+                            In log view, list per hr stats every X seconds [env
+                            var: POGOMAP_STATS_LOG_TIMER]
+      -sn STATUS_NAME, --status-name STATUS_NAME
+                            Enable status page database update using STATUS_NAME
+                            as main worker name. [env var: POGOMAP_STATUS_NAME]
+      -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
+                            Set the status page password. [env var:
+                            POGOMAP_STATUS_PAGE_PASSWORD]
+      -hk HASH_KEY, --hash-key HASH_KEY
+                            Key for hash server [env var: POGOMAP_HASH_KEY]
+      -tut, --complete-tutorial
+                            Complete ToS and tutorial steps on accounts if they
+                            haven't already. [env var: POGOMAP_COMPLETE_TUTORIAL]
+      -novc, --no-version-check
+                            Disable API version check. [env var:
+                            POGOMAP_NO_VERSION_CHECK]
+      -vci VERSION_CHECK_INTERVAL, --version-check-interval VERSION_CHECK_INTERVAL
+                            Interval to check API version in seconds (Default: in
+                            [60, 300]). [env var: POGOMAP_VERSION_CHECK_INTERVAL]
+      -el ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
+                            Path to encrypt lib to be used instead of the shipped
+                            ones. [env var: POGOMAP_ENCRYPT_LIB]
+      -odt ON_DEMAND_TIMEOUT, --on-demand_timeout ON_DEMAND_TIMEOUT
+                            Pause searching while web UI is inactive for this
+                            timeout (in seconds). [env var:
+                            POGOMAP_ON_DEMAND_TIMEOUT]
+      --disable-blacklist   Disable the global anti-scraper IP blacklist. [env
+                            var: POGOMAP_DISABLE_BLACKLIST]
+      -tp TRUSTED_PROXIES, --trusted-proxies TRUSTED_PROXIES
+                            Enables the use of X-FORWARDED-FOR headers to identify
+                            the IP of clients connecting through these trusted
+                            proxies. [env var: POGOMAP_TRUSTED_PROXIES]
+      --api-version API_VERSION
+                            API version currently in use. [env var:
+                            POGOMAP_API_VERSION]
+      -v [filename.log], --verbose [filename.log]
+                            Show debug messages from RocketMap and pgoapi.
+                            Optionally specify file to log to. [env var:
+                            POGOMAP_VERBOSE]
+      -vv [filename.log], --very-verbose [filename.log]
+                            Like verbose, but show debug messages from all modules
+                            as well. Optionally specify file to log to. [env var:
+                            POGOMAP_VERY_VERBOSE]

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -20,8 +20,8 @@
                         [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-kph KPH]
                         [-hkph HLVL_KPH] [-ldur LURE_DURATION]
                         [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY] [-pxsc]
-                        [-pxt PROXY_TIMEOUT] [-pxre PROXY_RETRIES]
-                        [-pxbf PROXY_BACKOFF_FACTOR] [-pxc PROXY_CONCURRENCY]
+                        [-pxt PROXY_TEST_TIMEOUT] [-pxre PROXY_TEST_RETRIES]
+                        [-pxbf PROXY_TEST_BACKOFF_FACTOR] [-pxc PROXY_TEST_CONCURRENCY]
                         [-pxd PROXY_DISPLAY] [-pxf PROXY_FILE]
                         [-pxr PROXY_REFRESH] [-pxo PROXY_ROTATION]
                         [--db-type DB_TYPE] [--db-name DB_NAME]
@@ -255,19 +255,19 @@
       -pxsc, --proxy-skip-check
                             Disable checking of proxies before start. [env var:
                             POGOMAP_PROXY_SKIP_CHECK]
-      -pxt PROXY_TIMEOUT, --proxy-timeout PROXY_TIMEOUT
+      -pxt PROXY_TEST_TIMEOUT, --proxy-test-timeout PROXY_TEST_TIMEOUT
                             Timeout settings for proxy checker in seconds. [env
-                            var: POGOMAP_PROXY_TIMEOUT]
-      -pxre PROXY_RETRIES, --proxy-retries PROXY_RETRIES
+                            var: POGOMAP_PROXY_TEST_TIMEOUT]
+      -pxre PROXY_TEST_RETRIES, --proxy-test-retries PROXY_TEST_RETRIES
                             Number of times to retry sending proxy test requests
-                            on failure. [env var: POGOMAP_PROXY_RETRIES]
-      -pxbf PROXY_BACKOFF_FACTOR, --proxy-backoff-factor PROXY_BACKOFF_FACTOR
+                            on failure. [env var: POGOMAP_PROXY_TEST_RETRIES]
+      -pxbf PROXY_TEST_BACKOFF_FACTOR, --proxy-test-backoff-factor PROXY_TEST_BACKOFF_FACTOR
                             Factor (in seconds) by which the delay until next
                             retry will increase. [env var:
-                            POGOMAP_PROXY_BACKOFF_FACTOR]
-      -pxc PROXY_CONCURRENCY, --proxy-concurrency PROXY_CONCURRENCY
+                            POGOMAP_PROXY_TEST_BACKOFF_FACTOR]
+      -pxc PROXY_TEST_CONCURRENCY, --proxy-test-concurrency PROXY_TEST_CONCURRENCY
                             Async requests pool size. [env var:
-                            POGOMAP_PROXY_CONCURRENCY]
+                            POGOMAP_PROXY_TEST_CONCURRENCY]
       -pxd PROXY_DISPLAY, --proxy-display PROXY_DISPLAY
                             Display info on which proxy being used (index or
                             full). To be used with -ps. [env var:

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -157,6 +157,8 @@ def load_proxies(args):
 
 # Check all proxies and return a working list with proxies.
 def check_proxies(args, proxies):
+    total_proxies = len(proxies)
+
     # Store counter per result type.
     check_results = [0] * (check_result_max + 1)
 
@@ -164,7 +166,7 @@ def check_proxies(args, proxies):
     proxy_concurrency = args.proxy_concurrency
 
     if args.proxy_concurrency == 0:
-        proxy_concurrency = len(proxies)
+        proxy_concurrency = total_proxies
 
     # Get persistent session per host.
     # TODO: Rework API request wrapper so requests are retried, then increase
@@ -175,9 +177,6 @@ def check_proxies(args, proxies):
     niantic_session = get_async_requests_session(args.proxy_retries,
                                                  args.proxy_backoff_factor,
                                                  proxy_concurrency)
-
-    # Start proxy checking.
-    total_proxies = len(proxies)
 
     # List to hold background workers.
     proxy_queue = []

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -91,13 +91,13 @@ def start_request_futures(session, proxy, timeout):
                          'https%3A%2F%2Fwww.nianticlabs.com%2Fpokemongo' \
                          '%2Ferror'
 
-    log.debug('Checking proxy: %s.', proxy[1])
+    log.debug('Checking proxy: %s.', proxy)
 
     # Send request to nianticlabs.com.
     future_niantic = session.post(
         proxy_test_url,
         '',
-        proxies={'http': proxy[1], 'https': proxy[1]},
+        proxies={'http': proxy, 'https': proxy},
         timeout=timeout,
         background_callback=__proxy_check_completed)
 
@@ -105,7 +105,7 @@ def start_request_futures(session, proxy, timeout):
     future_ptc = session.get(
         proxy_test_ptc_url,
         '',
-        proxies={'http': proxy[1], 'https': proxy[1]},
+        proxies={'http': proxy, 'https': proxy},
         timeout=timeout,
         headers={'User-Agent':
                  'pokemongo/1 '

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -6,9 +6,8 @@ import requests
 import sys
 import time
 
-from queue import Queue
-from threading import Thread
 from random import randint
+from utils import get_async_requests_session
 
 log = logging.getLogger(__name__)
 
@@ -26,102 +25,105 @@ check_result_empty = 6
 check_result_max = 6  # Should be equal to maximal return code.
 
 
-# Simple function to do a call to Niantic's system for
-# testing proxy connectivity.
-def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
+# Evaluates the status of PTC and Niantic request futures, and returns the
+# result (optionally with an error).
+# Warning: blocking! Can only get status code if request has finished.
+def get_proxy_test_status(proxy, future_ptc, future_niantic):
+    # Start by assuming everything is OK.
+    check_result = check_result_ok
+    proxy_error = None
 
-    # Url for proxy testing.
+    # Make sure we don't trip any code quality tools that test scope.
+    ptc_response = None
+    niantic_response = None
+
+    # Make sure both requests are completed.
+    try:
+        ptc_response = future_ptc.result()
+        niantic_response = future_niantic.result()
+    except requests.ConnectTimeout:
+        proxy_error = ('Connection timeout for'
+                       + ' proxy {}.').format(proxy)
+        check_result = check_result_timeout
+    except requests.ConnectionError:
+        proxy_error = 'Failed to connect to proxy {}.'.format(proxy)
+        check_result = check_result_failed
+    except Exception as e:
+        proxy_error = e
+        check_result = check_result_exception
+
+    # If we've already encountered a problem, stop here.
+    if proxy_error:
+        return (proxy_error, check_result)
+
+    # Evaluate response status code.
+    ptc_status = ptc_response.status_code
+    niantic_status = niantic_response.status_code
+
+    banned_status_codes = [403, 409]
+
+    if niantic_status == 200 and ptc_status == 200:
+        log.debug('Proxy %s is ok.', proxy)
+    elif (niantic_status in banned_status_codes or
+          ptc_status in banned_status_codes):
+        proxy_error = ('Proxy {} is banned -'
+                       + ' got PTC status code: {}, Niantic status'
+                       + ' code: {}.').format(proxy,
+                                              ptc_status,
+                                              niantic_status)
+        check_result = check_result_banned
+    else:
+        proxy_error = ('Wrong status codes -'
+                       + ' PTC: {},'
+                       + ' Niantic: {}.').format(ptc_status,
+                                                 niantic_status)
+        check_result = check_result_wrong
+
+    return (proxy_error, check_result)
+
+
+# Requests to send for testing, which returns futures for Niantic and PTC.
+def start_request_futures(session, proxy, timeout):
+    # URLs for proxy testing.
     proxy_test_url = 'https://pgorelease.nianticlabs.com/plfe/rpc'
     proxy_test_ptc_url = 'https://sso.pokemon.com/sso/oauth2.0/authorize?' \
                          'client_id=mobile-app_pokemon-go&redirect_uri=' \
                          'https%3A%2F%2Fwww.nianticlabs.com%2Fpokemongo' \
                          '%2Ferror'
-    proxy = proxy_queue.get()
 
-    check_result = check_result_ok
+    log.debug('Checking proxy: %s.', proxy[1])
 
-    if proxy and proxy[1]:
+    # Send request to nianticlabs.com.
+    future_niantic = session.post(
+        proxy_test_url,
+        '',
+        proxies={'http': proxy[1], 'https': proxy[1]},
+        timeout=timeout,
+        background_callback=__proxy_check_completed)
 
-        log.debug('Checking proxy: %s', proxy[1])
+    # Send request to pokemon.com.
+    future_ptc = session.get(
+        proxy_test_ptc_url,
+        '',
+        proxies={'http': proxy[1], 'https': proxy[1]},
+        timeout=timeout,
+        headers={'User-Agent':
+                 'pokemongo/1 '
+                 'CFNetwork/811.4.18 '
+                 'Darwin/16.5.0',
+                 'Host':
+                 'sso.pokemon.com',
+                 'X-Unity-Version':
+                 '5.5.1f1'},
+        background_callback=__proxy_check_completed)
 
-        try:
-            proxy_response = requests.post(proxy_test_url, '',
-                                           proxies={'http': proxy[1],
-                                                    'https': proxy[1]},
-                                           timeout=timeout)
-
-            proxy_response_ptc = requests.get(proxy_test_ptc_url, '',
-                                              proxies={'http': proxy[1],
-                                                       'https': proxy[1]},
-                                              timeout=timeout,
-                                              headers={'User-Agent':
-                                                       'pokemongo/1 '
-                                                       'CFNetwork/811.4.18 '
-                                                       'Darwin/16.5.0',
-                                                       'Host':
-                                                       'sso.pokemon.com',
-                                                       'X-Unity-Version':
-                                                       '5.5.1f1'})
-
-            niantic_status = proxy_response.status_code
-            ptc_status = proxy_response_ptc.status_code
-
-            banned_status_codes = [403, 409]
-
-            if niantic_status == 200 and ptc_status == 200:
-                log.debug('Proxy %s is ok.', proxy[1])
-                proxy_queue.task_done()
-                proxies.append(proxy[1])
-                check_results[check_result_ok] += 1
-                return True
-
-            elif (niantic_status in banned_status_codes or
-                  ptc_status in banned_status_codes):
-                proxy_error = ("Proxy " + proxy[1] +
-                               " is banned - got Niantic status code: " +
-                               str(niantic_status) + ", PTC status code: " +
-                               str(ptc_status))
-                check_result = check_result_banned
-
-            else:
-                proxy_error = ("Wrong status codes - " + str(niantic_status) +
-                               ", " + str(ptc_status))
-                check_result = check_result_wrong
-
-        except requests.ConnectTimeout:
-            proxy_error = ("Connection timeout (" + str(timeout) +
-                           " second(s) ) via proxy " + proxy[1])
-            check_result = check_result_timeout
-
-        except requests.ConnectionError:
-            proxy_error = "Failed to connect to proxy " + proxy[1]
-            check_result = check_result_failed
-
-        except Exception as e:
-            proxy_error = e
-            check_result = check_result_exception
-
-    else:
-        proxy_error = "Empty proxy server."
-        check_result = check_result_empty
-
-    # Decrease output amount if there are lot of proxies.
-    if show_warnings:
-        log.warning('%s', repr(proxy_error))
-    else:
-        log.debug('%s', repr(proxy_error))
-    proxy_queue.task_done()
-
-    check_results[check_result] += 1
-    return False
+    # Return futures.
+    return (future_ptc, future_niantic)
 
 
-# Check all proxies and return a working list with proxies.
-def check_proxies(args):
-
-    source_proxies = []
-
-    check_results = [0] * (check_result_max + 1)
+# Load proxies and return a list.
+def load_proxies(args):
+    proxies = []
 
     # Load proxies from the file. Override args.proxy if specified.
     if args.proxy_file is not None:
@@ -129,95 +131,128 @@ def check_proxies(args):
 
         with open(args.proxy_file) as f:
             for line in f:
+                stripped = line.strip()
+
                 # Ignore blank lines and comment lines.
-                if len(line.strip()) == 0 or line.startswith('#'):
+                if len(stripped) == 0 or line.startswith('#'):
                     continue
-                source_proxies.append(line.strip())
 
-        log.info('Loaded %d proxies.', len(source_proxies))
+                proxies.append(stripped)
 
-        if len(source_proxies) == 0:
+        log.info('Loaded %d proxies.', len(proxies))
+
+        if len(proxies) == 0:
             log.error('Proxy file was configured but ' +
                       'no proxies were loaded. Aborting.')
             sys.exit(1)
     else:
-        source_proxies = args.proxy
+        proxies = args.proxy
 
     # No proxies - no cookies.
-    if (source_proxies is None) or (len(source_proxies) == 0):
+    if (proxies is None) or (len(proxies) == 0):
         log.info('No proxies are configured.')
         return None
 
-    if args.proxy_skip_check:
-        return source_proxies
+    return proxies
 
-    proxy_queue = Queue()
-    total_proxies = len(source_proxies)
+
+# Check all proxies and return a working list with proxies.
+def check_proxies(args, proxies):
+    # Store counter per result type.
+    check_results = [0] * (check_result_max + 1)
+
+    # Get persistent session.
+    # TODO: Rework API request wrapper so requests are retried, then increase
+    # the # of retries to allow for proxies.
+    session = get_async_requests_session(args.proxy_retries,
+                                         args.proxy_backoff_factor,
+                                         args.proxy_concurrency)
+
+    # Start proxy checking.
+    total_proxies = len(proxies)
+
+    # List to hold background workers.
+    proxy_queue = []
+    working_proxies = []
+    show_warnings = total_proxies <= 10
 
     log.info('Checking %d proxies...', total_proxies)
-    if (total_proxies > 10):
-        log.info('Enable "-v or -vv" to see checking details.')
+    if not show_warnings:
+        log.info('Enable -v or -vv to see proxy testing details.')
 
-    proxies = []
+    # Start async requests & store futures.
+    for proxy in proxies:
+        future_ptc, future_niantic = start_request_futures(session,
+                                                           proxy,
+                                                           args.proxy_timeout)
 
-    for proxy in enumerate(source_proxies):
-        proxy_queue.put(proxy)
+        proxy_queue.append((proxy, future_ptc, future_niantic))
 
-        t = Thread(target=check_proxy,
-                   name='check_proxy',
-                   args=(proxy_queue, args.proxy_timeout, proxies,
-                         total_proxies <= 10, check_results))
-        t.daemon = True
-        t.start()
+    # Wait here until all items in proxy_queue are processed, so we have a list
+    # of working proxies. We intentionally start all requests before handling
+    # them so they can asynchronously continue in the background, even as we're
+    # blocking to wait for one. The double loop is intentional.
+    for proxy, future_ptc, future_niantic in proxy_queue:
+        error, result = get_proxy_test_status(proxy,
+                                              future_ptc,
+                                              future_niantic)
 
-    # This is painful but we need to wait here until proxy_queue is
-    # completed so we have a working list of proxies.
-    proxy_queue.join()
+        check_results[result] += 1
 
-    working_proxies = len(proxies)
+        if error:
+            # Decrease output amount if there are a lot of proxies.
+            if show_warnings:
+                log.warning(error)
+            else:
+                log.debug(error)
+        else:
+            working_proxies.append(proxy)
 
-    if working_proxies == 0:
-        log.error('Proxy was configured but no working ' +
-                  'proxies were found. Aborting.')
+    num_working_proxies = len(working_proxies)
+
+    if num_working_proxies == 0:
+        log.error('Proxy was configured but no working'
+                  + ' proxies were found. Exiting process.')
         sys.exit(1)
     else:
         other_fails = (check_results[check_result_failed] +
                        check_results[check_result_wrong] +
                        check_results[check_result_exception] +
                        check_results[check_result_empty])
-        log.info('Proxy check completed. Working: %d, banned: %d, ' +
-                 'timeout: %d, other fails: %d of total %d configured.',
-                 working_proxies, check_results[check_result_banned],
+        log.info('Proxy check completed. Working: %d, banned: %d,'
+                 + ' timeout: %d, other fails: %d of total %d configured.',
+                 num_working_proxies, check_results[check_result_banned],
                  check_results[check_result_timeout],
                  other_fails,
                  total_proxies)
-        return proxies
+
+        return working_proxies
 
 
 # Thread function for periodical proxy updating.
 def proxies_refresher(args):
-
     while True:
-        # Wait BEFORE refresh, because initial refresh is done at startup.
+        # Wait before refresh, because initial refresh is done at startup.
         time.sleep(args.proxy_refresh)
 
         try:
-            proxies = check_proxies(args)
+            proxies = load_proxies(args)
 
-            if len(proxies) == 0:
-                log.warning('No live proxies found. Using previous ones ' +
-                            'until next round...')
-                continue
+            if not args.proxy_skip_check:
+                proxies = check_proxies(args, proxies)
+
+            # If we've arrived here, we're guaranteed to have at least one
+            # working proxy. check_proxies stops the process if no proxies
+            # are left.
 
             args.proxy = proxies
             log.info('Regular proxy refresh complete.')
         except Exception as e:
-            log.exception('Exception while refresh proxies: %s', repr(e))
+            log.exception('Exception while refreshing proxies: %s.', e)
 
 
 # Provide new proxy for a search thread.
 def get_new_proxy(args):
-
     global last_proxy
 
     # If none/round - simply get next proxy.
@@ -237,3 +272,9 @@ def get_new_proxy(args):
         lp = 0
 
     return lp, args.proxy[lp]
+
+
+# Background handler for completed proxy check requests.
+# Currently doesn't do anything.
+def __proxy_check_completed(sess, resp):
+    pass

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -161,7 +161,7 @@ def check_proxies(args, proxies):
     check_results = [0] * (check_result_max + 1)
 
     # If proxy testing concurrency is set to automatic, use max.
-    proxy_concurrency = 0
+    proxy_concurrency = args.proxy_concurrency
 
     if args.proxy_concurrency == 0:
         proxy_concurrency = len(proxies)

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -104,7 +104,6 @@ def start_request_futures(session, proxy, timeout):
     # Send request to pokemon.com.
     future_ptc = session.get(
         proxy_test_ptc_url,
-        '',
         proxies={'http': proxy, 'https': proxy},
         timeout=timeout,
         headers={'User-Agent':

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -163,20 +163,22 @@ def check_proxies(args, proxies):
     check_results = [0] * (check_result_max + 1)
 
     # If proxy testing concurrency is set to automatic, use max.
-    proxy_concurrency = args.proxy_concurrency
+    proxy_concurrency = args.proxy_test_concurrency
 
-    if args.proxy_concurrency == 0:
+    if args.proxy_test_concurrency == 0:
         proxy_concurrency = total_proxies
 
     # Get persistent session per host.
     # TODO: Rework API request wrapper so requests are retried, then increase
     # the # of retries to allow for proxies.
-    ptc_session = get_async_requests_session(args.proxy_retries,
-                                             args.proxy_backoff_factor,
-                                             proxy_concurrency)
-    niantic_session = get_async_requests_session(args.proxy_retries,
-                                                 args.proxy_backoff_factor,
-                                                 proxy_concurrency)
+    ptc_session = get_async_requests_session(
+        args.proxy_test_retries,
+        args.proxy_test_backoff_factor,
+        proxy_concurrency)
+    niantic_session = get_async_requests_session(
+        args.proxy_test_retries,
+        args.proxy_test_backoff_factor,
+        proxy_concurrency)
 
     # List to hold background workers.
     proxy_queue = []
@@ -189,10 +191,11 @@ def check_proxies(args, proxies):
 
     # Start async requests & store futures.
     for proxy in proxies:
-        future_ptc, future_niantic = start_request_futures(ptc_session,
-                                                           niantic_session,
-                                                           proxy,
-                                                           args.proxy_timeout)
+        future_ptc, future_niantic = start_request_futures(
+            ptc_session,
+            niantic_session,
+            proxy,
+            args.proxy_test_timeout)
 
         proxy_queue.append((proxy, future_ptc, future_niantic))
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -17,6 +17,9 @@ import hashlib
 
 from s2sphere import CellId, LatLng
 from geopy.geocoders import GoogleV3
+from requests_futures.sessions import FuturesSession
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 from . import config
 
@@ -316,6 +319,17 @@ def get_args():
     parser.add_argument('-pxt', '--proxy-timeout',
                         help='Timeout settings for proxy checker in seconds.',
                         type=int, default=5)
+    parser.add_argument('-pxre', '--proxy-retries',
+                        help=('Number of times to retry sending proxy ' +
+                              'test requests on failure.'),
+                        type=int, default=0)
+    parser.add_argument('-pxbf', '--proxy-backoff-factor',
+                        help=('Factor (in seconds) by which the delay ' +
+                              'until next retry will increase.'),
+                        type=float, default=0.25)
+    parser.add_argument('-pxc', '--proxy-concurrency',
+                        help=('Async requests pool size.'), type=int,
+                        default=10)
     parser.add_argument('-pxd', '--proxy-display',
                         help=('Display info on which proxy being used ' +
                               '(index or full). To be used with -ps.'),
@@ -929,11 +943,11 @@ def generate_device_info(identifier):
 
 def extract_sprites(root_path):
     zip_path = os.path.join(
-           root_path,
-           'static01.zip')
+        root_path,
+        'static01.zip')
     extract_path = os.path.join(
-           root_path,
-           'static')
+        root_path,
+        'static')
     log.debug('Extracting sprites from "%s" to "%s"', zip_path, extract_path)
     zip = zipfile.ZipFile(zip_path, 'r')
     zip.extractall(extract_path)
@@ -1000,3 +1014,33 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
                       + ' Using default locale.', e)
 
     return player_locale
+
+
+# Get a future_requests FuturesSession that supports asynchronous workers
+# and retrying requests on failure.
+# Setting up a persistent session that is re-used by multiple requests can
+# speed up requests to the same host, as it'll re-use the underlying TCP
+# connection.
+def get_async_requests_session(num_retries, backoff_factor, pool_size,
+                               status_forcelist=[500, 502, 503, 504]):
+    # Use requests & urllib3 to auto-retry.
+    # If the backoff_factor is 0.1, then sleep() will sleep for [0.1s, 0.2s,
+    # 0.4s, ...] between retries. It will also force a retry if the status
+    # code returned is in status_forcelist.
+    session = FuturesSession(max_workers=pool_size)
+
+    # If any regular response is generated, no retry is done. Without using
+    # the status_forcelist, even a response with status 500 will not be
+    # retried.
+    retries = Retry(total=num_retries, backoff_factor=backoff_factor,
+                    status_forcelist=status_forcelist)
+
+    # Mount handler on both HTTP & HTTPS.
+    session.mount('http://', HTTPAdapter(max_retries=retries,
+                                         pool_connections=pool_size,
+                                         pool_maxsize=pool_size))
+    session.mount('https://', HTTPAdapter(max_retries=retries,
+                                          pool_connections=pool_size,
+                                          pool_maxsize=pool_size))
+
+    return session

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -316,18 +316,18 @@ def get_args():
     parser.add_argument('-pxsc', '--proxy-skip-check',
                         help='Disable checking of proxies before start.',
                         action='store_true', default=False)
-    parser.add_argument('-pxt', '--proxy-timeout',
+    parser.add_argument('-pxt', '--proxy-test-timeout',
                         help='Timeout settings for proxy checker in seconds.',
                         type=int, default=5)
-    parser.add_argument('-pxre', '--proxy-retries',
+    parser.add_argument('-pxre', '--proxy-test-retries',
                         help=('Number of times to retry sending proxy ' +
                               'test requests on failure.'),
                         type=int, default=0)
-    parser.add_argument('-pxbf', '--proxy-backoff-factor',
+    parser.add_argument('-pxbf', '--proxy-test-backoff-factor',
                         help=('Factor (in seconds) by which the delay ' +
                               'until next retry will increase.'),
                         type=float, default=0.25)
-    parser.add_argument('-pxc', '--proxy-concurrency',
+    parser.add_argument('-pxc', '--proxy-test-concurrency',
                         help=('Async requests pool size.'), type=int,
                         default=0)
     parser.add_argument('-pxd', '--proxy-display',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -329,7 +329,7 @@ def get_args():
                         type=float, default=0.25)
     parser.add_argument('-pxc', '--proxy-concurrency',
                         help=('Async requests pool size.'), type=int,
-                        default=10)
+                        default=0)
     parser.add_argument('-pxd', '--proxy-display',
                         help=('Display info on which proxy being used ' +
                               '(index or full). To be used with -ps.'),

--- a/runserver.py
+++ b/runserver.py
@@ -27,7 +27,7 @@ from pogom.models import (init_database, create_tables, drop_tables,
                           verify_table_encoding, verify_database_schema)
 from pogom.webhook import wh_updater
 
-from pogom.proxy import check_proxies, proxies_refresher
+from pogom.proxy import load_proxies, check_proxies, proxies_refresher
 
 # Currently supported pgoapi.
 pgoapi_version = "1.1.7"
@@ -313,17 +313,19 @@ def main():
     config['GMAPS_KEY'] = args.gmaps_key
 
     if not args.only_server:
-
-        # Abort if we don't have a hash key set
+        # Abort if we don't have a hash key set.
         if not args.hash_key:
             log.critical('Hash key is required for scanning. Exiting.')
             sys.exit()
 
         # Processing proxies if set (load from file, check and overwrite old
-        # args.proxy with new working list)
-        args.proxy = check_proxies(args)
+        # args.proxy with new working list).
+        args.proxy = load_proxies(args)
 
-        # Run periodical proxy refresh thread
+        if not args.proxy_skip_check:
+            check_proxies(args, args.proxy)
+
+        # Run periodical proxy refresh thread.
         if (args.proxy_file is not None) and (args.proxy_refresh > 0):
             t = Thread(target=proxies_refresher,
                        name='proxy-refresh', args=(args,))

--- a/runserver.py
+++ b/runserver.py
@@ -323,7 +323,7 @@ def main():
         args.proxy = load_proxies(args)
 
         if not args.proxy_skip_check:
-            check_proxies(args, args.proxy)
+            args.proxy = check_proxies(args, args.proxy)
 
         # Run periodical proxy refresh thread.
         if (args.proxy_file is not None) and (args.proxy_refresh > 0):


### PR DESCRIPTION
## Description
Consistent with how we send webhook data, proxy tests now use requests_futures' FutureSession for asynchronous requests and a proper worker pool.

FutureSession with urllib3's `Retry` allows for async requests that can automatically be retried, although retrying is disabled for now until we properly implement automatically retrying API requests to allow unstable proxies.

Also cleaned up `proxy.py` and separated proxy loading from proxy checking.

Added config items:
* `-pxre, --proxy-test-retries`: Number of times to retry sending proxy test requests on failure. Default: 0.
* `-pxbf, --proxy-test-backoff-factor`: Factor (in seconds) by which the delay until next retry will increase. Default: 0.25.
* `-pxc, --proxy-test-concurrency`: Async requests pool size. Default: 0 (= automatically set pool size to the number of proxies we have to test).

Tested performance difference is between 10% and 30%.

## Motivation and Context
Readability, consistency, performance.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
