### PR TITLE
Remove lowest_pokemon_motivation from major webhook updates field

### DIFF
--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -190,8 +190,7 @@ def __get_key_fields(whtype):
                     'individual_stamina', 'individual_defense',
                     'individual_attack', 'form', 'cp', 'pokemon_level'],
         'gym': ['team_id', 'guard_pokemon_id', 'gym_points', 'enabled',
-                'latitude', 'longitude', 'total_gym_cp',
-                'lowest_pokemon_motivation', 'occupied_seconds'],
+                'latitude', 'longitude', 'total_gym_cp', 'occupied_seconds'],
         'gym_details': ['latitude', 'longitude', 'team', 'pokemon']
     }
 


### PR DESCRIPTION
It is causing a substantial amount of gym webhook updates, that we really do not need.


