### PR TITLE
Stop external app by default. Make it opt-in.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ static/css/custom.css
 !contrib/supervisord/install-reinstall.sh
 !static/data/*
 !static/icons/hsl*.png
+!static/app/settings.json

--- a/static/app/settings.json
+++ b/static/app/settings.json
@@ -1,0 +1,4 @@
+{
+    "appAllowed": false,
+    "statsAllowed": false
+}


### PR DESCRIPTION
## Description
Someone built a mobile app (a web browser with changed interface) called [ThunderRadar](https://thunderstrike.software/thunderradar/) (unaffiliated to Thunderfox on Discord) that can be used to browse to any RocketMap website.

This change disables the app from visiting/scraping your website (regular browsers will still work) by default. Renaming or removing the file `static/app/settings.json` will re-enable it.

This changes it to act as an opt-in rather than an opt-out, which gives more control to server owners and it's much more in line with the EU's regulations on privacy of data.

## Motivation and Context
Privacy, choice, regulations.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
