### PR TITLE
Fix stats icons

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1078,7 +1078,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
         sprite: sprite
     }
 
-    var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    const iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
     if (scaleByRarity) {
         const rarityValues = {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1070,34 +1070,45 @@ function getGoogleSprite(index, sprite, displayHeight) {
     }
 }
 
-function setupPokemonMarkerDetails(item, map) {
-    const rarityValues = {
-        'legendary': 50,
-        'ultra rare': 40,
-        'very rare': 30
-    }
-
-    const pokemonRarity = item['pokemon_rarity'].toLowerCase()
-    var rarityValue = (isNotifyPoke(item)) ? 29 : 2
-
-    if (rarityValues.hasOwnProperty(pokemonRarity)) {
-        rarityValue = rarityValues[pokemonRarity]
-    }
-    const iconSize = rarityValue + (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
+    const iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     const pokemonIndex = item['pokemon_id'] - 1
     const sprite = pokemonSprites
     const icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
-    return {
-        rarityValue: rarityValue,
-        iconSize: iconSize,
+
+    var markerDetails = {
         sprite: sprite,
-        icon: icon
+        icon: icon,
+        iconSize: iconSize
     }
+
+    if (scaleByRarity) {
+        const rarityValues = {
+            'very rare': 30,
+            'ultra rare': 40,
+            'legendary': 50
+        }
+
+        var rarityValue = isNotifyPoke(item) ? 29 : 2
+
+        if (item.hasOwnProperty('pokemon_rarity')) {
+            const pokemonRarity = item['pokemon_rarity'].toLowerCase()
+
+            if (rarityValues.hasOwnProperty(pokemonRarity)) {
+                rarityValue = rarityValues[pokemonRarity]
+            }
+        }
+
+        markerDetails.rarityValue = rarityValue
+        markerDetails.iconSize += rarityValue
+    }
+
+    return markerDetails
 }
 
-function setupPokemonMarker(item, map, isBounceDisabled) {
+function setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity = true) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const markerDetails = setupPokemonMarkerDetails(item, map)
+    const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity)
     const icon = markerDetails.icon
 
     var marker = new google.maps.Marker({
@@ -1113,9 +1124,9 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
     return marker
 }
 
-function updatePokemonMarker(item, map) {
+function updatePokemonMarker(item, map, scaleByRarity = true) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const markerDetails = setupPokemonMarkerDetails(item, map)
+    const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity)
     const icon = markerDetails.icon
     const marker = item.marker
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1078,7 +1078,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
         sprite: sprite
     }
 
-    const iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
+    var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
     if (scaleByRarity) {
         const rarityValues = {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1071,16 +1071,14 @@ function getGoogleSprite(index, sprite, displayHeight) {
 }
 
 function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
-    const iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     const pokemonIndex = item['pokemon_id'] - 1
     const sprite = pokemonSprites
-    const icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
 
     var markerDetails = {
-        sprite: sprite,
-        icon: icon,
-        iconSize: iconSize
+        sprite: sprite
     }
+
+    var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
     if (scaleByRarity) {
         const rarityValues = {
@@ -1100,8 +1098,11 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
         }
 
         markerDetails.rarityValue = rarityValue
-        markerDetails.iconSize += rarityValue
+        iconSize += rarityValue
     }
+
+    markerDetails.icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
+    markerDetails.iconSize = iconSize
 
     return markerDetails
 }

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -434,7 +434,7 @@ function redrawAppearances(appearances) {
         var item = appearances[key]
         if (!item['hidden']) {
             item['marker'].setMap(null)
-            var newMarker = setupPokemonMarker(item, map, true, false)
+            const newMarker = setupPokemonMarker(item, map, true, false)
             newMarker.setMap(map)
             addListeners(newMarker)
             newMarker.spawnpointId = item['spawnpoint_id']

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -420,7 +420,7 @@ function processAppearance(i, item) {
         if (item['marker']) {
             item['marker'].setMap(null)
         }
-        item['marker'] = setupPokemonMarker(item, map, true)
+        item['marker'] = setupPokemonMarker(item, map, true, false)
         addListeners(item['marker'])
         item['marker'].spawnpointId = spawnpointId
         mapData.appearances[spawnpointId] = item
@@ -432,8 +432,8 @@ function redrawAppearances(appearances) {
     $.each(appearances, function (key, value) {
         var item = appearances[key]
         if (!item['hidden']) {
-            var newMarker = setupPokemonMarker(item, map, true)
             item['marker'].setMap(null)
+            var newMarker = setupPokemonMarker(item, map, true, false)
             addListeners(newMarker)
             newMarker.spawnpointId = item['spawnpoint_id']
             appearances[key].marker = newMarker

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -421,6 +421,7 @@ function processAppearance(i, item) {
             item['marker'].setMap(null)
         }
         item['marker'] = setupPokemonMarker(item, map, true, false)
+        item['marker'].setMap(map)
         addListeners(item['marker'])
         item['marker'].spawnpointId = spawnpointId
         mapData.appearances[spawnpointId] = item
@@ -434,6 +435,7 @@ function redrawAppearances(appearances) {
         if (!item['hidden']) {
             item['marker'].setMap(null)
             var newMarker = setupPokemonMarker(item, map, true, false)
+            newMarker.setMap(map)
             addListeners(newMarker)
             newMarker.spawnpointId = item['spawnpoint_id']
             appearances[key].marker = newMarker


### PR DESCRIPTION
Two fixes for the /stats page.

## Description
1. PR #2184's additions to setupPokemonMarker() caused the stats page (which also uses this function) to break
2. Icons have been missing from the stats page since #2173

## Motivation and Context
This resolves #2219, and an issue (acknowledged on Discord) where Pokemon icons are not displayed on the stats page.

## How Has This Been Tested?
Runing on a local map.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
