### PR TITLE
Wrapper for PGoApi and PGoApiRequest, implements auto-retrying on API request failures.

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -149,7 +149,7 @@
 
 #webhook:                       # Webhook URL e.g. http://127.0.0.1:12345 or a list for multiple webhooks
                                 # [http://127.0.0.1:1345,http://127.0.0.1:12346] (default=None)
-#wh-types:[]                    # List of events to be sent: gym, raid, egg, tth, gym-info, pokestop, lure. (default= nothing)
+#wh-types:[]                    # List of events to be sent: pokemon, gym, raid, egg, tth, gym-info, pokestop, lure. (default= nothing)
 #wh-threads:                    # Number of webhook threads; increase if the webhook queue falls behind. (default=1)
 #wh-retries:                    # Number of times to retry sending webhook data on failure (default=5)
 #wh-timeout:                    # Timeout (in seconds) for webhook requests (default=2).

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -11,6 +11,7 @@ from pgoapi import PGoApi
 from pgoapi.exceptions import AuthException
 
 from .fakePogoApi import FakePogoApi
+from .pgoapiwrapper import PGoApiWrapper
 from .utils import (in_radius, generate_device_info, equi_rect_distance,
                     clear_dict_response)
 from .proxy import get_new_proxy
@@ -41,7 +42,7 @@ def setup_api(args, status, account):
     else:
         identifier = account['username'] + account['password']
         device_info = generate_device_info(identifier)
-        api = PGoApi(device_info=device_info)
+        api = PGoApiWrapper(PGoApi(device_info=device_info))
 
     # New account - new proxy.
     if args.proxy:

--- a/pogom/captcha.py
+++ b/pogom/captcha.py
@@ -22,6 +22,7 @@ from threading import Thread
 
 from pgoapi import PGoApi
 from .fakePogoApi import FakePogoApi
+from .pgoapiwrapper import PGoApiWrapper
 
 from .models import Token
 from .transform import jitter_location
@@ -115,7 +116,7 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
     if args.mock != '':
         api = FakePogoApi(args.mock)
     else:
-        api = PGoApi()
+        api = PGoApiWrapper(PGoApi())
 
     if hash_key:
         log.debug('Using key {} for solving this captcha.'.format(hash_key))

--- a/pogom/pgoapiwrapper.py
+++ b/pogom/pgoapiwrapper.py
@@ -14,7 +14,7 @@ class PGoApiWrapper:
 
     def __getattr__(self, attr):
         log.info('PGoApiWrapper getattr %s.', attr)
-        orig_attr = self.api.__getattribute__(attr)
+        orig_attr = self.api.__dict__[attr]
 
         if callable(orig_attr):
             def hooked(*args, **kwargs):

--- a/pogom/pgoapiwrapper.py
+++ b/pogom/pgoapiwrapper.py
@@ -19,6 +19,9 @@ class PGoApiWrapper:
         if callable(orig_attr):
             def hooked(*args, **kwargs):
                 result = orig_attr(*args, **kwargs)
+                # Prevent wrapped class from becoming unwrapped.
+                if result == self.api:
+                    return self
                 return result
             return hooked
         else:

--- a/pogom/pgoapiwrapper.py
+++ b/pogom/pgoapiwrapper.py
@@ -14,7 +14,7 @@ class PGoApiWrapper:
 
     def __getattr__(self, attr):
         log.info('PGoApiWrapper getattr %s.', attr)
-        orig_attr = self.api.__dict__[attr]
+        orig_attr = getattr(self.api, attr)
 
         if callable(orig_attr):
             def hooked(*args, **kwargs):

--- a/pogom/pgoapiwrapper.py
+++ b/pogom/pgoapiwrapper.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import logging
+
+from .pgorequestwrapper import PGoRequestWrapper
+
+log = logging.getLogger(__name__)
+
+
+class PGoApiWrapper:
+    def __init__(self, api):
+        self.api = api
+
+    def __getattr__(self, attr):
+        log.info('PGoApiWrapper getattr %s.', attr)
+        orig_attr = self.api.__getattribute__(attr)
+
+        if callable(orig_attr):
+            def hooked(*args, **kwargs):
+                result = orig_attr(*args, **kwargs)
+                return result
+            return hooked
+        else:
+            return orig_attr
+
+    def create_request(self, *args, **kwargs):
+        request = self.api.create_request(*args, **kwargs)
+        return PGoRequestWrapper(request)

--- a/pogom/pgoapiwrapper.py
+++ b/pogom/pgoapiwrapper.py
@@ -10,10 +10,10 @@ log = logging.getLogger(__name__)
 
 class PGoApiWrapper:
     def __init__(self, api):
+        log.debug('Wrapped PGoApi.')
         self.api = api
 
     def __getattr__(self, attr):
-        log.info('PGoApiWrapper getattr %s.', attr)
         orig_attr = getattr(self.api, attr)
 
         if callable(orig_attr):

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -17,10 +17,10 @@ class PGoRequestWrapper:
 
     def __init__(self, request):
         log.debug('Wrapped PGoApiRequest.')
-        args = get_args()
+        self.args = get_args()
 
         self.request = request
-        self.retries = args.api_retries
+        self.retries = self.args.api_retries
 
     def __getattr__(self, attr):
         orig_attr = getattr(self.request, attr)
@@ -50,16 +50,17 @@ class PGoRequestWrapper:
         # hasn't returned yet.
 
         # Try again if we have retries left.
-        if args.proxy and retries_left > 0:
-            # Rotate proxy.
-            proxy_idx, proxy_url = get_new_proxy(get_args())
+        if retries_left > 0:
+            if self.args.proxy:
+                # Rotate proxy.
+                proxy_idx, proxy_url = get_new_proxy(get_args())
 
-            if proxy_url:
-                log.debug('Changed to proxy: %s.', proxy_url)
-                proxy_config = {'http': proxy_url, 'https': proxy_url}
-                parent = self.request.__parent__
-                parent.set_proxy(proxy_config)
-                parent._auth_provider.set_proxy(proxy_config)
+                if proxy_url:
+                    log.debug('Changed to proxy: %s.', proxy_url)
+                    proxy_config = {'http': proxy_url, 'https': proxy_url}
+                    parent = self.request.__parent__
+                    parent.set_proxy(proxy_config)
+                    parent._auth_provider.set_proxy(proxy_config)
 
             log.debug('API request failed. Retrying...')
             return self.do_call(retries_left - 1, *args, **kwargs)

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class PGoRequestWrapper:
+    def __init__(self, request):
+        self.request = request
+
+    def __getattr__(self, attr):
+        log.info('PGoRequestWrapper getattr %s.', attr)
+        orig_attr = self.api.__getattribute__(attr)
+
+        if callable(orig_attr):
+            def hooked(*args, **kwargs):
+                result = orig_attr(*args, **kwargs)
+                return result
+            return hooked
+        else:
+            return orig_attr

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -17,6 +17,9 @@ class PGoRequestWrapper:
         if callable(orig_attr):
             def hooked(*args, **kwargs):
                 result = orig_attr(*args, **kwargs)
+                # Prevent wrapped class from becoming unwrapped.
+                if result == self.request:
+                    return self
                 return result
             return hooked
         else:

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -12,7 +12,7 @@ class PGoRequestWrapper:
 
     def __getattr__(self, attr):
         log.info('PGoRequestWrapper getattr %s.', attr)
-        orig_attr = self.api.__getattribute__(attr)
+        orig_attr = self.request.__dict__[attr]
 
         if callable(orig_attr):
             def hooked(*args, **kwargs):

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from .utils import get_async_requests_session
+from .utils import get_args
 
 log = logging.getLogger(__name__)
 
@@ -11,18 +11,11 @@ log = logging.getLogger(__name__)
 class PGoRequestWrapper:
 
     def __init__(self, request):
+        log.debug('Wrapped PGoApiRequest.')
+        args = get_args()
+
         self.request = request
-
-        # Get a session with auto-retries. Concurrency can stay at 1, we're
-        # not re-using our session objects in other requests.
-        api_retries = 3
-        api_backoff_factor = 0.2
-        api_concurrency = 1
-
-        self.session = get_async_requests_session(
-            api_retries,
-            api_backoff_factor,
-            api_concurrency)
+        self.retries = args.api_retries
 
     def __getattr__(self, attr):
         orig_attr = getattr(self.request, attr)
@@ -38,12 +31,17 @@ class PGoRequestWrapper:
         else:
             return orig_attr
 
+    def do_call(self, retries_left, *args, **kwargs):
+        try:
+            log.debug('Sending API request. Retries left: %d.', retries_left)
+            return self.request.call(*args, **kwargs)
+        except:
+            if retries_left > 0:
+                log.debug('API request failed. Retrying...')
+                return self.do_call(retries_left - 1, *args, **kwargs)
+            else:
+                raise
+
     def call(self, *args, **kwargs):
-        # Make sure request has retry session set w/ proxies.
-        self.session.proxies = self.request.__parent__._session.proxies
-        self.request.__parent__._session = self.session
-
-        log.info('PGoRequestWrapper proxies: %s', self.session.proxies)
-
-        result = self.request.call(*args, **kwargs)
-        return result
+        # Retry x times on failure.
+        return self.do_call(self.retries, *args, **kwargs)

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -50,7 +50,7 @@ class PGoRequestWrapper:
         # hasn't returned yet.
 
         # Try again if we have retries left.
-        if retries_left > 0:
+        if args.proxy and retries_left > 0:
             # Rotate proxy.
             proxy_idx, proxy_url = get_new_proxy(get_args())
 

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -1,9 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import time
+import random
 import logging
 
 from .utils import get_args
+from .proxy import get_new_proxy
+
+from pgoapi.exceptions import HashingQuotaExceededException
 
 log = logging.getLogger(__name__)
 
@@ -33,14 +38,33 @@ class PGoRequestWrapper:
 
     def do_call(self, retries_left, *args, **kwargs):
         try:
-            log.debug('Sending API request. Retries left: %d.', retries_left)
+            log.debug('Sending API request w/ %d retries left.', retries_left)
             return self.request.call(*args, **kwargs)
+        except HashingQuotaExceededException:
+            # Sleep a minimum to free some RPM.
+            time.sleep(random.uniform(0.75, 1.5))
         except:
-            if retries_left > 0:
-                log.debug('API request failed. Retrying...')
-                return self.do_call(retries_left - 1, *args, **kwargs)
-            else:
-                raise
+            pass
+
+        # If we've reached here, an exception was raised and the function
+        # hasn't returned yet.
+
+        # Try again if we have retries left.
+        if retries_left > 0:
+            # Rotate proxy.
+            proxy_idx, proxy_url = get_new_proxy(get_args())
+
+            if proxy_url:
+                log.debug('Changed to proxy: %s.', proxy_url)
+                proxy_config = {'http': proxy_url, 'https': proxy_url}
+                parent = self.request.__parent__
+                parent.set_proxy(proxy_config)
+                parent._auth_provider.set_proxy(proxy_config)
+
+            log.debug('API request failed. Retrying...')
+            return self.do_call(retries_left - 1, *args, **kwargs)
+        else:
+            raise
 
     def call(self, *args, **kwargs):
         # Retry x times on failure.

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -12,7 +12,7 @@ class PGoRequestWrapper:
 
     def __getattr__(self, attr):
         log.info('PGoRequestWrapper getattr %s.', attr)
-        orig_attr = self.request.__dict__[attr]
+        orig_attr = getattr(self.request, attr)
 
         if callable(orig_attr):
             def hooked(*args, **kwargs):

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -180,6 +180,9 @@ def get_args():
                               + ' the number of logins per account, but '
                               + ' decreases memory usage.'),
                         action='store_true', default=False)
+    parser.add_argument('-apir', '--api-retries',
+                        help=('Number of times to retry an API request.'),
+                        type=int, default=3)
     webhook_list = parser.add_mutually_exclusive_group()
     webhook_list.add_argument('-wwht', '--webhook-whitelist',
                               action='append', default=[],


### PR DESCRIPTION
## Description

* Added `PGoApiWrapper` that wraps around a `PGoApi` object and overwrites its `.create_request` method to return a wrapped `PGoApiRequest`.
* Added `PGoRequestWrapper` to wrap `PGoApiRequest`, implementing auto-retrying on API request failure.
* Updated webhook docs because people on Discord need to know "pokemon" is also a type.

## Motivation and Context
Consistent behavior.

## How Has This Been Tested?
Tested with @Alderon86.

## Screenshots (if appropriate):
```
2017-07-27 22:47:33,625 [   search-worker-0][pgorequestwrapper][   DEBUG] Wrapped PGoApiRequest.
2017-07-27 22:47:33,625 [   search-worker-0][pgorequestwrapper][   DEBUG] Sending API request. Retries left: 3.
2017-07-27 22:47:33,795 [   search-worker-0][pgorequestwrapper][   DEBUG] API request failed. Retrying...
2017-07-27 22:47:33,795 [   search-worker-0][pgorequestwrapper][   DEBUG] Sending API request. Retries left: 2.
2017-07-27 22:47:33,825 [   search-worker-0][pgorequestwrapper][   DEBUG] API request failed. Retrying...
2017-07-27 22:47:33,825 [   search-worker-0][pgorequestwrapper][   DEBUG] Sending API request. Retries left: 1.
2017-07-27 22:47:33,854 [   search-worker-0][pgorequestwrapper][   DEBUG] API request failed. Retrying...
2017-07-27 22:47:33,854 [   search-worker-0][pgorequestwrapper][   DEBUG] Sending API request. Retries left: 0.
2017-07-27 22:47:33,891 [   search-worker-0][       account][   ERROR] Login for account -censored- failed. Exception in call request: Unexpected HTTP server response - needs 200 got 404. .
```

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
