### PR TITLE
Fix expired Pokémon not disappearing.

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -27,6 +27,7 @@ $(function () {
     ]
 
     // Clustering! Different zoom levels for desktop vs mobile.
+    const disableClusters = false // Default: false
     const maxClusterZoomLevel = 14 // Default: 14
     const maxClusterZoomLevelMobile = 14 // Default: same as desktop
     const clusterZoomOnClick = false // Default: false
@@ -69,6 +70,10 @@ $(function () {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
         Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)
         Store.set('clusterGridSize', clusterGridSizeMobile)
+    }
+
+    if (disableClusters) {
+        Store.set('maxClusterZoomLevel', -1)
     }
 
     // Google Analytics.

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -239,7 +239,7 @@ function initMap() { // eslint-disable-line no-unused-vars
             // We're done processing the list. Redraw.
             markerCluster.resetViewport()
             markerCluster.redraw()
-        }, 500)
+        }, 400)
     })
 
     searchMarker = createSearchMarker()
@@ -1830,7 +1830,7 @@ function updateMap() {
     })
 }
 
-function redrawPokemon(pokemonList, useMarkerCluster) {
+function redrawPokemon(pokemonList) {
     $.each(pokemonList, function (key, value) {
         var item = pokemonList[key]
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -237,8 +237,7 @@ function initMap() { // eslint-disable-line no-unused-vars
             redrawPokemon(mapData.lurePokemons)
 
             // We're done processing the list. Redraw.
-            markerCluster.resetViewport()
-            markerCluster.redraw()
+            markerCluster.repaint()
         }, 400)
     })
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -237,8 +237,9 @@ function initMap() { // eslint-disable-line no-unused-vars
             redrawPokemon(mapData.lurePokemons)
 
             // We're done processing the list. Redraw.
-            markerCluster.repaint()
-        }, 400)
+            markerCluster.resetViewport()
+            markerCluster.redraw()
+        }, 500)
     })
 
     searchMarker = createSearchMarker()
@@ -1797,7 +1798,7 @@ function updateMap() {
         clearStaleMarkers()
 
         // We're done processing. Redraw.
-        markerCluster.redraw()
+        markerCluster.repaint()
 
         updateScanned()
         updateSpawnPoints()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -233,9 +233,13 @@ function initMap() { // eslint-disable-line no-unused-vars
         // Don't redraw constantly even if the user scrolls multiple times,
         // just add it on a timer.
         redrawTimeout = setTimeout(function () {
-            redrawPokemon(mapData.pokemons, true)
-            redrawPokemon(mapData.lurePokemons, false)
-        }, 600)
+            redrawPokemon(mapData.pokemons)
+            redrawPokemon(mapData.lurePokemons)
+
+            // We're done processing the list. Redraw.
+            markerCluster.resetViewport()
+            markerCluster.redraw()
+        }, 500)
     })
 
     searchMarker = createSearchMarker()
@@ -1318,6 +1322,8 @@ function clearStaleMarkers() {
             oldPokeMarkers.push(oldMarker)
             oldMarker.setMap(null)
             delete mapData.pokemons[key]
+            // Overwrite method to avoid all timing issues with libraries.
+            oldMarker.setMap = function () {}
         }
     })
 
@@ -1494,6 +1500,14 @@ function processPokemonChunked(pokemon, chunkSize) {
     const chunk = pokemon.splice(-1 * chunkSize)
 
     $.each(chunk, function (i, poke) {
+        // Early skip if we've already stored this spawn or if it's expiring
+        // too soon.
+        const encounterId = poke.encounter_id
+        const expiringSoon = (poke.disappear_time < (Date.now() + 3000))
+        if (mapData.pokemons.hasOwnProperty(encounterId) || expiringSoon) {
+            return
+        }
+
         const markers = processPokemon(poke)
         const newMarker = markers[0]
         const oldMarker = markers[1]
@@ -1824,12 +1838,6 @@ function redrawPokemon(pokemonList, useMarkerCluster) {
             updatePokemonMarker(item, map)
         }
     })
-
-    // We're done processing the list. Redraw.
-    if (useMarkerCluster) {
-        markerCluster.resetViewport()
-        markerCluster.redraw()
-    }
 }
 
 var updateLabelDiffTime = function () {
@@ -2283,8 +2291,12 @@ $(function () {
 
     $selectIconSize.on('change', function () {
         Store.set('iconSizeModifier', this.value)
-        redrawPokemon(mapData.pokemons, true)
-        redrawPokemon(mapData.lurePokemons, false)
+        redrawPokemon(mapData.pokemons)
+        redrawPokemon(mapData.lurePokemons)
+
+        // We're done processing the list. Redraw.
+        markerCluster.resetViewport()
+        markerCluster.redraw()
     })
 
     $switchOpenGymsOnly = $('#open-gyms-only-switch')


### PR DESCRIPTION
## Description
Since adding clustering, there was an issue with expired Pokémon not disappearing from the map. I looked for the cause and here's what I've found:

- The order of processing items is well done. Some of our previous PRs had already cleaned this up a bit - we're not reprocessing the same items twice, we're not accidentally calling functions in a wrong order, ... that's all good.
- The expired Pokémon is properly deleted by `clearStaleMarkers()`: as a result, its `encounter_id` is also deleted from `mapData.pokemons`.
- The marker is still visible on the map because, after deletion, *something* (see attached stack trace below) calls the marker's `setMap()` method again with the map as argument, visibly re-adding the marker to the map but never re-adding it to `mapData.pokemons`.
- Although the stack trace clearly shows `markerCluster.addMarkers(newMarkers)` as the perpetrator, this means one of the markers in `newMarkers` passed by `clearStaleMarkers()` and was marked for deletion *before* it has even reached `.addMarkers'` internal `.redraw`, which is called right after adding the markers. But `clearStaleMarkers` is only supposed to be called *after* we're done fully processing the new Pokémon *and* I added a check that only Pokémon that will be alive for at least 3 seconds will be added to the map and the bug still happens, so this is an interesting one.
- This is simultaneously the reason it's not being grouped in the clusters: only `.setMap()` was called on the marker, but the marker itself has properly been removed from `mapData.pokemons` **and** from the Marker Clusterer's internal marker storage (I triple-checked this while debugging: it's properly and permanently removed).

This is the stack trace of the method that calls `.setMap(...)` on the marker of the expired Pokémon after it had already been deleted:
![image](https://user-images.githubusercontent.com/4874269/28650259-d49d7272-727a-11e7-82ef-b62216e86460.png)

Although further debugging hasn't made me realize the exact cause of the bug yet (and it's 4am), I've applied a permanent fix that takes care of any and all timing/processing mistakes by overwriting a deleted marker's `.setMap` method with an empty function.

I've made sure this doesn't cause any reference problems: all references for the expired objects are properly deleted from anything that stores it (including the external library).

I've also moved some redrawing methods around to do less total redrawing calls, and I've added early skipping while processing for items that have already been added or will very soon expire.

`custom.js.example` was updated to include an example on how to disable clustering entirely.

## Motivation and Context
Bugfix & performance.

## How Has This Been Tested?
On two separately hosted maps.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
