### PR TITLE
Fix spawnpoint colors.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1155,7 +1155,7 @@ function spawnPointIndex(color) {
 
 function setupSpawnpointMarker(item) {
     var circleCenter = new google.maps.LatLng(item['latitude'], item['longitude'])
-    var hue = getColorBySpawnTime(item.time)
+    var hue = getColorBySpawnTime(item.appear_time)
     var zoom = map.getZoom()
 
     var marker = new google.maps.Marker({
@@ -1579,7 +1579,7 @@ function updateSpawnPoints() {
 
     $.each(mapData.spawnpoints, function (key, value) {
         if (map.getBounds().contains(value.marker.getPosition())) {
-            var hue = getColorBySpawnTime(value['time'])
+            var hue = getColorBySpawnTime(value.appear_time)
             value.marker.setIcon(changeSpawnIcon(hue, zoom))
             value.marker.setZIndex(spawnPointIndex(hue))
         }


### PR DESCRIPTION
Fixes spawnpoint colors.

## Description
Updates `map.js` to call `getColorBySpawnTime()` correctly.

## Motivation and Context
#1948 changed `spawnpoint.time` to `spawnpoint.appear_time` in the result from `SpawnPoint.get_spawnpoints()`, but two calls to `getColorBySpawnTime()` were missed.

This was raised in #2145.

## How Has This Been Tested?
Tested on a small map instance.

## Screenshots (if appropriate):
Before:
![before](https://user-images.githubusercontent.com/23409825/28251211-30009fbc-6a70-11e7-810f-30c4b0cc542b.png)

After:
![after](https://user-images.githubusercontent.com/23409825/28251213-39fd2ec2-6a70-11e7-9970-f308651111cf.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
