### PR TITLE
Make Push.js serviceWorker.min.js path relative

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2282,6 +2282,7 @@ $(function () {
     /* If push.js is unsupported or disabled, fall back to toastr
      * notifications. */
     Push.config({
+        serviceWorker: 'serviceWorker.min.js',
         fallback: function (notification) {
             sendToastrPokemonNotification(
                 notification.title,


### PR DESCRIPTION
## Description
Add option to Push.js configuration to point to the correct relative service worker path.
serviceWorker: 'serviceWorker.min.js'
Default is: serviceWorker: '/serviceWorker.min.js'

Fixes #2290

## Motivation and Context
Push.js by default looks for the required serviceworker.min.js file at an absolute path on domain level like 'xyz.org/serviceworker.min.js'.
Since many of us run their maps under a subpath like 'xyz.org/map' the file can not be found.
Which then leads to no notifications on mobile browsers.

## How Has This Been Tested?
Tested on own instance running under subpath '/map/'.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
