### PR TITLE
fix warning msg when running gym scanner

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1892,14 +1892,19 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     # If there are no wild or nearby Pokemon . . .
     if not wild_pokemon and not nearby_pokemon:
         # . . . and there are no gyms/pokestops then it's unusable/bad.
-        if not forts:
-            log.warning('Bad scan. Parsing found absolutely nothing.')
-            log.info('Common causes: captchas or IP bans.')
+        if args.no_pokemon:
+            if not forts:
+                log.warning('Bad scan. Parsing found absolutely nothing.')
+                log.info('Common causes: captchas or IP bans.')
         else:
-            # No wild or nearby Pokemon but there are forts.  It's probably
-            # a speed violation.
-            log.warning('No nearby or wild Pokemon but there are visible gyms '
-                        'or pokestops. Possible speed violation.')
+            if not forts:
+                log.warning('Bad scan. Parsing found absolutely nothing.')
+                log.info('Common causes: captchas or IP bans.')
+            else:
+                # No wild or nearby Pokemon but there are forts.  It's probably
+                # a speed violation.
+                log.warning('No nearby or wild Pokemon but there are visible gyms '
+                            'or pokestops. Possible speed violation.')
 
     scan_loc = ScannedLocation.get_by_loc(step_location)
     done_already = scan_loc['done']

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1892,11 +1892,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     # If there are no wild or nearby Pokemon . . .
     if not wild_pokemon and not nearby_pokemon:
         # . . . and there are no gyms/pokestops then it's unusable/bad.
-        if args.no_pokemon:
-            if not forts:
-                log.warning('Bad scan. Parsing found absolutely nothing.')
-                log.info('Common causes: captchas or IP bans.')
-        else:
+        if not forts:
+            log.warning('Bad scan. Parsing found absolutely nothing.')
+            log.info('Common causes: captchas or IP bans.')
+        elif not args.no_pokemon:
             if not forts:
                 log.warning('Bad scan. Parsing found absolutely nothing.')
                 log.info('Common causes: captchas or IP bans.')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1896,14 +1896,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             log.warning('Bad scan. Parsing found absolutely nothing.')
             log.info('Common causes: captchas or IP bans.')
         elif not args.no_pokemon:
-            if not forts:
-                log.warning('Bad scan. Parsing found absolutely nothing.')
-                log.info('Common causes: captchas or IP bans.')
-            else:
-                # No wild or nearby Pokemon but there are forts.  It's probably
-                # a speed violation.
-                log.warning('No nearby or wild Pokemon but there are visible '
-                            'gyms or pokestops. Possible speed violation.')
+            # No wild or nearby Pokemon but there are forts.  It's probably
+            # a speed violation.
+            log.warning('No nearby or wild Pokemon but there are visible '
+                        'gyms or pokestops. Possible speed violation.')
 
     scan_loc = ScannedLocation.get_by_loc(step_location)
     done_already = scan_loc['done']

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1889,14 +1889,17 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
     del map_dict['responses']['GET_MAP_OBJECTS']
 
-    # If there are no wild or nearby Pokemon . . .
+    # If there are no wild or nearby Pokemon...
     if not wild_pokemon and not nearby_pokemon:
-        # . . . and there are no gyms/pokestops then it's unusable/bad.
+        # ...and there are no gyms/pokestops then it's unusable/bad.
         if not forts:
             log.warning('Bad scan. Parsing found absolutely nothing.')
             log.info('Common causes: captchas or IP bans.')
         elif not args.no_pokemon:
-            # No wild or nearby Pokemon but there are forts.  It's probably
+            # When gym scanning we'll go over the speed limit
+            # and Pokémon will be invisible, but we'll still be able
+            # to scan gyms so we disable the error logging.
+            # No wild or nearby Pokemon but there are forts. It's probably
             # a speed violation.
             log.warning('No nearby or wild Pokemon but there are visible '
                         'gyms or pokestops. Possible speed violation.')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1903,8 +1903,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             else:
                 # No wild or nearby Pokemon but there are forts.  It's probably
                 # a speed violation.
-                log.warning('No nearby or wild Pokemon but there are visible gyms '
-                            'or pokestops. Possible speed violation.')
+                log.warning('No nearby or wild Pokemon but there are visible '
+                            'gyms or pokestops. Possible speed violation.')
 
     scan_loc = ScannedLocation.get_by_loc(step_location)
     done_already = scan_loc['done']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For those running a raid/gym scanner only there is no need to fill up the logfile with warnings about no wild/nearby pokemon when using -np

## Description
<!--- Describe your changes in detail -->
changed warning for no wild pokemon to only display if not using -np

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
creates less logs when unnecessary

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
self map
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
