### PR TITLE
Add cache and lock to avoid getting the same gym twice

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1040,7 +1040,7 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                                 continue
                             else:
                                 # Set the gym as in progress it will just be
-                                # locked for 60 seconds due to TTL eviction
+                                # locked for 60 seconds due to TTL eviction.
                                 gym_cache[gym['gym_id']] = True
 
                         # Can only get gym details within 1km of our position.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -342,6 +342,7 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
     hashkeys_last_upsert = timeit.default_timer()
     hashkeys_upsert_min_delay = 5.0
     gym_cache = None
+
     if args.gym_info:
         gym_cache = TTLCache(maxsize=10000, ttl=60)
 
@@ -1038,6 +1039,8 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                                     gym['latitude'], gym['longitude'])
                                 continue
                             else:
+                                # Set the gym as in progress it will just be
+                                # locked for 60 seconds due to TTL eviction
                                 gym_cache[gym['gym_id']] = True
 
                         # Can only get gym details within 1km of our position.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -28,6 +28,7 @@ import requests
 import schedulers
 import terminalsize
 import timeit
+import threading
 
 from datetime import datetime
 from threading import Thread, Lock
@@ -37,6 +38,7 @@ from collections import deque
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from distutils.version import StrictVersion
+from cachetools import TTLCache
 
 from pgoapi.utilities import f2i
 from pgoapi import utilities as util
@@ -54,6 +56,7 @@ from .proxy import get_new_proxy
 log = logging.getLogger(__name__)
 
 loginDelayLock = Lock()
+gym_cache_lock = threading.Lock()
 
 
 # Thread to handle user input.
@@ -338,6 +341,9 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
     api_check_time = 0
     hashkeys_last_upsert = timeit.default_timer()
     hashkeys_upsert_min_delay = 5.0
+    gym_cache = None
+    if args.gym_info:
+        gym_cache = TTLCache(maxsize=10000, ttl=60)
 
     '''
     Create a queue of accounts for workers to pull from. When a worker has
@@ -452,14 +458,14 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
             'proxy_display': proxy_display,
             'proxy_url': proxy_url,
         }
+        argset = (
+            args, account_queue, account_sets, account_failures,
+            account_captchas, control_flags, threadStatus[workerId],
+            db_updates_queue, wh_queue, scheduler, key_scheduler, gym_cache)
 
         t = Thread(target=search_worker_thread,
                    name='search-worker-{}'.format(i),
-                   args=(args, account_queue, account_sets,
-                         account_failures, account_captchas,
-                         control_flags, threadStatus[workerId],
-                         db_updates_queue, wh_queue,
-                         scheduler, key_scheduler))
+                   args=argset)
         t.daemon = True
         t.start()
 
@@ -752,10 +758,9 @@ def generate_hive_locations(current_location, step_distance,
     return results
 
 
-def search_worker_thread(args, account_queue, account_sets,
-                         account_failures, account_captchas,
-                         control_flags, status, dbq, whq,
-                         scheduler, key_scheduler):
+def search_worker_thread(args, account_queue, account_sets, account_failures,
+                         account_captchas, control_flags, status, dbq, whq,
+                         scheduler, key_scheduler, gym_cache):
 
     log.debug('Search worker thread starting...')
 
@@ -1025,6 +1030,16 @@ def search_worker_thread(args, account_queue, account_sets,
                     # Build a list of gyms to update.
                     gyms_to_update = {}
                     for gym in parsed['gyms'].values():
+                        with gym_cache_lock:
+                            if gym['gym_id'] in gym_cache:
+                                log.debug(
+                                    ('Skipping update of gym @ %f/%f, ' +
+                                     'already in progress.'),
+                                    gym['latitude'], gym['longitude'])
+                                continue
+                            else:
+                                gym_cache[gym['gym_id']] = True
+
                         # Can only get gym details within 1km of our position.
                         distance = calc_distance(
                             step_location, [gym['latitude'], gym['longitude']])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just avoid asking details of the same gym twice setting a small ttl cache with 1 min eviction and capacity of 10K gym ids (it is a big number just in case it shouldn't never be such big).

~This PR is not production ready for some reason you can not kill the process anymore with Ctrl+C and flask stop working as soon as I add the line `with gym_cache_lock:`~ Seems to be working perfectly now 😅 

**Seb:** Fixes #2162.

## Motivation and Context
Currently we check for last_modified to see if we need to as gym info but between we decide to go for it and when we store the data back in the DB it could take some time, so other workers can be already doing the same, that ends with gym members duped and time wasted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
