### PR TITLE
Give custom.js load priority.

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -73,7 +73,7 @@ $(function () {
     Store.set('upscalePokemon', upscalePokemon)
     Store.set('upscaledPokemon', upscaledPokemon)
 
-    if (typeof window.orientation !== "undefined" || isMobileDevice()) {
+    if (typeof window.orientation !== 'undefined' || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
         Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)
         Store.set('clusterGridSize', clusterGridSizeMobile)

--- a/templates/map.html
+++ b/templates/map.html
@@ -444,29 +444,29 @@
       <div id="map"></div>
       <div class="fab" id="scan-here" style="display:none"></div>
     </div>
-    <!-- Scripts -->
+    <!-- Load JS libs before custom scripts. -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/vendor/markerclusterer.min.js').lstrip('/') }}"></script>
-    <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>
     <script>
       var centerLat = {{lat}};
       var centerLng = {{lng}};
       var showConfig = {{show|tojson|safe}};
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>
+    <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>
+    <!-- Load custom JS before map.js so it can change Store defaults. -->
+      {% if show.custom_js %}
+    <script src="{{ url_for('static', filename='dist/js/custom.min.js').lstrip('/') }}"></script>
+      {% endif %}
     <script src="{{ url_for('static', filename='dist/js/map.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='dist/js/stats.min.js').lstrip('/') }}"></script>
     <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>
     <script async src='https://www.google-analytics.com/analytics.js'></script>
-    <!-- Custom JS -->
-      {% if show.custom_js %}
-    <script src="{{ url_for('static', filename='dist/js/custom.min.js').lstrip('/') }}"></script>
-      {% endif %}
   </body>
 </html>

--- a/templates/mobile_list.html
+++ b/templates/mobile_list.html
@@ -2,7 +2,6 @@
 <head>
 	<title>Nearby Pokémon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<script>var pageLoaded = new Date().getTime();</script>
 	<link rel="stylesheet" href="{{ url_for('static', filename='dist/css/mobile.min.css').lstrip('/') }}" type="text/css" />
 	<!-- Custom CSS code-->
 		{% if show.custom_css %}
@@ -33,11 +32,13 @@
 		</div>
 	</div>
 
+	<!-- Load JS libs before custom scripts. -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-	<script src="{{ url_for('static', filename='dist/js/mobile.min.js').lstrip('/') }}"></script>
-    <!-- Custom JS -->
+    <script>var pageLoaded = new Date().getTime();</script>
+    <!-- Load custom JS before mobile.js so it can change Store defaults. -->
       {% if show.custom_js %}
     <script src="{{ url_for('static', filename='dist/js/custom.min.js').lstrip('/') }}"></script>
       {% endif %}
+	<script src="{{ url_for('static', filename='dist/js/mobile.min.js').lstrip('/') }}"></script>
 </body>
 </html>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -30,13 +30,6 @@
       {% if show.custom_css %}
     <link rel="stylesheet" type="text/css" href="static/css/custom.css">
       {% endif %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
-    <script>
-      var centerLat = {{lat}};
-      var centerLng = {{lng}};
-    </script>
-    <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>
 </head>
 <body class="statisticsPage">
         <!-- Header -->
@@ -76,11 +69,19 @@
                 </div>
             </div>
         </div>
-    <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
-    <script src="{{ url_for('static', filename='dist/js/statistics.min.js').lstrip('/') }}"></script>
-    <!-- Custom JS -->
+    <!-- Load JS libs before custom scripts. -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
+    <script>
+      var centerLat = {{lat}};
+      var centerLng = {{lng}};
+    </script>
+    <script src="{{ url_for('static', filename='dist/js/map.common.min.js').lstrip('/') }}"></script>
+    <!-- Load custom JS before statistics.js so it can change Store defaults. -->
       {% if show.custom_js %}
     <script src="{{ url_for('static', filename='dist/js/custom.min.js').lstrip('/') }}"></script>
       {% endif %}
+    <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
+    <script src="{{ url_for('static', filename='dist/js/statistics.min.js').lstrip('/') }}"></script>
 </body>
 </html>

--- a/templates/status.html
+++ b/templates/status.html
@@ -83,12 +83,13 @@
         </form>
     </div>
 </div>
-<script src="{{ url_for('static', filename='dist/js/status.min.js').lstrip('/') }}"></script>
-<script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
+<!-- Load JS libs before custom scripts. -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
-<!-- Custom JS -->
+<!-- Load custom JS before status.js so it can change Store defaults. -->
   {% if show.custom_js %}
 <script src="{{ url_for('static', filename='dist/js/custom.min.js').lstrip('/') }}"></script>
   {% endif %}
+<script src="{{ url_for('static', filename='dist/js/status.min.js').lstrip('/') }}"></script>
+<script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

- Separated vendor libs from custom JS files for readability & consistency. Avoids conflicts in loading.
- Load custom.js before other custom JS files so we can use it to overwrite default Store values.
- Moved all JS that was in `<head>` to the end of `<body>`.
- Edited double quotes in `custom.js.example` to single quotes so it passes the linter.

## Motivation and Context
Fixes #2280.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
