### PR TITLE
Explicitly close requests connections.

### DIFF
--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -79,6 +79,11 @@ def get_proxy_test_status(proxy, future_ptc, future_niantic):
                                                  niantic_status)
         check_result = check_result_wrong
 
+    # Explicitly release connection back to the pool, because we don't need
+    # or want to consume the content.
+    ptc_response.close()
+    niantic_response.close()
+
     return (proxy_error, check_result)
 
 
@@ -98,14 +103,12 @@ def start_request_futures(ptc_session, niantic_session, proxy, timeout):
         proxy_test_ptc_url,
         proxies={'http': proxy, 'https': proxy},
         timeout=timeout,
-        headers={'User-Agent':
-                 'pokemongo/1 '
-                 'CFNetwork/811.4.18 '
-                 'Darwin/16.5.0',
-                 'Host':
-                 'sso.pokemon.com',
-                 'X-Unity-Version':
-                 '5.5.1f1'},
+        headers={'User-Agent': ('pokemongo/1 '
+                                'CFNetwork/811.4.18 '
+                                'Darwin/16.5.0'),
+                 'Host': 'sso.pokemon.com',
+                 'X-Unity-Version': '5.5.1f1',
+                 'Connection': 'close'},
         background_callback=__proxy_check_completed)
 
     # Send request to nianticlabs.com.
@@ -114,6 +117,7 @@ def start_request_futures(ptc_session, niantic_session, proxy, timeout):
         '',
         proxies={'http': proxy, 'https': proxy},
         timeout=timeout,
+        headers={'Connection': 'close'},
         background_callback=__proxy_check_completed)
 
     # Return futures.

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -109,7 +109,8 @@ def start_request_futures(ptc_session, niantic_session, proxy, timeout):
                  'Host': 'sso.pokemon.com',
                  'X-Unity-Version': '5.5.1f1',
                  'Connection': 'close'},
-        background_callback=__proxy_check_completed)
+        background_callback=__proxy_check_completed,
+        stream=True)
 
     # Send request to nianticlabs.com.
     future_niantic = niantic_session.post(
@@ -118,7 +119,8 @@ def start_request_futures(ptc_session, niantic_session, proxy, timeout):
         proxies={'http': proxy, 'https': proxy},
         timeout=timeout,
         headers={'Connection': 'close'},
-        background_callback=__proxy_check_completed)
+        background_callback=__proxy_check_completed,
+        stream=True)
 
     # Return futures.
     return (future_ptc, future_niantic)


### PR DESCRIPTION
## Description
`requests` releases connections to the pool when the response's content is consumed, but we don't need the content - we only parse the response headers.

I've also set the requests to `stream=True` so we save time by not downloading the response content.

## Motivation and Context
Performance and reduce resources.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
