### PR TITLE
add option to disable scaling by rarity in custom.js

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,9 +4,13 @@ $(function () {
 
     /* Settings. */
 
-    //Disable scaling by rarity and notification
-    const disableScaleByRarity = false // Default: false
-    Store.set('disableScaleByRarity', disableScaleByRarity)
+    // Scaling settings
+
+    // Add custom Pokemon to scale bigger
+    const customPokemon = [] // add id of pokemon seperated by comma. eg [1, 2, 3]
+    // Disable scaling by rarity and notification
+    const scaleByRarity = true // Default: true
+
 
     // Google Analytics property ID. Leave empty to disable.
     // Looks like 'UA-XXXXX-Y'.
@@ -69,6 +73,8 @@ $(function () {
     Store.set('clusterGridSize', clusterGridSize)
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
+    Store.set('scaleByRarity', scaleByRarity)
+    Store.set('customPokemon', (JSON.stringify(customPokemon)))
 
     if (typeof window.orientation !== "undefined" || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,12 +4,8 @@ $(function () {
 
     /* Settings. */
 
-    // Scaling settings
-
-    // Add custom Pokemon to scale bigger
-    const customPokemon = [] // add id of pokemon seperated by comma. eg [1, 2, 3]
-    // Disable scaling by rarity and notification
-    const scaleByRarity = true // Default: true
+    const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
+    const scaleByRarity = true // Disable scaling by rarity and notification. Default: true.
 
 
     // Google Analytics property ID. Leave empty to disable.
@@ -74,7 +70,7 @@ $(function () {
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
     Store.set('scaleByRarity', scaleByRarity)
-    Store.set('customPokemon', (JSON.stringify(customPokemon)))
+    Store.set('upscaledPokemon', JSON.stringify(upscaledPokemon))
 
     if (typeof window.orientation !== "undefined" || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,6 +4,10 @@ $(function () {
 
     /* Settings. */
 
+    //Disable scaling by rarity and notification
+    const disableScaleByRarity = false // Default: false
+    Store.set('disableScaleByRarity', disableScaleByRarity)
+
     // Google Analytics property ID. Leave empty to disable.
     // Looks like 'UA-XXXXX-Y'.
     const analyticsKey = ''

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -69,7 +69,7 @@ $(function () {
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
     Store.set('scaleByRarity', scaleByRarity)
-    Store.set('upscaledPokemon', JSON.stringify(upscaledPokemon))
+    Store.set('upscaledPokemon', upscaledPokemon)
 
     if (typeof window.orientation !== "undefined" || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,9 +4,8 @@ $(function () {
 
     /* Settings. */
 
-    const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
     const scaleByRarity = true // Disable scaling by rarity and notification. Default: true.
-
+    const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 
     // Google Analytics property ID. Leave empty to disable.
     // Looks like 'UA-XXXXX-Y'.

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1094,7 +1094,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
             'ultra rare': 40,
             'legendary': 50
         }
-        const upscaledPokemon = JSON.parse(Store.get('upscaledPokemon'))
+        const upscaledPokemon = Store.get('upscaledPokemon')
         var rarityValue = isNotifyPoke(item) || (upscaledPokemon.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -982,7 +982,7 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
-    'customPokemon': {
+    'upscaledPokemon': {
         default: [],
         type: StoreTypes.JSON
     },
@@ -1094,9 +1094,9 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
             'ultra rare': 40,
             'legendary': 50
         }
-        var customPokemon = Store.get('customPokemon')
-        var customPokemonData = JSON.parse(customPokemon)
-        var rarityValue = isNotifyPoke(item) || (customPokemonData.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
+        var upscaledPokemon = Store.get('upscaledPokemon')
+        var upscaledPokemonData = JSON.parse(upscaledPokemon)
+        var rarityValue = isNotifyPoke(item) || (upscaledPokemonData.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {
             const pokemonRarity = item['pokemon_rarity'].toLowerCase()

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1095,7 +1095,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
             'legendary': 50
         }
         const upscaledPokemon = JSON.parse(Store.get('upscaledPokemon'))
-        var rarityValue = isNotifyPoke(item) || (upscaledPokemonData.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
+        var rarityValue = isNotifyPoke(item) || (upscaledPokemon.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {
             const pokemonRarity = item['pokemon_rarity'].toLowerCase()

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -978,6 +978,10 @@ var StoreOptions = {
         default: 0,
         type: StoreTypes.Number
     },
+    'disableScaleByRarity': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
     'searchMarkerStyle': {
         default: 'pokesition',
         type: StoreTypes.String
@@ -1080,7 +1084,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
 
     var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
-    if (scaleByRarity) {
+    if (scaleByRarity && Store.get('disableScaleByRarity') != true) {
         const rarityValues = {
             'very rare': 30,
             'ultra rare': 40,

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1094,8 +1094,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
             'ultra rare': 40,
             'legendary': 50
         }
-        const upscaledPokemon = Store.get('upscaledPokemon')
-        const upscaledPokemonData = JSON.parse(upscaledPokemon)
+        const upscaledPokemon = JSON.parse(Store.get('upscaledPokemon'))
         var rarityValue = isNotifyPoke(item) || (upscaledPokemonData.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1094,8 +1094,8 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
             'ultra rare': 40,
             'legendary': 50
         }
-        var upscaledPokemon = Store.get('upscaledPokemon')
-        var upscaledPokemonData = JSON.parse(upscaledPokemon)
+        const upscaledPokemon = Store.get('upscaledPokemon')
+        const upscaledPokemonData = JSON.parse(upscaledPokemon)
         var rarityValue = isNotifyPoke(item) || (upscaledPokemonData.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -978,9 +978,13 @@ var StoreOptions = {
         default: 0,
         type: StoreTypes.Number
     },
-    'disableScaleByRarity': {
-        default: false,
+    'scaleByRarity': {
+        default: true,
         type: StoreTypes.Boolean
+    },
+    'customPokemon': {
+        default: [],
+        type: StoreTypes.JSON
     },
     'searchMarkerStyle': {
         default: 'pokesition',
@@ -1083,15 +1087,16 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
     }
 
     var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
-
-    if (scaleByRarity && Store.get('disableScaleByRarity') !== true) {
+    scaleByRarity = scaleByRarity && Store.get('scaleByRarity')
+    if (scaleByRarity) {
         const rarityValues = {
             'very rare': 30,
             'ultra rare': 40,
             'legendary': 50
         }
-
-        var rarityValue = isNotifyPoke(item) ? 29 : 2
+        var customPokemon = Store.get('customPokemon')
+        var customPokemonData = JSON.parse(customPokemon)
+        var rarityValue = isNotifyPoke(item) || (customPokemonData.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {
             const pokemonRarity = item['pokemon_rarity'].toLowerCase()

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1084,7 +1084,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
 
     var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
-    if (scaleByRarity && Store.get('disableScaleByRarity') != true) {
+    if (scaleByRarity && Store.get('disableScaleByRarity') !== true) {
         const rarityValues = {
             'very rare': 30,
             'ultra rare': 40,


### PR DESCRIPTION
## Description
Adds a simple way to disable scaling by rarity and notification in custom.js.

Now adds ability to list pokemon you wish to have bigger on the map (without it needing to be in notify or high rarity) in custom.js.

## Motivation and Context
For those that dislike change

## How Has This Been Tested?
tested locally and watched the outcome 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
