### PR TITLE
Fix sprite sizing in non-english locales.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -27,8 +27,9 @@ from cachetools import cached
 from timeit import default_timer
 
 from . import config
-from .utils import (get_pokemon_name, get_pokemon_rarity, get_pokemon_types,
-                    get_args, cellid, in_radius, date_secs, clock_between,
+from .utils import (get_pokemon_name, get_pokemon_rarity_index,
+                    get_pokemon_rarity, get_pokemon_types, get_args,
+                    cellid, in_radius, date_secs, clock_between,
                     get_move_name, get_move_damage, get_move_energy,
                     get_move_type, calc_pokemon_level)
 from .transform import transform_from_wgs_to_gcj, get_new_coords
@@ -183,10 +184,11 @@ class Pokemon(BaseModel):
 
         pokemon = []
         for p in list(query):
-
-            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-            p['pokemon_rarity'] = get_pokemon_rarity(p['pokemon_id'])
-            p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
+            pokemon_id = p['pokemon_id']
+            p['pokemon_name'] = get_pokemon_name(pokemon_id)
+            p['pokemon_rarity_index'] = get_pokemon_rarity_index(pokemon_id)
+            p['pokemon_rarity'] = get_pokemon_rarity(pokemon_id)
+            p['pokemon_types'] = get_pokemon_types(pokemon_id)
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])
@@ -222,9 +224,11 @@ class Pokemon(BaseModel):
 
         pokemon = []
         for p in query:
-            p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-            p['pokemon_rarity'] = get_pokemon_rarity(p['pokemon_id'])
-            p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
+            pokemon_id = p['pokemon_id']
+            p['pokemon_name'] = get_pokemon_name(pokemon_id)
+            p['pokemon_rarity_index'] = get_pokemon_rarity_index(pokemon_id)
+            p['pokemon_rarity'] = get_pokemon_rarity(pokemon_id)
+            p['pokemon_types'] = get_pokemon_types(pokemon_id)
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -872,6 +872,20 @@ def get_pokemon_name(pokemon_id):
     return i8ln(get_pokemon_data(pokemon_id)['name'])
 
 
+def get_pokemon_rarity_index(pokemon_id):
+    if not hasattr(get_pokemon_rarity_index, 'rarity_indexes'):
+        get_pokemon_rarity_index.rarity_indexes = {
+            'Common': 0,
+            'Uncommon': 1,
+            'Rare': 2,
+            'Very Rare': 3,
+            'Ultra Rare': 4,
+            'Legendary': 5
+        }
+    pokemon_rarity = get_pokemon_data(pokemon_id)['rarity']
+    return get_pokemon_rarity_index.rarity_indexes[pokemon_rarity]
+
+
 def get_pokemon_rarity(pokemon_id):
     return i8ln(get_pokemon_data(pokemon_id)['rarity'])
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1082,15 +1082,15 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
 
     if (scaleByRarity) {
         const rarityValues = {
-            'very rare': 30,
-            'ultra rare': 40,
-            'legendary': 50
+            3: 30,
+            4: 40,
+            5: 50
         }
 
         var rarityValue = isNotifyPoke(item) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {
-            const pokemonRarity = item['pokemon_rarity'].toLowerCase()
+            const pokemonRarity = item['pokemon_rarity_index']
 
             if (rarityValues.hasOwnProperty(pokemonRarity)) {
                 rarityValue = rarityValues[pokemonRarity]


### PR DESCRIPTION
## Description
Adds a new method `get_pokemon_rarity_index` to `utils.py` to provide a locale-inspecific rarity value.
This is passed to `raw_data` as `pokemon['pokemon_rarity_index']`.

## Motivation and Context
Sprite scaling based on rarity is currently hardcoded to english strings. Consequently icon scaling doesn't work in locales other than english. Fixes #2228.

(Arguably, the rarity values in `data/pokemon.json` shouldn't be hardcoded to english in the first place.)

## How Has This Been Tested?
Running a map with `locale: fr`.

## Screenshots (if appropriate):
![frenchy](https://user-images.githubusercontent.com/23409825/29078866-77809b68-7c53-11e7-8554-c8f40c166bbd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
