### PR TITLE
Fix int has no attribute isalnum

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -166,11 +166,6 @@ def can_start_scanning(args):
         log.critical('Hash key is required for scanning. Exiting.')
         return False
 
-    # Abort if status name is not alphanumeric.
-    if not args.status_name.isalnum():
-        log.critical('Status name must be alphanumeric.')
-        return False
-
     # Check the PoGo api pgoapi implements against what RM is expecting
     try:
         if PGoApi.get_api_version() != int(args.api_version.replace('.', '0')):
@@ -191,6 +186,11 @@ def main():
     sys.excepthook = handle_exception
 
     args = get_args()
+
+    # Abort if status name is not alphanumeric.
+    if not str(args.status_name).isalnum():
+        log.critical('Status name must be alphanumeric.')
+        sys.exit(1)
 
     set_log_and_verbosity(log)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes "int has no attribute isalnum"
## Description
<!--- Describe your changes in detail -->
Converts the args.status_name to a string all the time with str()

Also moves the status-name check to the main def, as the validate_assets and can_start_scanning are *after* the logging is initialized, meaning the exception happens before the check takes place.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default status-name is PIDs, which are of course integers, and therefor create an int object instead of str in configargparse. The int object doesn't have the alphanumeric check.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows 10, Python 2.7.12
Passes Flake8

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
