### PR TITLE
Move to devkat/RM maintained pgoapi.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/pogodevorg/pgoapi.git@85abbb94ce30bb7cb59931edb5a02a7f3474682a#egg=pgoapi
+git+https://github.com/sebastienvercammen/pgoapi.git@71cb419590381665e044c6ec885c56ddadd974bd#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
## Description
Move to the devkat/RM maintained pgoapi repository.

## Motivation and Context
Due to a lack of updates and disclosure in pgoapi/pogodev, we're going to maintain the pgoapi used in RocketMap.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
