### PR TITLE
Close DB after queries to properly use the pool of connections

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -46,7 +46,6 @@
 #db-user:                       # Required for mysql
 #db-pass:                       # Required for mysql
 #db-port:                       # Required for mysql (default=3306)
-#db-max_connections:            # Max connections (per thread) for the database. (default=5)
 #db-threads:                    # Number of db threads; increase if the db queue falls behind. (default=1)
 
 

--- a/docs/common-issues/faq.md
+++ b/docs/common-issues/faq.md
@@ -155,22 +155,6 @@ InternalError(1054, u"unknown column 'cp' in 'field list'") or similar
 
 Only one instance can run when the database is being modified or upgraded. Run ***ONE*** instance of RM with `-cd` to wipe your database, then run ***ONE*** instance of RM (without `-cd`) to setup your database.
 
-#### Peewee max connections
-
-```
-ValueError: Exceeded maximum connections.
-```
-
-Try raising --db-max_connections, default is 5.
-
-#### MySQL max connections
-
-```
-OperationalError(1040, u'Too many connections')
-```
-
-You need to raise the maximum connections allowed on your MySQL server configuration, this is typically by setting `max_connections` in my.cnf or my.ini. Please use Google to find where this file is located on your specific operating system.
-
 #### SQLite query limit
 
 ```

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -31,7 +31,6 @@
                     [--db-name DB_NAME] [--db-user DB_USER]
                     [--db-pass DB_PASS] [--db-host DB_HOST]
                     [--db-port DB_PORT]
-                    [--db-max_connections DB_MAX_CONNECTIONS]
                     [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi]
                     [--disable-clean]
                     [--wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure}]
@@ -57,7 +56,7 @@
     ConfigArgParse documentation. If an arg is specified in more than one place,
     then commandline values override environment variables which override config
     file values which override defaults.
-    
+
     optional arguments:
       -h, --help            show this help message and exit [env var:
                             POGOMAP_HELP]
@@ -322,9 +321,6 @@
       --db-host DB_HOST     IP or hostname for the database. [env var:
                             POGOMAP_DB_HOST]
       --db-port DB_PORT     Port for the database. [env var: POGOMAP_DB_PORT]
-      --db-max_connections DB_MAX_CONNECTIONS
-                            Max connections (per thread) for the database. [env
-                            var: POGOMAP_DB_MAX_CONNECTIONS]
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
                             behind. [env var: POGOMAP_DB_THREADS]
@@ -413,4 +409,3 @@
                             logs. [env var: POGOMAP_NO_FILE_LOGS]
       --log-path LOG_PATH   Defines directory to save log files to. [env var:
                             POGOMAP_LOG_PATH]
-    

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -875,7 +875,10 @@ class SpeedScan(HexSearch):
             ms = ((now_date - self.refresh_date).total_seconds() +
                   self.refresh_ms)
             best = {}
-            worker_loc = [status['latitude'], status['longitude']]
+            if not status['latitude']:
+                worker_loc = None
+            else:
+                worker_loc = [status['latitude'], status['longitude']]
             last_action = status['last_scan_date']
 
             # Logging.
@@ -954,10 +957,14 @@ class SpeedScan(HexSearch):
 
                 # If we are going to get there before it starts then ignore.
                 loc = item['loc']
-                meters = distance(loc, worker_loc)
-                secs_to_arrival = meters / self.args.kph * 3.6
-                secs_waited = (now_date - last_action).total_seconds()
-                secs_to_arrival = max(secs_to_arrival - secs_waited, 0)
+                if worker_loc:
+                    meters = distance(loc, worker_loc)
+                    secs_to_arrival = meters / self.args.kph * 3.6
+                    secs_waited = (now_date - last_action).total_seconds()
+                    secs_to_arrival = max(secs_to_arrival - secs_waited, 0)
+                else:
+                    meters = 0
+                    secs_to_arrival = 0
                 if ms + secs_to_arrival < item['start']:
                     count_early += 1
                     continue
@@ -1037,7 +1044,7 @@ class SpeedScan(HexSearch):
                                         + ' under the speed limit.')
                 return -1, 0, 0, 0, messages, 0
 
-            meters = distance(loc, worker_loc)
+            meters = distance(loc, worker_loc) if worker_loc else 0
             if (meters > (now_date - last_action).total_seconds() *
                     self.args.kph / 3.6):
                 # Flag item as "parked" by a specific thread, because

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1065,7 +1065,7 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                             except GymDetails.DoesNotExist:
                                 gyms_to_update[gym['gym_id']] = gym
                                 continue
-                            GymDetails._meta.database.close()
+                            GymDetails.database().close()
 
                             # If we have a record of this gym already, check if
                             # the gym has been updated since our last update.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -482,8 +482,8 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
     # The real work starts here but will halt when any control flag is set.
     while True:
         if (args.hash_key is not None and
-                (hashkeys_last_upsert + hashkeys_upsert_min_delay)
-                <= timeit.default_timer()):
+            (hashkeys_last_upsert + hashkeys_upsert_min_delay) <=
+                timeit.default_timer()):
             upsertKeys(args.hash_key, key_scheduler, db_updates_queue)
             hashkeys_last_upsert = timeit.default_timer()
 
@@ -787,22 +787,38 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
             log.info(status['message'])
 
             # Get an account.
+            stagger_thread(args)
             account = account_queue.get()
             # Reset account statistics tracked per loop.
-            status.update(WorkerStatus.get_worker(
-                account['username'], scheduler.scan_location))
-            status['message'] = 'Switching to account {}.'.format(
-                account['username'])
-            log.info(status['message'])
-
+            prevStatus = WorkerStatus.get_worker(account['username'])
+            if prevStatus:
+                status.update(prevStatus)
+            else:
+                status.update({
+                    'username': account['username'],
+                    'last_modified': datetime.utcnow(),
+                    'last_scan_date': datetime.utcnow(),
+                    'latitude': None,
+                    'longitude': None
+                })
             # New lease of life right here.
-            status['fail'] = 0
-            status['success'] = 0
-            status['noitems'] = 0
-            status['skip'] = 0
-            status['captcha'] = 0
-
-            stagger_thread(args)
+            status.update({
+                'fail':
+                    0,
+                'success':
+                    0,
+                'noitems':
+                    0,
+                'skip':
+                    0,
+                'captcha':
+                    0,
+                'active':
+                    True,
+                'message':
+                    'Switching to account {}.'.format(account['username'])
+            })
+            log.info(status['message'])
 
             # Sleep when consecutive_fails reaches max_failures, overall fails
             # for stat purposes.
@@ -816,7 +832,6 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
 
             # The forever loop for the searches.
             while True:
-                status['active'] = True
                 while is_paused(control_flags):
                     status['message'] = 'Scanning paused.'
                     time.sleep(2)
@@ -1050,6 +1065,7 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                             except GymDetails.DoesNotExist:
                                 gyms_to_update[gym['gym_id']] = gym
                                 continue
+                            GymDetails._meta.database.close()
 
                             # If we have a record of this gym already, check if
                             # the gym has been updated since our last update.
@@ -1170,15 +1186,14 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
 
         # Catch any process exceptions, log them, and continue the thread.
         except Exception as e:
-            log.error((
-                'Exception in search_worker under account {} Exception ' +
-                'message: {}.').format(account['username'], repr(e)))
+            log.exception(
+                'Exception in search_worker under account %s.',
+                account['username'])
             status['active'] = False
             status['message'] = (
                 'Exception in search_worker using account {}. Restarting ' +
                 'with fresh account. See logs for details.').format(
                     account['username'])
-            traceback.print_exc(file=sys.stdout)
             account_failures.append({'account': account,
                                      'last_fail_time': now(),
                                      'reason': 'exception'})

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -375,9 +375,6 @@ def get_args():
     parser.add_argument('--db-host', help='IP or hostname for the database.')
     parser.add_argument(
         '--db-port', help='Port for the database.', type=int, default=3306)
-    parser.add_argument('--db-max_connections',
-                        help='Max connections (per thread) for the database.',
-                        type=int, default=5)
     parser.add_argument('--db-threads',
                         help=('Number of db threads; increase if the db ' +
                               'queue falls behind.'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The main change is trying to close the db after each query.
Also removed the db-max_connections param as it makes no sense, see https://github.com/RocketMap/RocketMap/pull/2273#issuecomment-325293182 for details.
Logging procedure is changed a bit to clean the status reset procedure and to avoid requesting a lot of db connnections at once.

## Motivation and Context
This is done as peewee by default will not close connections rendering the pool useless, using flaskUtils do close the db after a webserver request but for long lasting threads (like workers) there were no control to close them.
This change do reduce the number of open connections from 170 to 3-4 in my setup (no web) ~there is still a spike when all workers are created that I need to address otherwise~ it will be doable to set have at max 10 simultaneus connections in most of the setups (+ web server that heavily depends on user count).
Also it will reduce the number of open sockets so it will help the systems that have problems with too many open files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Have been running for days in my main instance, Mysql is happier but couldn't see clear improvements in memory usage from RM or Mysql.

## Screenshots (if appropriate):
![whm host show mysql processes - 66 0 23_2017-09-19_23-07-36](https://user-images.githubusercontent.com/487098/30615517-789fda56-9d8f-11e7-913f-09e66d5c6466.png)

Connections using the previous version on main instance: 140 workers - 5 open connections and test instance with latest version 18 workers - 2 connections

![whm host show mysql processes - 66 0 23_2017-09-19_23-13-03](https://user-images.githubusercontent.com/487098/30615774-474ca028-9d90-11e7-8b88-3f3705f5c5d3.png)

Same config in latest develop 18 workers - 23 connections.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
