### PR TITLE
Added toggle switch for the feature of pokemon size by rarity

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -942,7 +942,7 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
-    'sizeUp': {
+    'upScale': {
         default: true,
         type: StoreTypes.Boolean
     },
@@ -1074,7 +1074,7 @@ function getGoogleSprite(index, sprite, displayHeight) {
     }
 }
 
-function setupPokemonMarkerDetails(item, map) {
+function setupPokemonMarkerDetails(item, map, scaleByRarity) {
     const pokemonIndex = item['pokemon_id'] - 1
     const sprite = pokemonSprites
 
@@ -1084,7 +1084,7 @@ function setupPokemonMarkerDetails(item, map) {
 
     var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
-    if (Store.get('sizeUp')) {
+    if (Store.get('upScale') && scaleByRarity !== false) {
         const rarityValues = {
             'very rare': 30,
             'ultra rare': 40,
@@ -1111,9 +1111,9 @@ function setupPokemonMarkerDetails(item, map) {
     return markerDetails
 }
 
-function setupPokemonMarker(item, map, isBounceDisabled) {
+function setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const markerDetails = setupPokemonMarkerDetails(item, map)
+    const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity)
     const icon = markerDetails.icon
 
     var marker = new google.maps.Marker({
@@ -1129,9 +1129,9 @@ function setupPokemonMarker(item, map, isBounceDisabled) {
     return marker
 }
 
-function updatePokemonMarker(item, map) {
+function updatePokemonMarker(item, map, scaleByRarity) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const markerDetails = setupPokemonMarkerDetails(item, map)
+    const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity)
     const icon = markerDetails.icon
     const marker = item.marker
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -942,6 +942,10 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
+    'sizeUp': {
+        default: true,
+        type: StoreTypes.Boolean
+    },
     'geoLocate': {
         default: false,
         type: StoreTypes.Boolean
@@ -1070,7 +1074,7 @@ function getGoogleSprite(index, sprite, displayHeight) {
     }
 }
 
-function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
+function setupPokemonMarkerDetails(item, map) {
     const pokemonIndex = item['pokemon_id'] - 1
     const sprite = pokemonSprites
 
@@ -1080,7 +1084,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
 
     var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
 
-    if (scaleByRarity) {
+    if (Store.get('sizeUp')) {
         const rarityValues = {
             'very rare': 30,
             'ultra rare': 40,
@@ -1107,9 +1111,9 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
     return markerDetails
 }
 
-function setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity = true) {
+function setupPokemonMarker(item, map, isBounceDisabled) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity)
+    const markerDetails = setupPokemonMarkerDetails(item, map)
     const icon = markerDetails.icon
 
     var marker = new google.maps.Marker({
@@ -1125,9 +1129,9 @@ function setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity = true) {
     return marker
 }
 
-function updatePokemonMarker(item, map, scaleByRarity = true) {
+function updatePokemonMarker(item, map) {
     // Scale icon size up with the map exponentially, also size with rarity.
-    const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity)
+    const markerDetails = setupPokemonMarkerDetails(item, map)
     const icon = markerDetails.icon
     const marker = item.marker
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2733,7 +2733,25 @@ $(function () {
 
     $('#upscale-switch').change(function () {
         Store.set('upScale', this.checked)
+        // Remove all Pokemon markers from map
+        var oldPokeMarkers = []
+        $.each(mapData['pokemons'], function (key, pkm) {
+            // for any marker you're turning off, you'll want to wipe off the range
+            if (pkm.marker.rangeCircle) {
+                pkm.marker.rangeCircle.setMap(null)
+                delete pkm.marker.rangeCircle
+            }
+            pkm.marker.setMap(null)
+            oldPokeMarkers.push(pkm.marker)
+        })
+        markerCluster.removeMarkers(oldPokeMarkers)
+        mapData['pokemons'] = {}
+
+        // Reload all Pokemon
+        lastpokemon = false
+        updateMap()
     })
+
     $('#geoloc-switch').change(function () {
         $('#next-location').prop('disabled', this.checked)
         $('#next-location').css('background-color', this.checked ? '#e0e0e0' : '#ffffff')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -415,6 +415,7 @@ function initSidebar() {
     $('#sound-switch').prop('checked', Store.get('playSound'))
     $('#pokemoncries').toggle(Store.get('playSound'))
     $('#cries-switch').prop('checked', Store.get('playCries'))
+    $('#size-switch').prop('checked', Store.get('sizeUp'))
 
     // Only create the Autocomplete element if it's enabled in template.
     var elSearchBox = document.getElementById('next-location')
@@ -2730,6 +2731,9 @@ $(function () {
         Store.set('playCries', this.checked)
     })
 
+    $('#size-switch').change(function () {
+        Store.set('sizeUp', this.checked)
+    })
     $('#geoloc-switch').change(function () {
         $('#next-location').prop('disabled', this.checked)
         $('#next-location').css('background-color', this.checked ? '#e0e0e0' : '#ffffff')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -415,7 +415,7 @@ function initSidebar() {
     $('#sound-switch').prop('checked', Store.get('playSound'))
     $('#pokemoncries').toggle(Store.get('playSound'))
     $('#cries-switch').prop('checked', Store.get('playCries'))
-    $('#size-switch').prop('checked', Store.get('sizeUp'))
+    $('#upscale-switch').prop('checked', Store.get('upScale'))
 
     // Only create the Autocomplete element if it's enabled in template.
     var elSearchBox = document.getElementById('next-location')
@@ -2731,8 +2731,8 @@ $(function () {
         Store.set('playCries', this.checked)
     })
 
-    $('#size-switch').change(function () {
-        Store.set('sizeUp', this.checked)
+    $('#upscale-switch').change(function () {
+        Store.set('upScale', this.checked)
     })
     $('#geoloc-switch').change(function () {
         $('#next-location').prop('disabled', this.checked)

--- a/templates/map.html
+++ b/templates/map.html
@@ -379,6 +379,17 @@
           <h3><i class="fa fa-map-o fa-fw"></i>Style Settings</h3>
           <div>
             <div class="form-control switch-container">
+              <h3>Size Pokémon by rarity</h3>
+              <div class="onoffswitch">
+                <input id="size-switch" type="checkbox" name="size-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="size-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+		  
+            <div class="form-control switch-container">
               <h3>Map Style</h3>
               <select id="map-style"></select>
             </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -381,8 +381,8 @@
             <div class="form-control switch-container">
               <h3>Size Pokémon by rarity</h3>
               <div class="onoffswitch">
-                <input id="size-switch" type="checkbox" name="size-switch" class="onoffswitch-checkbox" checked>
-                <label class="onoffswitch-label" for="size-switch">
+                <input id="upscale-switch" type="checkbox" name="upscale-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="upscale-switch">
                   <span class="switch-label" data-on="On" data-off="Off"></span>
                   <span class="switch-handle"></span>
                 </label>

--- a/templates/map.html
+++ b/templates/map.html
@@ -379,7 +379,7 @@
           <h3><i class="fa fa-map-o fa-fw"></i>Style Settings</h3>
           <div>
             <div class="form-control switch-container">
-              <h3>Size Pokémon by rarity</h3>
+              <h3>Upscale Pokémon by rarity</h3>
               <div class="onoffswitch">
                 <input id="upscale-switch" type="checkbox" name="upscale-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="upscale-switch">


### PR DESCRIPTION
Some people prefer their rare pokemon to be enlarged, and some do not.
This toggle, under "Style Settings" will allow it to be customized.

## How Has This Been Tested?
I tested this on my development map.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7101432/29138857-e904b3ea-7d12-11e7-86d3-8d0b7d41a213.png)
![image](https://user-images.githubusercontent.com/7101432/29138936-2302c4ec-7d13-11e7-9ee5-7bb2e6b8c893.png)
![image](https://user-images.githubusercontent.com/7101432/29138972-39f3914a-7d13-11e7-8307-8110e75f5614.png)
![image](https://user-images.githubusercontent.com/7101432/29138975-402cb974-7d13-11e7-82f5-b88d909b8a47.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


