### PR TITLE
Scale Pokemon size on rarity and notification. change zIndex

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
     "google": true,
     "moment": false,
     "MarkerClusterer": true,
-
+    "isNotifyPoke": true,
     "isTouchDevice": true,
     "isMobileDevice": true,
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1089,7 +1089,7 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
             lat: item['latitude'],
             lng: item['longitude']
         },
-        zIndex: 9949 + pokemonMarker.rarityValue,
+        zIndex: 9949 + markerDetails.rarityValue,
         icon: icon,
         animationDisabled: isBounceDisabled
     })

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1056,7 +1056,7 @@ function getGoogleSprite(index, sprite, displayHeight) {
 
 function setupPokemonMarker(item, map, isBounceDisabled) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : 2
+    var rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : (isNotifyPoke(item)) ? 29 : 2
     var iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     var iconSize = rarityValue + iconModify
     var pokemonIndex = item['pokemon_id'] - 1
@@ -1078,7 +1078,7 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
 
 function updatePokemonMarker(item, map) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : 2
+    const rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : (isNotifyPoke(item)) ? 29 : 2
     const iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     const iconSize = rarityValue + iconModify
     const pokemonIndex = item['pokemon_id'] - 1

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1055,8 +1055,10 @@ function getGoogleSprite(index, sprite, displayHeight) {
 }
 
 function setupPokemonMarker(item, map, isBounceDisabled) {
-    // Scale icon size up with the map exponentially.
-    var iconSize = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    // Scale icon size up with the map exponentially, also size with rarity.
+    var rarityValue = (item['pokemon_rarity'] === "Legendary") ? 50 : (item['pokemon_rarity'] === "Ultra Rare") ? 40 : (item['pokemon_rarity'] === "Very Rare") ? 30 : 2
+    var iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    var iconSize = rarityValue + iconModify
     var pokemonIndex = item['pokemon_id'] - 1
     var sprite = pokemonSprites
     var icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
@@ -1066,7 +1068,7 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
             lat: item['latitude'],
             lng: item['longitude']
         },
-        zIndex: 9999,
+        zIndex: 9949 + rarityValue,
         icon: icon,
         animationDisabled: isBounceDisabled
     })
@@ -1075,8 +1077,10 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
 }
 
 function updatePokemonMarker(item, map) {
-    // Scale icon size up with the map exponentially.
-    const iconSize = 2 + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    // Scale icon size up with the map exponentially, also size with rarity.
+    const rarityValue = (item['pokemon_rarity'] === "Legendary") ? 50 : (item['pokemon_rarity'] === "Ultra Rare") ? 40 : (item['pokemon_rarity'] === "Very Rare") ? 30 : 2
+    const iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    const iconSize = rarityValue + iconModify
     const pokemonIndex = item['pokemon_id'] - 1
     const sprite = pokemonSprites
     const icon = getGoogleSprite(pokemonIndex, sprite, iconSize)

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1054,11 +1054,26 @@ function getGoogleSprite(index, sprite, displayHeight) {
     }
 }
 
+function pokemonRarityValue(item, map) {
+    const rarityValues = {
+        'legendary': 50,
+        'ultra rare': 40,
+        'very rare': 30
+    }
+
+    const pokemonRarity = item['pokemon_rarity'].toLowerCase()
+    var rarityValue = (isNotifyPoke(item)) ? 29 : 2
+
+    if (rarityValues.hasOwnProperty(pokemonRarity)) {
+        rarityValue = rarityValues[pokemonRarity]
+    }
+    return rarityValue
+}
+
 function setupPokemonMarker(item, map, isBounceDisabled) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : (isNotifyPoke(item)) ? 29 : 2
-    var iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
-    var iconSize = rarityValue + iconModify
+    var rarityValue = pokemonRarityValue(item)
+    var iconSize = rarityValue + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     var pokemonIndex = item['pokemon_id'] - 1
     var sprite = pokemonSprites
     var icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
@@ -1078,9 +1093,8 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
 
 function updatePokemonMarker(item, map) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : (isNotifyPoke(item)) ? 29 : 2
-    const iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
-    const iconSize = rarityValue + iconModify
+    var rarityValue = pokemonRarityValue(item)
+    const iconSize = rarityValue + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     const pokemonIndex = item['pokemon_id'] - 1
     const sprite = pokemonSprites
     const icon = getGoogleSprite(pokemonIndex, sprite, iconSize)

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1056,7 +1056,7 @@ function getGoogleSprite(index, sprite, displayHeight) {
 
 function setupPokemonMarker(item, map, isBounceDisabled) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var rarityValue = (item['pokemon_rarity'] === "Legendary") ? 50 : (item['pokemon_rarity'] === "Ultra Rare") ? 40 : (item['pokemon_rarity'] === "Very Rare") ? 30 : 2
+    var rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : 2
     var iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     var iconSize = rarityValue + iconModify
     var pokemonIndex = item['pokemon_id'] - 1
@@ -1078,7 +1078,7 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
 
 function updatePokemonMarker(item, map) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const rarityValue = (item['pokemon_rarity'] === "Legendary") ? 50 : (item['pokemon_rarity'] === "Ultra Rare") ? 40 : (item['pokemon_rarity'] === "Very Rare") ? 30 : 2
+    const rarityValue = (item['pokemon_rarity'] === 'Legendary') ? 50 : (item['pokemon_rarity'] === 'Ultra Rare') ? 40 : (item['pokemon_rarity'] === 'Very Rare') ? 30 : 2
     const iconModify = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     const iconSize = rarityValue + iconModify
     const pokemonIndex = item['pokemon_id'] - 1

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1054,7 +1054,7 @@ function getGoogleSprite(index, sprite, displayHeight) {
     }
 }
 
-function pokemonMarkerBasics(item, map) {
+function setupPokemonMarkerDetails(item, map) {
     const rarityValues = {
         'legendary': 50,
         'ultra rare': 40,
@@ -1081,8 +1081,8 @@ function pokemonMarkerBasics(item, map) {
 
 function setupPokemonMarker(item, map, isBounceDisabled) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var pokemonMarker = pokemonMarkerBasics(item, map)
-    const icon = pokemonMarker.icon
+    const markerDetails = setupPokemonMarkerDetails(item, map)
+    const icon = markerDetails.icon
 
     var marker = new google.maps.Marker({
         position: {
@@ -1099,8 +1099,8 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
 
 function updatePokemonMarker(item, map) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var pokemonMarker = pokemonMarkerBasics(item, map)
-    const icon = pokemonMarker.icon
+    const markerDetails = setupPokemonMarkerDetails(item, map)
+    const icon = markerDetails.icon
     const marker = item.marker
 
     marker.setIcon(icon)

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1054,7 +1054,7 @@ function getGoogleSprite(index, sprite, displayHeight) {
     }
 }
 
-function pokemonRarityValue(item, map) {
+function pokemonMarkerBasics(item, map) {
     const rarityValues = {
         'legendary': 50,
         'ultra rare': 40,
@@ -1067,23 +1067,29 @@ function pokemonRarityValue(item, map) {
     if (rarityValues.hasOwnProperty(pokemonRarity)) {
         rarityValue = rarityValues[pokemonRarity]
     }
-    return rarityValue
+    const iconSize = rarityValue + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    const pokemonIndex = item['pokemon_id'] - 1
+    const sprite = pokemonSprites
+    const icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
+    return {
+        rarityValue: rarityValue,
+        iconSize: iconSize,
+        sprite: sprite,
+        icon: icon
+    }
 }
 
 function setupPokemonMarker(item, map, isBounceDisabled) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var rarityValue = pokemonRarityValue(item)
-    var iconSize = rarityValue + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
-    var pokemonIndex = item['pokemon_id'] - 1
-    var sprite = pokemonSprites
-    var icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
+    var pokemonMarker = pokemonMarkerBasics(item, map)
+    const icon = pokemonMarker.icon
 
     var marker = new google.maps.Marker({
         position: {
             lat: item['latitude'],
             lng: item['longitude']
         },
-        zIndex: 9949 + rarityValue,
+        zIndex: 9949 + pokemonMarker.rarityValue,
         icon: icon,
         animationDisabled: isBounceDisabled
     })
@@ -1093,11 +1099,8 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
 
 function updatePokemonMarker(item, map) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    var rarityValue = pokemonRarityValue(item)
-    const iconSize = rarityValue + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
-    const pokemonIndex = item['pokemon_id'] - 1
-    const sprite = pokemonSprites
-    const icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
+    var pokemonMarker = pokemonMarkerBasics(item, map)
+    const icon = pokemonMarker.icon
     const marker = item.marker
 
     marker.setIcon(icon)


### PR DESCRIPTION
Scale Pokemon size on rarity and notification. change zIndex to have rarer pokemon at the front

## Description
See rarer pokemon easier against the trash pokes

## Motivation and Context
who doesnt want to see rare pokemon easier

## How Has This Been Tested?
by running a map and seeing bigger pokemon in from of trash
## Screenshots (if appropriate):
![scale](https://user-images.githubusercontent.com/8204684/28583321-aea99fe8-7160-11e7-97b8-67f4c1ba48e1.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
