### PR TITLE
[bugfix] Make country lookup more robust

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1008,7 +1008,23 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
 
     try:
         reverse = geolocator.reverse(location)
-        country_code = reverse[-1].raw['address_components'][-1]['short_name']
+        address = reverse[-1].raw['address_components']
+        country_code = 'US'
+
+        # google returns an array of components, we need to find the one that is the country
+        for component in address:
+            component_is_country = False
+
+            # for good measure, each component has one or more types, look for country
+            for type in component['types']:
+                if type == 'country':
+                    component_is_country = True
+                    break
+
+            # Only when we found the country can we stop looking
+            if component_is_country:
+                country_code = component['short_name']
+                break
 
         try:
             timezone = geolocator.timezone(location)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1011,17 +1011,16 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
         address = reverse[-1].raw['address_components']
         country_code = 'US'
 
-        # google returns an array of components, we need to find the one that is the country
+        # find country component
         for component in address:
             component_is_country = False
 
-            # for good measure, each component has one or more types, look for country
+            # look for country
             for type in component['types']:
                 if type == 'country':
                     component_is_country = True
                     break
 
-            # Only when we found the country can we stop looking
             if component_is_country:
                 country_code = component['short_name']
                 break
@@ -1037,7 +1036,7 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
                           + 'Please check that you have Google Timezone API'
                           + ' enabled for your API key'
                           + ' (https://developers.google.com/maps/'
-                          + 'documentation/timezone/intro): %s.', e)
+                          + 'documentatiogit lon/timezone/intro): %s.', e)
     except Exception as e:
         log.exception('Exception while obtaining player locale: %s.'
                       + ' Using default locale.', e)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1011,10 +1011,11 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
         address = reverse[-1].raw['address_components']
         country_code = 'US'
 
-        # find country component
+        # Find country component.
         for component in address:
-            # look for country
-            component_is_country = any([t == 'country' for t in component.get('types', [])])
+            # Look for country.
+            component_is_country = any([t == 'country'
+                                        for t in component.get('types', [])])
 
             if component_is_country:
                 country_code = component['short_name']

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1013,13 +1013,8 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
 
         # find country component
         for component in address:
-            component_is_country = False
-
             # look for country
-            for type in component['types']:
-                if type == 'country':
-                    component_is_country = True
-                    break
+            component_is_country = any([t == 'country' for t in component.get('types', [])])
 
             if component_is_country:
                 country_code = component['short_name']
@@ -1036,7 +1031,7 @@ def gmaps_reverse_geolocate(gmaps_key, locale, location):
                           + 'Please check that you have Google Timezone API'
                           + ' enabled for your API key'
                           + ' (https://developers.google.com/maps/'
-                          + 'documentatiogit lon/timezone/intro): %s.', e)
+                          + 'documentation/timezone/intro): %s.', e)
     except Exception as e:
         log.exception('Exception while obtaining player locale: %s.'
                       + ' Using default locale.', e)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Code wrongfully make assumptions about the returned details from reverse geocoding. Instead of looking through the results it always assumed that the last result was the country. In some locations this was in fact the ZIP code.

## Motivation and Context
Noticed that RM tried to insert a string of more than 2 chars into the player locale table. 
Found out it was trying to insert a zip code because sloppy code assumed country was always the last result.

Obviously this would also cause the wrong country to be reported with requests.

## How Has This Been Tested?
Tested on local setup on a location that would produce a "zip code country" in current develop branch

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
