### PR TITLE
Separate scaleByRarity and upscale_Pokemon

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,7 +4,7 @@ $(function () {
 
     /* Settings. */
 
-    const scaleByRarity = true // Disable scaling by rarity and notification. Default: true.
+    const scaleByRarity = true // Disable scaling by rarity. Default: true.
 	const upscale_Pokemon = false // Enable Upscaling selected Pokemon and notification. Default: false
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -5,6 +5,7 @@ $(function () {
     /* Settings. */
 
     const scaleByRarity = true // Disable scaling by rarity and notification. Default: true.
+	const upscale_Pokemon = false // Enable Upscaling selected Pokemon and notification. Default: false
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 
     // Google Analytics property ID. Leave empty to disable.
@@ -69,6 +70,7 @@ $(function () {
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
     Store.set('scaleByRarity', scaleByRarity)
+    Store.set('upscale_Pokemon', upscale_Pokemon)
     Store.set('upscaledPokemon', upscaledPokemon)
 
     if (typeof window.orientation !== "undefined" || isMobileDevice()) {

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,8 +4,8 @@ $(function () {
 
     /* Settings. */
 
-    const scaleByRarity = true // Disable scaling by rarity. Default: true.
-	const upscale_Pokemon = false // Enable Upscaling selected Pokemon and notification. Default: false
+    const scaleByRarity = true // Set false to disable scaling by rarity. Default: true.
+    const upscalePokemon = false // Enable Upscaling selected Pokemon and notification. Default: false.
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 
     // Google Analytics property ID. Leave empty to disable.
@@ -70,7 +70,7 @@ $(function () {
     Store.set('processPokemonChunkSize', processPokemonChunkSize)
     Store.set('processPokemonIntervalMs', processPokemonIntervalMs)
     Store.set('scaleByRarity', scaleByRarity)
-    Store.set('upscale_Pokemon', upscale_Pokemon)
+    Store.set('upscalePokemon', upscalePokemon)
     Store.set('upscaledPokemon', upscaledPokemon)
 
     if (typeof window.orientation !== "undefined" || isMobileDevice()) {

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -4,8 +4,8 @@ $(function () {
 
     /* Settings. */
 
-    const scaleByRarity = true // Set false to disable scaling by rarity. Default: true.
-    const upscalePokemon = false // Enable Upscaling selected Pokemon and notification. Default: false.
+    const scaleByRarity = true // Enable scaling by rarity. Default: true.
+    const upscalePokemon = false // Enable upscaling of certain Pokemon (upscaledPokemon and notify list). Default: false.
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
 
     // Google Analytics property ID. Leave empty to disable.

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -982,7 +982,7 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
-    'upscale_Pokemon': {
+    'upscalePokemon': {
         default: false,
         type: StoreTypes.Boolean
     },
@@ -1093,7 +1093,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
     scaleByRarity = scaleByRarity && Store.get('scaleByRarity')
     rarityValue = 2
 
-    if (Store.get('upscale_Pokemon')) {
+    if (Store.get('upscalePokemon')) {
         const upscaledPokemon = Store.get('upscaledPokemon')
         var rarityValue = isNotifyPoke(item) || (upscaledPokemon.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
     }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -982,6 +982,10 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
+    'upscale_Pokemon': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
     'upscaledPokemon': {
         default: [],
         type: StoreTypes.JSON
@@ -1085,17 +1089,21 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
     var markerDetails = {
         sprite: sprite
     }
-
     var iconSize = (map.getZoom() - 3) * (map.getZoom() - 3) * 0.2 + Store.get('iconSizeModifier')
     scaleByRarity = scaleByRarity && Store.get('scaleByRarity')
+    rarityValue = 2
+
+    if (Store.get('upscale_Pokemon')) {
+        const upscaledPokemon = Store.get('upscaledPokemon')
+        var rarityValue = isNotifyPoke(item) || (upscaledPokemon.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
+    }
+
     if (scaleByRarity) {
         const rarityValues = {
             'very rare': 30,
             'ultra rare': 40,
             'legendary': 50
         }
-        const upscaledPokemon = Store.get('upscaledPokemon')
-        var rarityValue = isNotifyPoke(item) || (upscaledPokemon.indexOf(item['pokemon_id']) !== -1) ? 29 : 2
 
         if (item.hasOwnProperty('pokemon_rarity')) {
             const pokemonRarity = item['pokemon_rarity'].toLowerCase()
@@ -1104,11 +1112,10 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true) {
                 rarityValue = rarityValues[pokemonRarity]
             }
         }
-
-        markerDetails.rarityValue = rarityValue
-        iconSize += rarityValue
     }
 
+    iconSize += rarityValue
+    markerDetails.rarityValue = rarityValue
     markerDetails.icon = getGoogleSprite(pokemonIndex, sprite, iconSize)
     markerDetails.iconSize = iconSize
 


### PR DESCRIPTION
## Description
By making them 2 separate beings they can be run independently, allow custom pokemon upscaling without the need for ScalingByRarity

## Motivation and Context
Some people don't like ScalingByRarity due to the fact pokemon rarity is different for all areas.
This allows people to have what they like upscaled without having ultra rare and very rare upscaled which was a necessary before.

## How Has This Been Tested?
tested locally at 2am by a very tired me

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
