### PR TITLE
Add ability to customise map defaults without editing map.common.js

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -7,6 +7,22 @@ $(function () {
     const scaleByRarity = true // Disable scaling by rarity and notification. Default: true.
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 
+    const map_style = 'roadmap' //  default: 'roadmap'. Options - look at https://github.com/RocketMap/RocketMap/blob/develop/static/data/mapstyle.json
+    const remember_select_exclude = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3])
+    const remember_select_notify = [] //  Add Pokémon IDs separated by commas (e.g. [1, 2, 3])
+    const remember_select_rarity_notify = [] // Options - 'Common', 'Uncommon', 'Rare', 'Very Rare', 'Ultra Rare'
+    const showRaids = false // Default: false.
+    const showActiveRaidsOnly = false // Default: false.
+    const showGyms = false // Default: false.
+    const showPokemon = true // Default: true.
+    const showPokestops = true // Default: true.
+    const showRanges = false // Default: false.
+    const playSound = false // Default: false.
+    const playCries = false // Default: false.
+    const searchMarkerStyle = 'pokesition' //  default: 'pokesition'. Options - look at https://github.com/RocketMap/RocketMap/blob/develop/static/data/searchmarkerstyle.json
+    const locationMarkerStyle = 'mobile' // default: 'mobile'. Options - look at https://github.com/RocketMap/RocketMap/blob/develop/static/data/searchmarkerstyle.json
+    const zoomLevel = 16 // default: 16.
+	
     // Google Analytics property ID. Leave empty to disable.
     // Looks like 'UA-XXXXX-Y'.
     const analyticsKey = ''
@@ -70,6 +86,21 @@ $(function () {
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
     Store.set('scaleByRarity', scaleByRarity)
     Store.set('upscaledPokemon', upscaledPokemon)
+    Store.set('map_style', map_style)
+    Store.set('remember_select_exclude', remember_select_exclude)
+    Store.set('remember_select_notify', remember_select_notify)
+    Store.set('remember_select_rarity_notify', remember_select_rarity_notify)
+    Store.set('showRaids', showRaids)
+    Store.set('showActiveRaidsOnly', showActiveRaidsOnly)
+    Store.set('showGyms', showGyms)
+    Store.set('showPokemon', showPokemon)
+    Store.set('showPokestops', showPokestops)
+    Store.set('showRanges', showRanges)
+    Store.set('playSound', playSound)
+    Store.set('playCries', playCries)
+    Store.set('searchMarkerStyle', searchMarkerStyle)
+    Store.set('locationMarkerStyle', locationMarkerStyle)
+    Store.set('zoomLevel', zoomLevel)
 
     if (typeof window.orientation !== "undefined" || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -8,9 +8,7 @@ $(function () {
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 
     const map_style = 'roadmap' //  default: 'roadmap'. Options - look at https://github.com/RocketMap/RocketMap/blob/develop/static/data/mapstyle.json
-    const remember_select_exclude = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3])
-    const remember_select_notify = [] //  Add Pokémon IDs separated by commas (e.g. [1, 2, 3])
-    const remember_select_rarity_notify = [] // Options - 'Common', 'Uncommon', 'Rare', 'Very Rare', 'Ultra Rare'
+    const excluded_Pokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3])
     const showRaids = false // Default: false.
     const showActiveRaidsOnly = false // Default: false.
     const showGyms = false // Default: false.
@@ -87,9 +85,9 @@ $(function () {
     Store.set('scaleByRarity', scaleByRarity)
     Store.set('upscaledPokemon', upscaledPokemon)
     Store.set('map_style', map_style)
-    Store.set('remember_select_exclude', remember_select_exclude)
-    Store.set('remember_select_notify', remember_select_notify)
-    Store.set('remember_select_rarity_notify', remember_select_rarity_notify)
+	const remember_select_exclude = Store.get('remember_select_exclude')
+	const new_Exclude_List = remember_select_exclude.concat( excluded_Pokemon )
+    Store.set('remember_select_exclude', new_Exclude_List )
     Store.set('showRaids', showRaids)
     Store.set('showActiveRaidsOnly', showActiveRaidsOnly)
     Store.set('showGyms', showGyms)


### PR DESCRIPTION
## Description
Add ability to customise settings in map.common.js without editing core files

## Motivation and Context
adds the options to custom.example.js so people no longer need to edit map.common.js to set map defaults so they wont run into issues when they git pull

## How Has This Been Tested?
local testing and changing values

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
