### PR TITLE
Make background DB cleaner more complete.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2654,6 +2654,20 @@ def clean_db_loop(args):
                              (datetime.utcnow() - timedelta(minutes=30)))))
             query.execute()
 
+            # Remove old gym Details.
+            query = (GymDetails
+                     .delete()
+                     .where(GymDetails.last_scanned <
+                            (datetime.now() - timedelta(days=1))))
+            query.execute()
+
+            # Remove old gym locations.
+            query = (Gym
+                     .delete()
+                     .where(Gym.last_scanned <
+                            (datetime.now() - timedelta(days=1))))
+            query.execute()
+
             # Remove active modifier from expired lured pokestops.
             query = (Pokestop
                      .update(lure_expiration=None, active_fort_modifier=None)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2706,7 +2706,7 @@ def clean_db_loop(args):
             query = (HashKeys
                      .delete()
                      .where(HashKeys.expires <
-                            (datetime.now() - timedelta(days=1))))
+                            (datetime.utcnow() - timedelta(days=1))))
             query.execute()
 
             # If desired, clear old Pokemon spawns.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2658,14 +2658,35 @@ def clean_db_loop(args):
             query = (GymDetails
                      .delete()
                      .where(GymDetails.last_scanned <
-                            (datetime.now() - timedelta(days=1))))
+                            (datetime.utcnow() - timedelta(days=7))))
             query.execute()
 
             # Remove old gym locations.
             query = (Gym
                      .delete()
                      .where(Gym.last_scanned <
-                            (datetime.now() - timedelta(days=1))))
+                            (datetime.utcnow() - timedelta(days=7))))
+            query.execute()
+
+            # Remove old raid Details.
+            query = (Raid
+                     .delete()
+                     .where(Raid.end <
+                            (datetime.utcnow() - timedelta(days=7))))
+            query.execute()
+
+            # Remove old gym members.
+            query = (GymMember
+                     .delete()
+                     .where(GymMember.last_scanned <
+                            (datetime.utcnow() - timedelta(days=7))))
+            query.execute()
+
+            # Remove old gym Pokemon.
+            query = (GymPokemon
+                     .delete()
+                     .where(GymPokemon.last_seen <
+                            (datetime.utcnow() - timedelta(days=7))))
             query.execute()
 
             # Remove active modifier from expired lured pokestops.


### PR DESCRIPTION
add removal of gym and gym details over 24 hours old to clean db loop

<!--- Provide a general summary of your changes in the Title above -->

## Description
This will remove the gym and its deatils from the database if it has not been scanned in 24 hours

## Motivation and Context
If you no longer scan an area or a gym is removed by niantic the old gyms stay on the map and in the db but never updated.

**Seb:** Fixes #2278.

## How Has This Been Tested?
Had old gym info in db, the db cleaner loop removed them

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
