### PR TITLE
Actually fix unicode-path installs.

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -258,7 +258,9 @@ def main():
 
     app = None
     if not args.no_server and not args.clear_db:
-        app = Pogom(__name__, root_path=os.path.dirname(__file__))
+        app = Pogom(__name__,
+                    root_path=os.path.dirname(
+                              os.path.abspath(__file__)).decode('utf8'))
         app.before_request(app.validate_request)
         app.set_current_location(position)
 


### PR DESCRIPTION
## Description
Change the app's `root_path` from `os.path.dirname(__file__)` to `os.path.dirname(os.path.abspath(__file__)).decode('utf8')`.

## Motivation and Context
Fixes the issue described [here](https://github.com/RocketMap/RocketMap/commit/0dd438976c4697f28d152e02ab2373f8bce0b762#commitcomment-23550271) (by @neskk).

## How Has This Been Tested?
Again, run on a `linux` instance with a non-ascii path.

If someone could test this on a Windows setup, where the issue occured, that would be greatly appreciated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
