### PR TITLE
Proper defaults for empty values.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1197,8 +1197,8 @@ class SpawnPoint(BaseModel):
             'kind': 'hhhs',
             'links': '????',
             'missed_count': 0,
-            'latest_seen': None,
-            'earliest_unseen': None
+            'latest_seen': 0,
+            'earliest_unseen': 0
 
         }
 


### PR DESCRIPTION
## Description
Sets defaults to `0` rather than `None`.

## Motivation and Context
When spawnpoint data is incomplete, we used to return `None`, but we do *math thingies* with the field afterwards, which won't work on `NoneType`.

Incomplete data is most often because of user error after fiddling with their database, but it happens.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
