### PR TITLE
Specify Flask's root_path.

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -258,7 +258,7 @@ def main():
 
     app = None
     if not args.no_server and not args.clear_db:
-        app = Pogom(__name__)
+        app = Pogom(__name__, root_path=os.path.dirname(__file__))
         app.before_request(app.validate_request)
         app.set_current_location(position)
 


### PR DESCRIPTION
## Description
Pass the location of the runserver.py file into Flask as the root_path for the application.

## Motivation and Context
Currently if RM is installed into a non-ASCII path (e.g. /home/pokémon/rocketmap) Flask fails to load static files (pokemon icons, location markers etc.). Fixes #2226.

## How Has This Been Tested?
Tested by running RM under a non-ASCII path (/home/ubuntu/dɐɯʇǝʞɔoɹ).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
