### PR TITLE
Avoid Flask initialization for no-server and -cd

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -82,8 +82,9 @@ def init_database(app):
                                    ('cache_size', 10000),
                                    ('journal_size_limit', 1024 * 1024 * 4),))
 
-    app.config['DATABASE'] = db
-    flaskDb.init_app(app)
+    # Using internal method as the other way would be using internal var, we
+    # could use initializer but db is initialized later
+    flaskDb._load_database(app, db)
 
     return db
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We are intializing Flask for no reason in no-server instances, we are using FlaskDB so it needs to be initialized but it doesn't need a real flask instance (it can use it for config but nothing else), so I just moved everything flask related in startup to be inside not no-server if.

Also we were setting no-blacklist for -cd when we can just avoid flask in that situation.

## Motivation and Context
@tomballgithub asked  why where we retrieving blacklist and I did some investigation, it is tied to flask and it is not needed.

## How Has This Been Tested?
Local instance with no-server, only-server, -cd and nothing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
