### PR TITLE
Create a filter for webhooks types

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -149,14 +149,14 @@
 
 #webhook:                       # Webhook URL e.g. http://127.0.0.1:12345 or a list for multiple webhooks
                                 # [http://127.0.0.1:1345,http://127.0.0.1:12346] (default=None)
+#wh-types:[]                    # List of events to be sent: gym, raid, egg, tth, gym-info, pokestop, lure. (default= nothing)
 #wh-threads:                    # Number of webhook threads; increase if the webhook queue falls behind. (default=1)
-#webhook-updates-only           # Only send updates to webhooks (excludes gyms & non-lured pokéstops). (default=False)
-#webhook-scheduler-updates      # Send webhook updates with scheduler status (use with -wh). (default=True)
 #wh-retries:                    # Number of times to retry sending webhook data on failure (default=5)
 #wh-timeout:                    # Timeout (in seconds) for webhook requests (default=2).
 #wh-concurrency:                # Async requests pool size. (default=25)
 #wh-backoff-factor:             # Factor (in seconds) by which the delay until next retry will increase. (default=0.25).
 #wh-lfu-size:                   # Webhook LFU cache max size (default=1000).
+
 
 
 # Status and logs

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2054,7 +2054,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'cp_multiplier': pokemon_info.cp_multiplier
                 })
 
-            if args.webhooks:
+            if 'pokemon' in args.wh_types:
                 if (pokemon_id in args.webhook_whitelist or
                     (not args.webhook_whitelist and pokemon_id
                      not in args.webhook_blacklist)):
@@ -2106,39 +2106,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         f.last_modified_timestamp_ms / 1000.0) +
                         timedelta(minutes=args.lure_duration))
                     active_fort_modifier = f.active_fort_modifier[0]
-                    if args.webhooks and args.webhook_updates_only:
-                        wh_update_queue.put(('pokestop', {
-                            'pokestop_id': b64encode(str(f.id)),
-                            'enabled': f.enabled,
-                            'latitude': f.latitude,
-                            'longitude': f.longitude,
-                            'last_modified_time': f.last_modified_timestamp_ms,
-                            'lure_expiration': calendar.timegm(
-                                lure_expiration.timetuple()),
-                            'active_fort_modifier': active_fort_modifier
-                        }))
                 else:
                     lure_expiration, active_fort_modifier = None, None
-
-                # Send all pokestops to webhooks.
-                if args.webhooks and not args.webhook_updates_only:
-                    # Explicitly set 'webhook_data', in case we want to change
-                    # the information pushed to webhooks.  Similar to above and
-                    # previous commits.
-                    l_e = None
-
-                    if lure_expiration is not None:
-                        l_e = calendar.timegm(lure_expiration.timetuple())
-
-                    wh_update_queue.put(('pokestop', {
-                        'pokestop_id': b64encode(str(f.id)),
-                        'enabled': f.enabled,
-                        'latitude': f.latitude,
-                        'longitude': f.longitude,
-                        'last_modified_time': f.last_modified_timestamp_ms,
-                        'lure_expiration': l_e,
-                        'active_fort_modifier': active_fort_modifier
-                    }))
 
                 if ((f.id, int(f.last_modified_timestamp_ms / 1000.0))
                         in encountered_pokestops):
@@ -2158,13 +2127,28 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'active_fort_modifier': active_fort_modifier
                 }
 
+                # Send all pokestops to webhooks.
+                if 'pokestop' in args.wh_types or (
+                        'lure' in args.wh_types and
+                        lure_expiration is not None):
+                    l_e = None
+                    if lure_expiration is not None:
+                        l_e = calendar.timegm(lure_expiration.timetuple())
+                    wh_pokestop = pokestops[f.id].copy()
+                    wh_pokestop.update({
+                        'pokestop_id': b64encode(str(f.id)),
+                        'last_modified_time': f.last_modified_timestamp_ms,
+                        'lure_expiration': l_e,
+                    })
+                    wh_update_queue.put(('pokestop', wh_pokestop))
+
             # Currently, there are only stops and gyms.
             elif config['parse_gyms'] and f.type == 0:
                 b64_gym_id = b64encode(str(f.id))
                 gym_display = f.gym_display
                 raid_info = f.raid_info
                 # Send gyms to webhooks.
-                if args.webhooks and not args.webhook_updates_only:
+                if 'gym' in args.wh_types:
                     raid_active_until = 0
                     raid_battle_ms = raid_info.raid_battle_ms
                     raid_end_ms = raid_info.raid_end_ms
@@ -2252,7 +2236,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                                 'move_2': raid_pokemon.move_2
                             })
 
-                        if args.webhooks and not args.webhook_updates_only:
+                        if ('egg' in args.wh_types and
+                                raids[f.id]['pokemon_id'] is None) or (
+                                    'raid' in args.wh_types and
+                                    raids[f.id]['pokemon_id'] is not None):
                             wh_raid = raids[f.id].copy()
                             wh_raid.update({
                                 'gym_id': b64_gym_id,
@@ -2401,13 +2388,13 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
         # it's not alive anymore, we need to get a new proxy.
         elif (args.proxy and
               (hlvl_api._session.proxies['http'] not in args.proxy)):
-                proxy_idx, proxy_new = get_new_proxy(args)
-                hlvl_api.set_proxy({
-                    'http': proxy_new,
-                    'https': proxy_new})
-                hlvl_api._auth_provider.set_proxy({
-                    'http': proxy_new,
-                    'https': proxy_new})
+            proxy_idx, proxy_new = get_new_proxy(args)
+            hlvl_api.set_proxy({
+                'http': proxy_new,
+                'https': proxy_new})
+            hlvl_api._auth_provider.set_proxy({
+                'http': proxy_new,
+                'https': proxy_new})
 
         # Hashing key.
         # TODO: Rework inefficient threading.
@@ -2505,7 +2492,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
             'url': g.url
         }
 
-        if args.webhooks:
+        if 'gym-info' in args.wh_types:
             webhook_data = {
                 'id': b64encode(str(gym_id)),
                 'latitude': gym_state.pokemon_fort_proto.latitude,
@@ -2558,7 +2545,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'last_seen': datetime.utcnow(),
             }
 
-            if args.webhooks:
+            if 'gym-info' in args.wh_types:
                 wh_pokemon = gym_pokemon[i].copy()
                 del wh_pokemon['last_seen']
                 wh_pokemon.update({
@@ -2572,7 +2559,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 webhook_data['pokemon'].append(wh_pokemon)
 
             i += 1
-        if args.webhooks:
+        if 'gym-info' in args.wh_types:
             wh_update_queue.put(('gym_details', webhook_data))
 
     # All this database stuff is synchronous (not using the upsert queue) on

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -566,7 +566,7 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
         threadStatus['Overseer']['accounts_captcha'] = len(account_captchas)
 
         # Send webhook updates when scheduler status changes.
-        if args.webhook_scheduler_updates:
+        if args.speed_scan and 'tth' in args.wh_types:
             wh_status_update(args, threadStatus['Overseer'], wh_queue,
                              scheduler_array[0])
 
@@ -593,17 +593,16 @@ def get_scheduler_tth_found_pct(scheduler):
 def wh_status_update(args, status, wh_queue, scheduler):
     scheduler_name = status['scheduler']
 
-    if args.speed_scan:
-        tth_found = get_scheduler_tth_found_pct(scheduler)
-        spawns_found = getattr(scheduler, 'spawns_found', 0)
+    tth_found = get_scheduler_tth_found_pct(scheduler)
+    spawns_found = getattr(scheduler, 'spawns_found', 0)
 
-        if (tth_found - status['scheduler_status']['tth_found']) > 0.01:
-            log.debug('Scheduler update is due, sending webhook message.')
-            wh_queue.put(('scheduler', {'name': scheduler_name,
-                                        'instance': args.status_name,
-                                        'tth_found': tth_found,
-                                        'spawns_found': spawns_found}))
-            status['scheduler_status']['tth_found'] = tth_found
+    if (tth_found - status['scheduler_status']['tth_found']) > 0.01:
+        log.debug('Scheduler update is due, sending webhook message.')
+        wh_queue.put(('scheduler', {'name': scheduler_name,
+                                    'instance': args.status_name,
+                                    'tth_found': tth_found,
+                                    'spawns_found': spawns_found}))
+        status['scheduler_status']['tth_found'] = tth_found
 
 
 def get_stats_message(threadStatus, search_items_queue_array, db_updates_queue,

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -385,9 +385,15 @@ def get_args():
                         action='store_true', default=False)
     parser.add_argument('--disable-clean', help='Disable clean db loop.',
                         action='store_true', default=False)
-    parser.add_argument('--webhook-updates-only',
-                        help='Only send updates (Pokemon & lured pokestops).',
-                        action='store_true', default=False)
+    parser.add_argument(
+        '--wh-types',
+        help=('Defines the type of messages to send to webhooks.'),
+        choices=[
+            'pokemon', 'gym', 'raid', 'egg', 'tth', 'gym-info',
+            'pokestop', 'lure'
+        ],
+        action='append',
+        default=[])
     parser.add_argument('--wh-threads',
                         help=('Number of webhook threads; increase if the ' +
                               'webhook queue falls behind.'),
@@ -413,10 +419,6 @@ def get_args():
                         help=('Minimum time (in ms) to wait before sending the'
                               + ' next webhook data frame.'), type=int,
                         default=500)
-    parser.add_argument('-whsu', '--webhook-scheduler-updates',
-                        help=('Send webhook updates with scheduler status ' +
-                              '(use with -wh).'),
-                        action='store_true', default=True)
     parser.add_argument('--ssl-certificate',
                         help='Path to SSL certificate file.')
     parser.add_argument('--ssl-privatekey',
@@ -762,7 +764,9 @@ def get_args():
 
         # Disable webhook scheduler updates if webhooks are disabled
         if args.webhooks is None:
-            args.webhook_scheduler_updates = False
+            args.wh_types = frozenset()
+        else:
+            args.wh_types = frozenset([i for i in args.wh_types])
 
     return args
 

--- a/runserver.py
+++ b/runserver.py
@@ -327,13 +327,19 @@ def main():
     wh_updates_queue = Queue()
     wh_key_cache = {}
 
-    # Thread to process webhook updates.
-    for i in range(args.wh_threads):
-        log.debug('Starting wh-updater worker thread %d', i)
-        t = Thread(target=wh_updater, name='wh-updater-{}'.format(i),
-                   args=(args, wh_updates_queue, wh_key_cache))
-        t.daemon = True
-        t.start()
+    if len(args.wh_types) == 0:
+        log.info('Webhook disabled')
+    else:
+        log.info('Webhook enabled for events: %s sending to %s',
+                 args.wh_types, args.webhooks)
+
+        # Thread to process webhook updates.
+        for i in range(args.wh_threads):
+            log.debug('Starting wh-updater worker thread %d', i)
+            t = Thread(target=wh_updater, name='wh-updater-{}'.format(i),
+                       args=(args, wh_updates_queue, wh_key_cache))
+            t.daemon = True
+            t.start()
 
     config['ROOT_PATH'] = app.root_path
     config['GMAPS_KEY'] = args.gmaps_key

--- a/runserver.py
+++ b/runserver.py
@@ -328,10 +328,11 @@ def main():
     wh_key_cache = {}
 
     if len(args.wh_types) == 0:
-        log.info('Webhook disabled')
+        log.info('Webhook disabled.')
     else:
-        log.info('Webhook enabled for events: %s sending to %s',
-                 args.wh_types, args.webhooks)
+        log.info('Webhook enabled for events: sending %s to %s.',
+                 args.wh_types,
+                 args.webhooks)
 
         # Thread to process webhook updates.
         for i in range(args.wh_threads):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create a new argument that superseedes wh-scheduler and wh-updates-only, and also add support for sending or not every type of webhook.

You need to explicitly set what types of wh do you want with wh-types: [tth, lure], where valid types are: 'pokemon', 'gym', 'raid', 'egg', 'tth', 'gym-info', 'pokestop', 'lure'

Also I made some changes to pokestop wh, as it was being sent always when we are testing if it is already processed so moved to be inside that condition and made possible to send all pokestops or only lures. Keep in mind that due to the condition of not being previously processed even restarting the instance will not send all the pokestops again as it is doing for all other types.

Docs are not updated due to #2054 if this is going to merged before 2054 I will add docs.

## Motivation and Context
Currently wh-updates-only allows to send only pokes + lures or everything, there is no other option.
After Gym rework we have a lot more of gym updates and a lot of mappers only wants raids, so this would allow to only send what you want.

## How Has This Been Tested?
Tested in local instance, couldn't test 'lure' type and 'tth' is really strange, after reading the code and how it works there is something strange there.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
