### PR TITLE
Added front-end Pokémon chunk processing + customizability examples w/ custom.js.

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -26,6 +26,14 @@ $(function () {
         '/mobile'
     ]
 
+    // Clustering! Different zoom levels for desktop vs mobile.
+    const maxClusterZoomLevel = 14 // Default: 14
+    const maxClusterZoomLevelMobile = 14 // Default: same as desktop
+
+    // Process Pokémon in chunks to improve responsiveness.
+    const processPokemonChunkSize = 100 // Default: 100
+    const processPokemonIntervalMs = 100 // Default: 300ms
+
 
     /* Feature detection. */
 
@@ -44,6 +52,16 @@ $(function () {
     /* Do stuff. */
 
     const currentPage = window.location.pathname
+
+
+    // Set custom Store values.
+    Store.set('maxClusterZoomLevel', maxClusterZoomLevel)
+    Store.set('processPokemonChunkSize', processPokemonChunkSize)
+    Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
+
+    if (isMobileDevice()) {
+        Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
+    }
 
     // Google Analytics.
     if (analyticsKey.length > 0) {

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -31,6 +31,8 @@ $(function () {
     const maxClusterZoomLevelMobile = 14 // Default: same as desktop
     const clusterZoomOnClick = false // Default: false
     const clusterZoomOnClickMobile = false // Default: same as desktop
+    const clusterGridSize = 60 // Default: 60
+    const clusterGridSizeMobile = 60 // Default: same as desktop
 
     // Process Pokémon in chunks to improve responsiveness.
     const processPokemonChunkSize = 100 // Default: 100
@@ -59,12 +61,14 @@ $(function () {
     // Set custom Store values.
     Store.set('maxClusterZoomLevel', maxClusterZoomLevel)
     Store.set('clusterZoomOnClick', clusterZoomOnClick)
+    Store.set('clusterGridSize', clusterGridSize)
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
 
     if (isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
         Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)
+        Store.set('clusterGridSize', clusterGridSizeMobile)
     }
 
     // Google Analytics.

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -29,10 +29,12 @@ $(function () {
     // Clustering! Different zoom levels for desktop vs mobile.
     const maxClusterZoomLevel = 14 // Default: 14
     const maxClusterZoomLevelMobile = 14 // Default: same as desktop
+    const clusterZoomOnClick = false // Default: false
+    const clusterZoomOnClickMobile = false // Default: same as desktop
 
     // Process Pokémon in chunks to improve responsiveness.
     const processPokemonChunkSize = 100 // Default: 100
-    const processPokemonIntervalMs = 100 // Default: 300ms
+    const processPokemonIntervalMs = 100 // Default: 100ms
 
 
     /* Feature detection. */
@@ -56,11 +58,13 @@ $(function () {
 
     // Set custom Store values.
     Store.set('maxClusterZoomLevel', maxClusterZoomLevel)
+    Store.set('clusterZoomOnClick', clusterZoomOnClick)
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
 
     if (isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
+        Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)
     }
 
     // Google Analytics.

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -65,7 +65,7 @@ $(function () {
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
 
-    if (isMobileDevice()) {
+    if (typeof window.orientation !== "undefined" || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
         Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)
         Store.set('clusterGridSize', clusterGridSizeMobile)

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -998,6 +998,10 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
+    'clusterGridSize': {
+        default: 60,
+        type: StoreTypes.Number
+    },
     'processPokemonChunkSize': {
         default: 100,
         type: StoreTypes.Number

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -993,6 +993,14 @@ var StoreOptions = {
     'maxClusterZoomLevel': {
         default: 14,
         type: StoreTypes.Number
+    },
+    'processPokemonChunkSize': {
+        default: 100,
+        type: StoreTypes.Number
+    },
+    'processPokemonIntervalMs': {
+        default: 100,
+        type: StoreTypes.Number
     }
 }
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -994,6 +994,10 @@ var StoreOptions = {
         default: 14,
         type: StoreTypes.Number
     },
+    'clusterZoomOnClick': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
     'processPokemonChunkSize': {
         default: 100,
         type: StoreTypes.Number

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -153,7 +153,7 @@ function initMap() { // eslint-disable-line no-unused-vars
     var clusterOptions = {
         imagePath: 'static/images/cluster/m',
         maxZoom: Store.get('maxClusterZoomLevel'),
-        zoomOnClick: false
+        zoomOnClick: Store.get('clusterZoomOnClick')
     }
 
     markerCluster = new MarkerClusterer(map, [], clusterOptions)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1476,10 +1476,23 @@ function processPokemons(pokemon) {
         return false // In case the checkbox was unchecked in the meantime.
     }
 
+    // Process Pokémon per chunk of total so we don't overwhelm the client and
+    // allow redraws in between. We enable redraw in addMarkers, which doesn't
+    // repaint/reset all previous markers but only draws new ones.
+    processPokemonChunked(pokemon, Store.get('processPokemonChunkSize'))
+}
+
+function processPokemonChunked(pokemon, chunkSize) {
+    // Early skip if we have none to process.
+    if (pokemon.length === 0) {
+        return
+    }
+
     const oldMarkers = []
     const newMarkers = []
+    const chunk = pokemon.splice(-1 * chunkSize)
 
-    $.each(pokemon, function (i, poke) {
+    $.each(chunk, function (i, poke) {
         const markers = processPokemon(poke)
         const newMarker = markers[0]
         const oldMarker = markers[1]
@@ -1507,7 +1520,14 @@ function processPokemons(pokemon) {
     // Disable instant redraw, we'll repaint ourselves after we've added the
     // new markers.
     markerCluster.removeMarkers(oldMarkers, true)
-    markerCluster.addMarkers(newMarkers, true)
+    markerCluster.addMarkers(newMarkers, false)
+
+    // Any left?
+    if (pokemon.length > 0) {
+        setTimeout(function () {
+            processPokemonChunked(pokemon, chunkSize)
+        }, Store.get('processPokemonIntervalMs'))
+    }
 }
 
 function processPokemon(item) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -153,7 +153,8 @@ function initMap() { // eslint-disable-line no-unused-vars
     var clusterOptions = {
         imagePath: 'static/images/cluster/m',
         maxZoom: Store.get('maxClusterZoomLevel'),
-        zoomOnClick: Store.get('clusterZoomOnClick')
+        zoomOnClick: Store.get('clusterZoomOnClick'),
+        gridSize: Store.get('clusterGridSize')
     }
 
     markerCluster = new MarkerClusterer(map, [], clusterOptions)


### PR DESCRIPTION
## Description
Process Pokémon per chunks with delays in between so we don't overwhelm the client and freeze the rendering.

`custom.js` was extended with some customizability examples for the chunk processing and cluster options.

## Motivation and Context
Performance, customizability.

## How Has This Been Tested?
Local setup, 5k markers.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
