### PR TITLE
Use proper requests exceptions.

### DIFF
--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -41,11 +41,11 @@ def get_proxy_test_status(proxy, future_ptc, future_niantic):
     try:
         ptc_response = future_ptc.result()
         niantic_response = future_niantic.result()
-    except requests.ConnectTimeout:
+    except requests.exceptions.ConnectTimeout:
         proxy_error = ('Connection timeout for'
                        + ' proxy {}.').format(proxy)
         check_result = check_result_timeout
-    except requests.ConnectionError:
+    except requests.exceptions.ConnectionError:
         proxy_error = 'Failed to connect to proxy {}.'.format(proxy)
         check_result = check_result_failed
     except Exception as e:


### PR DESCRIPTION
## Description
Fix reference to requests exceptions.

## Motivation and Context
Bugfix.
```
Traceback (most recent call last):
  File "/RocketMap/runserver.py", line 484, in <module>
    main()
  File "/RocketMap/runserver.py", line 352, in main
    args.proxy = check_proxies(args, args.proxy)
  File "/RocketMap/pogom/proxy.py", line 224, in check_proxies
    future_niantic)
  File "/RocketMap/pogom/proxy.py", line 44, in get_proxy_test_status
    except requests.ConnectTimeout:
AttributeError: 'module' object has no attribute 'ConnectTimeout'
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
