### PR TITLE
Set content-type header for inject.js

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -76,9 +76,14 @@ class Pogom(Flask):
 
     def render_inject_js(self):
         args = get_args()
-        return render_template('inject.js',
+        src = render_template('inject.js',
                                domain=args.manual_captcha_domain,
                                timer=args.manual_captcha_refresh)
+        
+        response = make_response(src)
+        response.headers['Content-Type'] = 'application/javascript'
+        
+        return response
 
     def submit_token(self):
         response = 'error'

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -77,12 +77,12 @@ class Pogom(Flask):
     def render_inject_js(self):
         args = get_args()
         src = render_template('inject.js',
-                               domain=args.manual_captcha_domain,
-                               timer=args.manual_captcha_refresh)
-        
+                              domain=args.manual_captcha_domain,
+                              timer=args.manual_captcha_refresh)
+
         response = make_response(src)
         response.headers['Content-Type'] = 'application/javascript'
-        
+
         return response
 
     def submit_token(self):


### PR DESCRIPTION
## Description
Fixes issue where servers enforcing strict Content Type refuse to load inject.js thus never getting past the 404 on the captcha page.

## Motivation and Context
In my nginx config, I have `add_header X-Content-Type-Options "nosniff" always` in the `server` block for security. Flask sends the `text/html` type by default, so loading inject.js via the bookmarklet fails with the following error in console:

> Refused to execute script from 'https://example.com/inject.js?...' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.

As a result, the captcha solving page is always stuck at the 404. More on the "nosniff" option [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options).

## How Has This Been Tested?
Tested in Chrome, with map running in production on Ubuntu 16.04 and Nginx configured with the `X-Content-Type-Options` header mentioned above.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
