### PR TITLE
Fix icon flickering.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -236,9 +236,8 @@ function initMap() { // eslint-disable-line no-unused-vars
             redrawPokemon(mapData.pokemons)
             redrawPokemon(mapData.lurePokemons)
 
-            // We're done processing the list. Redraw.
-            markerCluster.resetViewport()
-            markerCluster.redraw()
+            // We're done processing the list. Repaint.
+            markerCluster.repaint()
         }, 500)
     })
 
@@ -1798,7 +1797,7 @@ function updateMap() {
         clearStaleMarkers()
 
         // We're done processing. Redraw.
-        markerCluster.repaint()
+        markerCluster.redraw()
 
         updateScanned()
         updateSpawnPoints()
@@ -2294,9 +2293,8 @@ $(function () {
         redrawPokemon(mapData.pokemons)
         redrawPokemon(mapData.lurePokemons)
 
-        // We're done processing the list. Redraw.
-        markerCluster.resetViewport()
-        markerCluster.redraw()
+        // We're done processing the list. Repaint.
+        markerCluster.repaint()
     })
 
     $switchOpenGymsOnly = $('#open-gyms-only-switch')
@@ -2639,7 +2637,8 @@ $(function () {
                             }
                         }
                     })
-                    if (dType === 'pokemons') {
+                    // If the type was "pokemons".
+                    if (oldPokeMarkers.length > 0) {
                         markerCluster.removeMarkers(oldPokeMarkers)
                     }
                     if (storageKey !== 'showRanges') data[dType] = {}
@@ -2689,6 +2688,7 @@ $(function () {
     })
     $('#pokemon-switch').change(function () {
         buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon').bind(this)()
+        markerCluster.repaint()
     })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()


### PR DESCRIPTION
## Description
Changed repaints to redraws (which doesn't remove all icons), and moved the repaints to change of zoom level.

Reintroduces the problem of cluster marker counters not going down if you stay zoomed out and *never* change zoom level, but any change of zoom level will force a full repaint which'll also update the counters. Considered not an issue under normal use.

## Motivation and Context
Fixes the icon flickering.
Fixes #2218.

## How Has This Been Tested?
Local instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
