### PR TITLE
Tap on cluster markers to zoom in on mobile

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -149,20 +149,19 @@ function initMap() { // eslint-disable-line no-unused-vars
         }
     })
 
-    // Enable clustering.
-    var screenSize = window.innerWidth;
+    var screenSize = window.innerWidth
+    var clusterOptions = {
+        imagePath: 'static/images/cluster/m',
+        maxZoom: Store.get('maxClusterZoomLevel'),
+        zoomOnClick: false
+    }
+
     if (screenSize < 900) {
-    	var clusterOptions = {
-    		imagePath: 'static/images/cluster/m',
-    		maxZoom: Store.get('maxClusterZoomLevel'),
-    		zoomOnClick: true
-    	}
-    } else {
-    	var clusterOptions = {
-    		imagePath: 'static/images/cluster/m',
-    		maxZoom: Store.get('maxClusterZoomLevel'),
-    		zoomOnClick: false
-    	}
+        clusterOptions = {
+            imagePath: 'static/images/cluster/m',
+            maxZoom: Store.get('maxClusterZoomLevel'),
+            zoomOnClick: true
+        }
     }
 
     markerCluster = new MarkerClusterer(map, [], clusterOptions)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -150,10 +150,19 @@ function initMap() { // eslint-disable-line no-unused-vars
     })
 
     // Enable clustering.
-    var clusterOptions = {
-        imagePath: 'static/images/cluster/m',
-        maxZoom: Store.get('maxClusterZoomLevel'),
-        zoomOnClick: false
+    var screenSize = window.innerWidth;
+    if (screenSize < 900) {
+    	var clusterOptions = {
+    		imagePath: 'static/images/cluster/m',
+    		maxZoom: Store.get('maxClusterZoomLevel'),
+    		zoomOnClick: true
+    	}
+    } else {
+    	var clusterOptions = {
+    		imagePath: 'static/images/cluster/m',
+    		maxZoom: Store.get('maxClusterZoomLevel'),
+    		zoomOnClick: false
+    	}
     }
 
     markerCluster = new MarkerClusterer(map, [], clusterOptions)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -156,7 +156,7 @@ function initMap() { // eslint-disable-line no-unused-vars
         zoomOnClick: false
     }
 
-    if (screenSize < 900) {
+    if (isMobileDevice() || isTouchDevice()) {
         clusterOptions = {
             imagePath: 'static/images/cluster/m',
             maxZoom: Store.get('maxClusterZoomLevel'),

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -149,7 +149,6 @@ function initMap() { // eslint-disable-line no-unused-vars
         }
     })
 // Enable clustering
-    var screenSize = window.innerWidth
     var clusterOptions = {
         imagePath: 'static/images/cluster/m',
         maxZoom: Store.get('maxClusterZoomLevel'),

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -148,7 +148,6 @@ function initMap() { // eslint-disable-line no-unused-vars
             ]
         }
     })
-    
 // Enable clustering
     var screenSize = window.innerWidth
     var clusterOptions = {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -148,7 +148,8 @@ function initMap() { // eslint-disable-line no-unused-vars
             ]
         }
     })
-
+    
+// Enable clustering
     var screenSize = window.innerWidth
     var clusterOptions = {
         imagePath: 'static/images/cluster/m',


### PR DESCRIPTION
## Description
I added the ability for mobile users to tap on cluster markers to automatically zoom-in to that location and view the Pokemon in that cluster.

## Motivation and Context
It's easy to navigate/zoom on desktop with a double-click, but cluster markers are less friendly for users "on the go" that want to quickly zoom into an area. A single tap, using one hand/finger, is much easier than pinch-zooming to an area you want to see. 

When clicking to drag the map on desktop, you constantly miss-click and hit the clusters, which forces you to involuntarily zoom in. This issue doesn't exist on mobile, so it's a good opportunity to add a better mobile experience.

## How Has This Been Tested?
On desktop/mobile on my production map.

## Screenshots (if appropriate):
N/A
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.