### PR TITLE
Remove gym distance control

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1025,35 +1025,25 @@ def search_worker_thread(args, account_queue, account_sets,
                     # Build a list of gyms to update.
                     gyms_to_update = {}
                     for gym in parsed['gyms'].values():
-                        # Can only get gym details within 1km of our position.
-                        distance = calc_distance(
-                            step_location, [gym['latitude'], gym['longitude']])
-                        if distance < 1.0:
-                            # Check if we already have details on this gym.
-                            # Get them if not.
-                            try:
-                                record = GymDetails.get(gym_id=gym['gym_id'])
-                            except GymDetails.DoesNotExist:
-                                gyms_to_update[gym['gym_id']] = gym
-                                continue
+                        # Check if we already have details on this gym.
+                        # Get them if not.
+                        try:
+                            record = GymDetails.get(gym_id=gym['gym_id'])
+                        except GymDetails.DoesNotExist:
+                            gyms_to_update[gym['gym_id']] = gym
+                            continue
 
-                            # If we have a record of this gym already, check if
-                            # the gym has been updated since our last update.
-                            if record.last_scanned < gym['last_modified']:
-                                gyms_to_update[gym['gym_id']] = gym
-                                continue
-                            else:
-                                log.debug(
-                                    ('Skipping update of gym @ %f/%f, ' +
-                                     'up to date.'),
-                                    gym['latitude'], gym['longitude'])
-                                continue
+                        # If we have a record of this gym already, check if
+                        # the gym has been updated since our last update.
+                        if record.last_scanned < gym['last_modified']:
+                            gyms_to_update[gym['gym_id']] = gym
+                            continue
                         else:
                             log.debug(
-                                ('Skipping update of gym @ %f/%f, too far ' +
-                                 'away from our location at %f/%f (%fkm).'),
-                                gym['latitude'], gym['longitude'],
-                                step_location[0], step_location[1], distance)
+                                ('Skipping update of gym @ %f/%f, ' +
+                                 'up to date.'),
+                                gym['latitude'], gym['longitude'])
+                            continue
 
                     if len(gyms_to_update):
                         gym_responses = {}
@@ -1080,10 +1070,8 @@ def search_worker_thread(args, account_queue, account_sets,
                             if response['responses'][
                                     'GYM_GET_INFO'].result == 2:
                                 log.warning(
-                                    ('Gym @ %f/%f is out of range (%dkm), ' +
-                                     'skipping.'),
-                                    gym['latitude'], gym['longitude'],
-                                    distance)
+                                    ('Gym @ %f/%f is out of range skipping.'),
+                                    gym['latitude'], gym['longitude'])
                             else:
                                 gym_responses[gym['gym_id']] = response[
                                     'responses']['GYM_GET_INFO']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently it seems that all gyms we get from GMO are fetchable so there is no reason to do an additional 
distance check.
We ask for cells in 500m radius but for some reason it seems that we get things a bit more far away but the most I have seen is aroun 720m that it is still nearer than the 1Km gym action radius.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
