### PR TITLE
Reset Gym Filter when disabled

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2649,11 +2649,41 @@ $(function () {
             }
         }
     }
+
+    function resetGymFilter() {
+        Store.set('showTeamGymsOnly', 0)
+        Store.set('minGymLevel', 0)
+        Store.set('maxGymLevel', 6)
+        Store.set('showOpenGymsOnly', false)
+        $('#team-gyms-only-switch').val(Store.get('showTeamGymsOnly'))
+        $('#open-gyms-only-switch').prop('checked', Store.get('showOpenGymsOnly'))
+        $('#min-level-gyms-filter-switch').val(Store.get('minGymLevel'))
+        $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
+        $selectTeamGymsOnly = $('#team-gyms-only-switch')
+        $selectTeamGymsOnly.select2({
+            placeholder: 'Only Show Gyms For Team',
+            minimumResultsForSearch: Infinity
+        })
+
+        $selectMinGymLevel = $('#min-level-gyms-filter-switch')
+        $selectMinGymLevel.select2({
+            placeholder: 'Minimum Gym Level',
+            minimumResultsForSearch: Infinity
+        })
+
+        $selectMaxGymLevel = $('#max-level-gyms-filter-switch')
+        $selectMaxGymLevel.select2({
+            placeholder: 'Maximum Gym Level',
+            minimumResultsForSearch: Infinity
+        })
+    }
+
     // Setup UI element interactions
     $('#gyms-switch').change(function () {
         var options = {
             'duration': 500
         }
+        resetGymFilter()
         var wrapper = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2655,11 +2655,14 @@ $(function () {
         Store.set('minGymLevel', 0)
         Store.set('maxGymLevel', 6)
         Store.set('showOpenGymsOnly', false)
+        
         $('#team-gyms-only-switch').val(Store.get('showTeamGymsOnly'))
         $('#open-gyms-only-switch').prop('checked', Store.get('showOpenGymsOnly'))
         $('#min-level-gyms-filter-switch').val(Store.get('minGymLevel'))
         $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
+        
         $selectTeamGymsOnly = $('#team-gyms-only-switch')
+
         $selectTeamGymsOnly.select2({
             placeholder: 'Only Show Gyms For Team',
             minimumResultsForSearch: Infinity

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2655,30 +2655,15 @@ $(function () {
         Store.set('minGymLevel', 0)
         Store.set('maxGymLevel', 6)
         Store.set('showOpenGymsOnly', false)
-        
+
         $('#team-gyms-only-switch').val(Store.get('showTeamGymsOnly'))
         $('#open-gyms-only-switch').prop('checked', Store.get('showOpenGymsOnly'))
         $('#min-level-gyms-filter-switch').val(Store.get('minGymLevel'))
         $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
-        
-        $selectTeamGymsOnly = $('#team-gyms-only-switch')
 
-        $selectTeamGymsOnly.select2({
-            placeholder: 'Only Show Gyms For Team',
-            minimumResultsForSearch: Infinity
-        })
-
-        $selectMinGymLevel = $('#min-level-gyms-filter-switch')
-        $selectMinGymLevel.select2({
-            placeholder: 'Minimum Gym Level',
-            minimumResultsForSearch: Infinity
-        })
-
-        $selectMaxGymLevel = $('#max-level-gyms-filter-switch')
-        $selectMaxGymLevel.select2({
-            placeholder: 'Maximum Gym Level',
-            minimumResultsForSearch: Infinity
-        })
+        $('#team-gyms-only-switch').trigger('change')
+        $('#min-level-gyms-filter-switch').trigger('change')
+        $('#max-level-gyms-filter-switch').trigger('change')
     }
 
     // Setup UI element interactions


### PR DESCRIPTION
added a Gym Filter reset function and call it when the gym switch is toggled

## Description
added a Gym Filter reset function and call it when the gym switch is toggled

## Motivation and Context
currently the filter is not disabled properly when the switch is turned off which affected the showing of gyms like in [Issue 2268](https://github.com/RocketMap/RocketMap/issues/2268)

**Seb:** Fixes #2268.

## How Has This Been Tested?
Tested to see if the filter is reset when turned off
Tested to see if it fixed the raid showing issue once gyms were disabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
