### PR TITLE
Fix default status names.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -442,7 +442,7 @@ def get_args():
     parser.add_argument('-slt', '--stats-log-timer',
                         help='In log view, list per hr stats every X seconds',
                         type=int, default=0)
-    parser.add_argument('-sn', '--status-name', default=os.getpid(),
+    parser.add_argument('-sn', '--status-name', default=str(os.getpid()),
                         help=('Enable status page database update using ' +
                               'STATUS_NAME as main worker name.'))
     parser.add_argument('-spp', '--status-page-password', default=None,


### PR DESCRIPTION
## Description
Wraps the default status name - `os.getpid()` - to a string.

## Motivation and Context
Prior to #2242, numeric (i.e. integer) satus names were allowed. After #2242, status names can only be strings (or the regex test throws an exception).

As ConfigArgParse parses status names as strings, this can only cause issues if the status name is set within RM (e.g. when setting a default value).

To keep the default value consistent with the type of the variable, the default status name is now wrapped to a string.

Fixes #2254.

## How Has This Been Tested?
Local scan instance with status name unset.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
