### PR TITLE
Replace 'pause_bit' with a dictionary of events ('control_flags').

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -340,7 +340,7 @@ def worker_status_db_thread(threads_status, name, db_updates_queue):
 
 
 # The main search loop that keeps an eye on the over all process.
-def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
+def search_overseer_thread(args, new_location_queue, control_flags, heartb,
                            db_updates_queue, wh_queue):
 
     log.info('Search overseer starting...')
@@ -475,7 +475,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
                    name='search-worker-{}'.format(i),
                    args=(args, account_queue, account_sets,
                          account_failures, account_captchas,
-                         search_items_queue, pause_bit,
+                         search_items_queue, control_flags,
                          threadStatus[workerId], db_updates_queue,
                          wh_queue, scheduler, key_scheduler))
         t.daemon = True
@@ -493,7 +493,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
 
     stats_timer = 0
 
-    # The real work starts here but will halt on pause_bit.set().
+    # The real work starts here but will halt when any control flag is set.
     while True:
         if (args.hash_key is not None and
                 (hashkeys_last_upsert + hashkeys_upsert_min_delay)
@@ -504,17 +504,17 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         odt_triggered = (args.on_demand_timeout > 0 and
                          (now() - args.on_demand_timeout) > heartb[0])
         if odt_triggered:
-            pause_bit.set()
+            control_flags['on_demand'].set()
             log.info('Searching paused due to inactivity...')
 
         # Wait here while scanning is paused.
-        while pause_bit.is_set():
+        while is_paused(control_flags):
             for i in range(0, len(scheduler_array)):
                 scheduler_array[i].scanning_paused()
             # API Watchdog - Continue to check API version.
             if not args.no_version_check and not odt_triggered:
                 api_check_time = check_forced_version(
-                    args, api_check_time, pause_bit)
+                    args, api_check_time, control_flags['api_watchdog'])
             time.sleep(1)
 
         # If a new location has been passed to us, get the most recent one.
@@ -590,7 +590,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
         # API Watchdog - Check if Niantic forces a new API.
         if not args.no_version_check and not odt_triggered:
             api_check_time = check_forced_version(
-                args, api_check_time, pause_bit)
+                args, api_check_time, control_flags['api_watchdog'])
 
         # Now we just give a little pause here.
         time.sleep(1)
@@ -752,7 +752,7 @@ def generate_hive_locations(current_location, step_distance,
 
 def search_worker_thread(args, account_queue, account_sets,
                          account_failures, account_captchas,
-                         search_items_queue, pause_bit, status, dbq, whq,
+                         search_items_queue, control_flags, status, dbq, whq,
                          scheduler, key_scheduler):
 
     log.debug('Search worker thread starting...')
@@ -810,7 +810,7 @@ def search_worker_thread(args, account_queue, account_sets,
             # The forever loop for the searches.
             while True:
 
-                while pause_bit.is_set():
+                while is_paused(control_flags):
                     status['message'] = 'Scanning paused.'
                     time.sleep(2)
 
@@ -894,7 +894,7 @@ def search_worker_thread(args, account_queue, account_sets,
                     first_loop = True
                     paused = False
                     while now() < appears + 10:
-                        if pause_bit.is_set():
+                        if is_paused(control_flags):
                             paused = True
                             break  # Why can't python just have `break 2`...
                         status['message'] = messages['early']
@@ -1288,7 +1288,7 @@ def stat_delta(current_status, last_status, stat_name):
     return current_status.get(stat_name, 0) - last_status.get(stat_name, 0)
 
 
-def check_forced_version(args, api_check_time, pause_bit):
+def check_forced_version(args, api_check_time, api_watchdog_flag):
     if int(time.time()) > api_check_time:
         log.debug("Checking forced API version.")
         api_check_time = int(time.time()) + args.version_check_interval
@@ -1296,7 +1296,7 @@ def check_forced_version(args, api_check_time, pause_bit):
 
         if not forced_api:
             # Couldn't retrieve API version. Pause scanning.
-            pause_bit.set()
+            api_watchdog_flag.set()
             log.warning('Forced API check got no or invalid response. ' +
                         'Possible bad proxy.')
             log.warning('Scanner paused due to failed API check.')
@@ -1306,7 +1306,7 @@ def check_forced_version(args, api_check_time, pause_bit):
         try:
             if StrictVersion(args.api_version) < StrictVersion(forced_api):
                 # Installed API version is lower. Pause scanning.
-                pause_bit.set()
+                api_watchdog_flag.set()
                 log.warning('Started with API: %s, ' +
                             'Niantic forced to API: %s',
                             args.api_version,
@@ -1317,17 +1317,17 @@ def check_forced_version(args, api_check_time, pause_bit):
                 # installed API version is newer or equal forced API.
                 # Continue scanning.
                 log.debug("API check was successful. Continue scanning.")
-                pause_bit.clear()
+                api_watchdog_flag.clear()
 
         except ValueError as e:
             # Unknown version format. Pause scanning as well.
-            pause_bit.set()
+            api_watchdog_flag.set()
             log.warning('Niantic forced unknown API version format: %s.',
                         forced_api)
             log.warning('Scanner paused due to unknown API version format.')
         except Exception as e:
             # Something else happened. Pause scanning as well.
-            pause_bit.set()
+            api_watchdog_flag.set()
             log.warning('Unknown error on API version comparison: %s.',
                         repr(e))
             log.warning('Scanner paused due to unknown API check error.')
@@ -1370,3 +1370,10 @@ def get_api_version(args):
     except Exception as e:
         log.warning('error on API check: %s', repr(e))
         return False
+
+
+def is_paused(control_flags):
+    for flag in control_flags.values():
+        if flag.is_set():
+            return True
+    return False


### PR DESCRIPTION
This replaces the existing 'pause_bit' (Event) with a dictionary of Events.

## Description
A new dictionary has been added providing flags for each of the reasons for the map to be paused:

```python
control_flags = {
    'on_demand'     : Event(),
    'api_watchdog'  : Event(),
    'search_control': Event()
}
```

## Motivation and Context
This has been introduced to avoid cases where collisions between the 'pause cases' (identified in the code above) caused the pause bit to be set/cleared incorrectly.

Fixes #2089, which occurs when the pause bit is set by search_control and then cleared by the api watchdog.

## How Has This Been Tested?
Tested on a small speedscan instance running 036bf2.

Testing from others with access to larger/more customized instances would be appreciated.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
