### PR TITLE
Fix GMaps InvalidValueError.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -410,8 +410,14 @@ function initSidebar() {
     $('#sound-switch').prop('checked', Store.get('playSound'))
     $('#pokemoncries').toggle(Store.get('playSound'))
     $('#cries-switch').prop('checked', Store.get('playCries'))
-    var searchBox = new google.maps.places.Autocomplete(document.getElementById('next-location'))
-    $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
+
+    // Only create the Autocomplete element if it's enabled in template.
+    var elSearchBox = document.getElementById('next-location')
+
+    if (elSearchBox) {
+        var searchBox = new google.maps.places.Autocomplete(elSearchBox)
+        $(elSearchBox).css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
+    }
 
     if ($('#search-switch').length) {
         updateSearchStatus()


### PR DESCRIPTION
## Description
Fixes this ugly thing in my beautiful console:
```
InvalidValueError: not an instance of HTMLInputElement.
```

## Motivation and Context
Bugfix. Bug caused when `--no-fixed-location` was **not** in use, so the HTML template didn't render the field we're trying to access.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
