### PR TITLE
Filter raids by Pokemon (raid boss)

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -882,6 +882,10 @@ var StoreOptions = {
         default: 5,
         type: StoreTypes.Number
     },
+    'showRaidPokemon': {
+        default: 0,
+        type: StoreTypes.Number
+    },
     'showGyms': {
         default: false,
         type: StoreTypes.Boolean

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -12,6 +12,7 @@ var $switchOpenGymsOnly
 var $switchActiveRaidGymsOnly
 var $switchRaidMinLevel
 var $switchRaidMaxLevel
+var $switchRaidPokemon
 var $selectTeamGymsOnly
 var $selectLastUpdateGymsOnly
 var $selectMinGymLevel
@@ -394,6 +395,7 @@ function initSidebar() {
     $('#raid-active-gym-switch').prop('checked', Store.get('showActiveRaidsOnly'))
     $('#raid-min-level-only-switch').val(Store.get('showRaidMinLevel'))
     $('#raid-max-level-only-switch').val(Store.get('showRaidMaxLevel'))
+    $('#raid-pokemon-only-switch').val(Store.get('showRaidPokemon'))
     $('#raids-filter-wrapper').toggle(Store.get('showRaids'))
     $('#open-gyms-only-switch').prop('checked', Store.get('showOpenGymsOnly'))
     $('#min-level-gyms-filter-switch').val(Store.get('minGymLevel'))
@@ -907,7 +909,13 @@ function getRaidLevel(raid) {
         return raid['level']
     }
 }
-
+function getRaidPokemon(raid) {
+    if (raid === null) {
+        return 0
+    } else {
+        return raid['pokemon_id']
+    }
+}
 function lpad(str, len, padstr) {
     return Array(Math.max(len - String(str).length + 1, 0)).join(padstr) + str
 }
@@ -1646,6 +1654,7 @@ function updatePokestops() {
 function processGym(i, item) {
     var gymLevel = getGymLevel(item)
     var raidLevel = getRaidLevel(item.raid)
+    var raidPokemon = getRaidPokemon(item.raid)
 
     if (!Store.get('showGyms') && !Store.get('showRaids')) {
         return false // in case the checkbox was unchecked in the meantime.
@@ -1681,6 +1690,11 @@ function processGym(i, item) {
             }
         }
 
+        if (Store.get('showRaidPokemon') > 0 && raidPokemon != Store.get('showRaidPokemon')) {
+            removeGymFromMap(item['gym_id'])
+            return true
+        }
+        
         if (raidLevel > Store.get('showRaidMaxLevel') || raidLevel < Store.get('showRaidMinLevel')) {
             removeGymFromMap(item['gym_id'])
             return true
@@ -2340,7 +2354,19 @@ $(function () {
         lastgyms = false
         updateMap()
     })
+    
+    $switchRaidPokemon = $('#raid-pokemon-only-switch')
 
+    $switchRaidPokemon.select2({
+        placeholder: 'Raid Pokemon',
+        minimumResultsForSearch: Infinity
+    })
+
+    $switchRaidPokemon.on('change', function () {
+        Store.set('showRaidPokemon', this.value)
+        lastgyms = false
+        updateMap()
+    })
 
     $selectTeamGymsOnly = $('#team-gyms-only-switch')
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -107,6 +107,39 @@
                   <option value="5">Level 5</option>
                 </select>
               </div>
+              <div class="form-control switch-container" id="max-pokemon-only-wrapper">
+                <h3>Show only one raid boss:</h3>
+                <select name="raid-pokemon-only-switch" id="raid-pokemon-only-switch">
+                  <option value="0">Show all</option>
+                  <option value="249">Lugia</option>
+                  <option value="146">Moltres</option>
+                  <option value="145">Zapdos</option>
+                  <option value="144">Articuno</option>
+                  <option value="248">Tyranitar</option>
+                  <option value="143">Snorlax</option>
+                  <option value="131">Lapras</option>
+                  <option value="112">Rhydon</option>
+                  <option value="9">Blastoise</option>
+                  <option value="6">Charizard</option>
+                  <option value="3">Venusaur</option>
+                  <option value="136">Flareon</option>                    
+                  <option value="135">Jolteon</option>
+                  <option value="134">Vaporeon</option>
+                  <option value="94">Gengar</option>
+                  <option value="68">Machamp</option>
+                  <option value="65">Alakazam</option>
+                  <option value="59">Arcanine</option>
+                  <option value="126">Magmar</option>
+                  <option value="125">Electabuzz</option>
+                  <option value="89">Muk</option>
+                  <option value="110">Weezing</option>
+                  <option value="103">Exeggutor</option>                    
+                  <option value="159">Croconaw</option>
+                  <option value="156">Quilava</option>
+                  <option value="153">Bayleef</option>
+                  <option value="129">Magikarp</option>
+                </select>
+              </div>
             </div>
               {% endif %}
               {% if show.gyms %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a new option to filter the raids by pokemon (raid boss)

## Description
<!--- Describe your changes in detail -->
My first PR so please be gentle :)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A lot of people this days only search for Moltres, Lugia or Tyranitar
It's easier to only show them on the map.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my local map

## Screenshots (if appropriate):
http://i.imgur.com/eEYV5IN.png

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
