### PR TITLE
Fixes parsing not defined raids

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2204,7 +2204,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 }
 
                 if config['parse_raids'] and f.type == 0:
-                    if raid_info:
+                    if f.HasField('raid_info'):
                         raids[f.id] = {
                             'gym_id': f.id,
                             'level': raid_info.raid_level,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the check to properly see if raid_info has been defined.

Fixes #2235

## Motivation and Context
Due to protobuf the old check was not correct anymore and we were storing and parsing a lot of empty raids.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
