### PR TITLE
change to allow logging of stats to console

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -655,7 +655,7 @@ def parse_inventory(api, account, api_response):
             account['spins'] = stats.poke_stop_visits
             account['walked'] = stats.km_walked
 
-            log.debug('Parsed %s player stats: level %d, %f km ' +
+            log.info('Parsed %s player stats: level %d, %f km ' +
                       'walked, %d spins.', account['username'],
                       account['level'], account['walked'], account['spins'])
         elif item_data.HasField('item'):

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -656,8 +656,8 @@ def parse_inventory(api, account, api_response):
             account['walked'] = stats.km_walked
 
             log.info('Parsed %s player stats: level %d, %f km ' +
-                      'walked, %d spins.', account['username'],
-                      account['level'], account['walked'], account['spins'])
+                     'walked, %d spins.', account['username'],
+                     account['level'], account['walked'], account['spins'])
         elif item_data.HasField('item'):
             item_id = item_data.item.item_id
             item_count = item_data.item.count


### PR DESCRIPTION
## Description
simple change to allow people to see levels of account and other details

## Motivation and Context
Currently its hard to see if pokestop spinning is working and accounts are level 2 or above to lower the captcha rate. This simple change will show stats in the console.

## How Has This Been Tested?
run locally and watched console

## Screenshots (if appropriate):
![accounts](https://user-images.githubusercontent.com/8204684/28755358-f2ba57ec-7550-11e7-9a3b-2f9b0a4c7046.png)

white spaces are where account  names appear
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
