### PR TITLE
Bundle webhook messages per timed frames.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -403,6 +403,10 @@ def get_args():
     parser.add_argument('-whlfu', '--wh-lfu-size',
                         help='Webhook LFU cache max size.', type=int,
                         default=2500)
+    parser.add_argument('-whfi', '--wh-frame-interval',
+                        help=('Minimum time (in ms) to wait before sending the'
+                              + ' next webhook data frame.'), type=int,
+                        default=500)
     parser.add_argument('-whsu', '--webhook-scheduler-updates',
                         help=('Send webhook updates with scheduler status ' +
                               '(use with -wh).'),

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -3,9 +3,9 @@
 
 import logging
 import requests
-from datetime import datetime
-from cachetools import LFUCache
 import threading
+from cachetools import LFUCache
+from timeit import default_timer
 from .utils import get_args, get_async_requests_session
 
 log = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def send_to_webhook(session, message_type, message):
 
 
 def wh_updater(args, queue, key_caches):
-    wh_threshold_timer = datetime.now()
+    wh_threshold_timer = default_timer()
     wh_over_threshold = False
 
     # Set up one session to use for all requests.
@@ -123,12 +123,12 @@ def wh_updater(args, queue, key_caches):
             if (not wh_over_threshold) and (
                     queue.qsize() > wh_warning_threshold):
                 wh_over_threshold = True
-                wh_threshold_timer = datetime.now()
+                wh_threshold_timer = default_timer()
             elif wh_over_threshold:
                 if queue.qsize() < wh_warning_threshold:
                     wh_over_threshold = False
                 else:
-                    timediff = datetime.now() - wh_threshold_timer
+                    timediff = default_timer() - wh_threshold_timer
 
                     if timediff.total_seconds() > wh_threshold_lifetime:
                         log.warning('Webhook queue has been > %d (@%d);'

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -133,7 +133,7 @@ def wh_updater(args, queue, key_caches):
 
             if num_messages > 0 and (time_passed_sec >
                                      frame_interval_sec):
-                log.debug('Sending %d items to %d webhooks.',
+                log.debug('Sending %d items to %d webhook(s).',
                           len(frame_messages),
                           len(args.webhooks))
                 send_to_webhooks(args, session, frame_messages)

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -121,7 +121,8 @@ def wh_updater(args, queue, key_caches):
             now = default_timer()
             time_passed_sec = now - frame_last_sent_sec
 
-            if (time_passed_sec > frame_interval_sec):
+            if len(frame_messages) > 0 and (time_passed_sec >
+                                            frame_interval_sec):
                 frame_last_sent_sec = now
 
                 log.debug('Sending %d items to %d webhooks.',

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -10,11 +10,6 @@ from .utils import get_async_requests_session
 
 log = logging.getLogger(__name__)
 
-# How low do we want the queue size to stay?
-wh_warning_threshold = 100
-# How long can it be over the threshold, in seconds?
-# Default: 5 seconds per 100 in threshold.
-wh_threshold_lifetime = int(5 * (wh_warning_threshold / 100.0))
 wh_lock = threading.Lock()
 
 
@@ -68,6 +63,13 @@ def wh_updater(args, queue, key_caches):
     frame_interval_sec = (args.wh_frame_interval / 1000)
     frame_first_message_time_sec = default_timer()
     frame_messages = []
+
+    # How low do we want the queue size to stay?
+    wh_warning_threshold = 100
+    # How long can it be over the threshold, in seconds?
+    # Default: 5 seconds per 100 in threshold + frame_interval_sec.
+    wh_threshold_lifetime = int(5 * (wh_warning_threshold / 100.0))
+    wh_threshold_timer += frame_interval_sec
 
     # The forever loop.
     while True:

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -141,9 +141,9 @@ def wh_updater(args, queue, key_caches):
                 if queue.qsize() < wh_warning_threshold:
                     wh_over_threshold = False
                 else:
-                    timediff = default_timer() - wh_threshold_timer
+                    timediff_sec = default_timer() - wh_threshold_timer
 
-                    if timediff.total_seconds() > wh_threshold_lifetime:
+                    if timediff_sec > wh_threshold_lifetime:
                         log.warning('Webhook queue has been > %d (@%d);'
                                     + ' for over %d seconds,'
                                     + ' try increasing --wh-concurrency'

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -97,11 +97,11 @@ def wh_updater(args, queue, key_caches):
                     # so let's just log and send as-is.
                     log.debug(
                         'Queued webhook item of uncached type: %s.', whtype)
-                    frame_messages.push(frame_message)
+                    frame_messages.append(frame_message)
                 elif ident not in key_cache:
                     key_cache[ident] = message
                     log.debug('Queued %s to webhook: %s.', whtype, ident)
-                    frame_messages.push(frame_message)
+                    frame_messages.append(frame_message)
                 else:
                     # Make sure to call key_cache[ident] in all branches so it
                     # updates the LFU usage count.
@@ -110,7 +110,7 @@ def wh_updater(args, queue, key_caches):
                     # data to webhooks.
                     if __wh_object_changed(whtype, key_cache[ident], message):
                         key_cache[ident] = message
-                        frame_messages.push(frame_message)
+                        frame_messages.append(frame_message)
                         log.debug('Queued updated %s to webhook: %s.',
                                   whtype, ident)
                     else:


### PR DESCRIPTION
## Description
* Removed global "args", moved it for dependency injection.
* Replaced timing code with `timeit.default_timer()`.
* Bundled webhook messages in message frames which will send all messages received in the last `--wh-frame-interval` milliseconds (default 500) as a single message.

## Motivation and Context
Performance, reduces number of total requests, increases throughput, reduces load on receiving server, improves requests' thread use since a single thread will be able to spend more time on I/O.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
