### PR TITLE
Split proxy into two different lists, PTC and Niantic

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -134,6 +134,8 @@
 
 #proxy:                         # Proxy URL e.g. socks5://127.0.0.1:9050 or a list of proxies
                                 # e.g. [socks5://127.0.0.1:9050,socks5://127.0.0.1:9050]
+#proxyauth:                     # Proxy Authentication URL e.g. socks5://127.0.0.1:9050 or a list of proxies
+                                # e.g. [socks5://127.0.0.1:9050,socks5://127.0.0.1:9050]
 #proxy-skip-check               # Disable checking of proxies before start.
 #proxy-test-timeout:            # Timeout before proceeding with next proxy while checking if the proxy works. (default=5)
 #proxy-test-retries:            # Number of times to retry sending proxy test requests on failure. (default=0)
@@ -141,6 +143,7 @@
 #proxy-test-concurrency:        # Async requests pool size. (default=0 for automatic optimal sizing)
 #proxy-display:                 # Used with -ps, full = display complete proxy address. Index = displays just the index for that proxy. (default='index')
 #proxy-file:                    # Load proxy list from text file (one proxy per line), overrides #proxy.
+#proxyauth-file:                # Load authentication proxy list from text file (one proxy per line), overrides #proxy.
 #proxy-refresh:                 # Period of proxy file reloading, in seconds. Works only with proxy-file. (default=0, 0 to disable)
 #proxy-rotation:                # Enable proxy rotation with account changing for search threads (none/round/random). (default='none')
 

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -22,11 +22,12 @@
                     [-nr] [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-spin]
                     [-ams ACCOUNT_MAX_SPINS] [-kph KPH] [-hkph HLVL_KPH]
                     [-ldur LURE_DURATION] [--dump-spawnpoints]
-                    [-pd PURGE_DATA] [-px PROXY] [-pxsc]
+                    [-pd PURGE_DATA] [-px PROXY] [-pxa PROXYAUTH] [-pxsc]
                     [-pxt PROXY_TEST_TIMEOUT] [-pxre PROXY_TEST_RETRIES]
                     [-pxbf PROXY_TEST_BACKOFF_FACTOR]
                     [-pxc PROXY_TEST_CONCURRENCY] [-pxd PROXY_DISPLAY]
-                    [-pxf PROXY_FILE] [-pxr PROXY_REFRESH]
+                    [-pxf PROXY_FILE] [-pxaf PROXYAUTH_FILE] 
+					[-pxr PROXY_REFRESH]
                     [-pxo PROXY_ROTATION] [--db-type DB_TYPE]
                     [--db-name DB_NAME] [--db-user DB_USER]
                     [--db-pass DB_PASS] [--db-host DB_HOST]
@@ -282,6 +283,9 @@
       -px PROXY, --proxy PROXY
                             Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
                             POGOMAP_PROXY]
+      -pxa PROXY, --proxyauth PROXY
+                            Proxy auth url (e.g. socks5://127.0.0.1:9050) [env var:
+                            POGOMAP_PROXY]
       -pxsc, --proxy-skip-check
                             Disable checking of proxies before start. [env var:
                             POGOMAP_PROXY_SKIP_CHECK]
@@ -304,6 +308,9 @@
                             POGOMAP_PROXY_DISPLAY]
       -pxf PROXY_FILE, --proxy-file PROXY_FILE
                             Load proxy list from text file (one proxy per line),
+                            overrides -px/--proxy. [env var: POGOMAP_PROXY_FILE]
+      -pxaf PROXYAUTH_FILE, --proxyauth-file PROXYAUTH_FILE
+                            Load auth proxy list from text file (one proxy per line),
                             overrides -px/--proxy. [env var: POGOMAP_PROXY_FILE]
       -pxr PROXY_REFRESH, --proxy-refresh PROXY_REFRESH
                             Period of proxy file reloading, in seconds. Works only

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -71,12 +71,12 @@ def setup_api(args, status, account):
 # Use API to check the login status, and retry the login if possible.
 def check_login(args, account, api):
     # Logged in? Enough time left? Cool!
-    if api._auth_provider and api._auth_provider._ticket_expire:
-        remaining_time = api._auth_provider._ticket_expire / 1000 - time.time()
+    if api._auth_provider and api._auth_provider._access_token:
+        remaining_time = api._auth_provider._access_token_expiry - time.time()
 
         if remaining_time > 60:
             log.debug(
-                'Credentials remain valid for another %f seconds.',
+                Credentials remain valid for another %f seconds.',
                 remaining_time)
             return
 

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -73,7 +73,6 @@ def check_login(args, account, api):
     # Logged in? Enough time left? Cool!
     if api._auth_provider and api._auth_provider._access_token:
         remaining_time = api._auth_provider._access_token_expiry - time.time()
-
         if remaining_time > 60:
             log.debug(
                 'Credentials remain valid for another %f seconds.',
@@ -94,11 +93,12 @@ def check_login(args, account, api):
                     proxyauth_idx, proxyauth_url = get_new_proxyauth(args)
                 elif api._auth_provider:
                     proxyauth_url = api._auth_provider._session.proxies['http']
-                    log.warning(
-                        'Tried replacing proxy %s with a new proxy, but ' +
-                        'proxy rotation is disabled ("none"). If this ' +
-                        'isn\'t intentional, enable proxy rotation.',
-                        proxyauth_url)
+                    if proxyauth_url not in args.proxyauth:
+                        log.warning(
+                            'Tried replacing proxy %s with a new proxy, but ' +
+                            'proxy rotation is disabled ("none"). If this ' +
+                            'isn\'t intentional, enable proxy rotation.',
+                            proxyauth_url)
                 api.set_authentication(
                     provider=account['auth_service'],
                     username=account['username'],

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -76,7 +76,7 @@ def check_login(args, account, api):
 
         if remaining_time > 60:
             log.debug(
-                Credentials remain valid for another %f seconds.',
+                'Credentials remain valid for another %f seconds.',
                 remaining_time)
             return
 

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -87,8 +87,18 @@ def check_login(args, account, api):
     while num_tries < (args.login_retries + 1):
         try:
             if args.proxyauth:
-                # If auth proxy configured, we use new proxy each login attempt
-                proxyauth_idx, proxyauth_url = get_new_proxyauth(args)
+                # If we still dont have any auth proxy configured or
+                # proxy rotation set, we change the proxy
+                if (not api._auth_provider or
+                        api._auth_provider and args.proxy_rotation != 'none'):
+                    proxyauth_idx, proxyauth_url = get_new_proxyauth(args)
+                elif api._auth_provider:
+                    proxyauth_url = api._auth_provider._session.proxies['http']
+                    log.warning(
+                        'Tried replacing proxy %s with a new proxy, but ' +
+                        'proxy rotation is disabled ("none"). If this ' +
+                        'isn\'t intentional, enable proxy rotation.',
+                        proxyauth_url)
                 api.set_authentication(
                     provider=account['auth_service'],
                     username=account['username'],

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -73,6 +73,7 @@ def check_login(args, account, api):
     # Logged in? Enough time left? Cool!
     if api._auth_provider and api._auth_provider._access_token:
         remaining_time = api._auth_provider._access_token_expiry - time.time()
+
         if remaining_time > 60:
             log.debug(
                 'Credentials remain valid for another %f seconds.',

--- a/pogom/captcha.py
+++ b/pogom/captcha.py
@@ -138,7 +138,7 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
         location = jitter_location(location)
 
     api.set_position(*location)
-    check_login(args, account, api, proxy_url)
+    check_login(args, account, api)
 
     wh_message = {'status_name': args.status_name,
                   'status': 'error',

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2388,10 +2388,10 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
         # it's not alive anymore, we need to get a new proxy.
         elif (args.proxy and
               (hlvl_api._session.proxies['http'] not in args.proxy)):
-                proxy_idx, proxy_new = get_new_proxy(args)
-                hlvl_api.set_proxy({
-                    'http': proxy_new,
-                    'https': proxy_new})
+            proxy_idx, proxy_new = get_new_proxy(args)
+            hlvl_api.set_proxy({
+                'http': proxy_new,
+                'https': proxy_new})
 
         # Hashing key.
         # TODO: Rework inefficient threading.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -34,7 +34,7 @@ from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 
 from .account import check_login, setup_api, pokestop_spinnable, spin_pokestop
-from .proxy import get_new_proxy
+from .proxy import get_new_proxy, get_new_proxyauth
 from .apiRequests import encounter
 
 log = logging.getLogger(__name__)
@@ -2386,15 +2386,20 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
 
         # If the already existent API is using a proxy but
         # it's not alive anymore, we need to get a new proxy.
-        elif (args.proxy and
-              (hlvl_api._session.proxies['http'] not in args.proxy)):
-            proxy_idx, proxy_new = get_new_proxy(args)
-            hlvl_api.set_proxy({
-                'http': proxy_new,
-                'https': proxy_new})
-            hlvl_api._auth_provider.set_proxy({
-                'http': proxy_new,
-                'https': proxy_new})
+        else:
+            if (args.proxy and
+               (hlvl_api._session.proxies['http'] not in args.proxy)):
+                proxy_idx, proxy_new = get_new_proxy(args)
+                hlvl_api.set_proxy({
+                    'http': proxy_new,
+                    'https': proxy_new})
+            if (args.proxyauth and
+                (hlvl_api._auth_provider._session.proxies['http'] not in
+                 args.proxyauth)):
+                proxyauth_idx, proxyauth_new = get_new_proxyauth(args)
+                hlvl_api._auth_provider.set_proxy({
+                    'http': proxyauth_new,
+                    'https': proxyauth_new})
 
         # Hashing key.
         # TODO: Rework inefficient threading.
@@ -2411,7 +2416,7 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
         hlvl_api.set_position(*scan_location)
 
         # Log in.
-        check_login(args, hlvl_account, hlvl_api, status['proxy_url'])
+        check_login(args, hlvl_account, hlvl_api, status['proxyauth_url'])
         encounter_level = hlvl_account['level']
 
         # User error -> we skip freeing the account.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -34,7 +34,7 @@ from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 
 from .account import check_login, setup_api, pokestop_spinnable, spin_pokestop
-from .proxy import get_new_proxy, get_new_proxyauth
+from .proxy import get_new_proxy
 from .apiRequests import encounter
 
 log = logging.getLogger(__name__)
@@ -2386,20 +2386,12 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
 
         # If the already existent API is using a proxy but
         # it's not alive anymore, we need to get a new proxy.
-        else:
-            if (args.proxy and
-               (hlvl_api._session.proxies['http'] not in args.proxy)):
+        elif (args.proxy and
+              (hlvl_api._session.proxies['http'] not in args.proxy)):
                 proxy_idx, proxy_new = get_new_proxy(args)
                 hlvl_api.set_proxy({
                     'http': proxy_new,
                     'https': proxy_new})
-            if (args.proxyauth and
-                (hlvl_api._auth_provider._session.proxies['http'] not in
-                 args.proxyauth)):
-                proxyauth_idx, proxyauth_new = get_new_proxyauth(args)
-                hlvl_api._auth_provider.set_proxy({
-                    'http': proxyauth_new,
-                    'https': proxyauth_new})
 
         # Hashing key.
         # TODO: Rework inefficient threading.
@@ -2416,7 +2408,7 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
         hlvl_api.set_position(*scan_location)
 
         # Log in.
-        check_login(args, hlvl_account, hlvl_api, status['proxyauth_url'])
+        check_login(args, hlvl_account, hlvl_api)
         encounter_level = hlvl_account['level']
 
         # User error -> we skip freeing the account.

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -103,7 +103,6 @@ class PGoRequestWrapper:
                     }
                     parent = self.request.__parent__
                     parent.set_proxy(proxy_config)
-                    parent._auth_provider.set_proxy(proxy_config)
 
         # If we've reached here, we have no retries left and an exception
         # still occurred.

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -109,11 +109,9 @@ def get_proxy_test_status(proxy, future_niantic):
     # Evaluate response status code.
     niantic_status = niantic_response.status_code
 
-    banned_status_codes = [403, 409]
-
     if niantic_status == 200:
         log.debug('Proxy %s is ok.', proxy)
-    elif niantic_status in banned_status_codes:
+    elif niantic_status == 403:
         proxy_error = ('Proxy {} is banned - got Niantic status'
                        + ' code: {}.').format(proxy,
                                               niantic_status)

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 # Last used proxy for round-robin.
 last_proxy = -1
+last_proxyauth = -1
 
 # Proxy check result constants.
 check_result_ok = 0
@@ -25,22 +26,20 @@ check_result_empty = 6
 check_result_max = 6  # Should be equal to maximal return code.
 
 
-# Evaluates the status of PTC and Niantic request futures, and returns the
+# Evaluates the status of PTC request futures, and returns the
 # result (optionally with an error).
 # Warning: blocking! Can only get status code if request has finished.
-def get_proxy_test_status(proxy, future_ptc, future_niantic):
+def get_proxyauth_test_status(proxy, future_ptc):
     # Start by assuming everything is OK.
     check_result = check_result_ok
     proxy_error = None
 
     # Make sure we don't trip any code quality tools that test scope.
     ptc_response = None
-    niantic_response = None
 
-    # Make sure both requests are completed.
+    # Make sure ptc requests is completed.
     try:
         ptc_response = future_ptc.result()
-        niantic_response = future_niantic.result()
     except requests.exceptions.ConnectTimeout:
         proxy_error = ('Connection timeout for'
                        + ' proxy {}.').format(proxy)
@@ -58,39 +57,82 @@ def get_proxy_test_status(proxy, future_ptc, future_niantic):
 
     # Evaluate response status code.
     ptc_status = ptc_response.status_code
-    niantic_status = niantic_response.status_code
 
     banned_status_codes = [403, 409]
 
-    if niantic_status == 200 and ptc_status == 200:
+    if ptc_status == 200:
         log.debug('Proxy %s is ok.', proxy)
-    elif (niantic_status in banned_status_codes or
-          ptc_status in banned_status_codes):
+    elif ptc_status in banned_status_codes:
         proxy_error = ('Proxy {} is banned -'
-                       + ' got PTC status code: {}, Niantic status'
-                       + ' code: {}.').format(proxy,
-                                              ptc_status,
-                                              niantic_status)
+                       + ' got PTC status code: {}.').format(proxy, ptc_status)
         check_result = check_result_banned
     else:
-        proxy_error = ('Wrong status codes -'
-                       + ' PTC: {},'
-                       + ' Niantic: {}.').format(ptc_status,
-                                                 niantic_status)
+        proxy_error = ('Wrong PTC status code - {}.').format(ptc_status)
         check_result = check_result_wrong
 
     # Explicitly release connection back to the pool, because we don't need
     # or want to consume the content.
     ptc_response.close()
+
+    return (proxy_error, check_result)
+
+
+# Evaluates the status of  Niantic request futures, and returns the
+# result (optionally with an error).
+# Warning: blocking! Can only get status code if request has finished.
+def get_proxy_test_status(proxy, future_niantic):
+    # Start by assuming everything is OK.
+    check_result = check_result_ok
+    proxy_error = None
+
+    # Make sure we don't trip any code quality tools that test scope.
+    niantic_response = None
+
+    # Make sure niantic requests is completed.
+    try:
+        niantic_response = future_niantic.result()
+    except requests.exceptions.ConnectTimeout:
+        proxy_error = ('Connection timeout for'
+                       + ' proxy {}.').format(proxy)
+        check_result = check_result_timeout
+    except requests.exceptions.ConnectionError:
+        proxy_error = 'Failed to connect to proxy {}.'.format(proxy)
+        check_result = check_result_failed
+    except Exception as e:
+        proxy_error = e
+        check_result = check_result_exception
+
+    # If we've already encountered a problem, stop here.
+    if proxy_error:
+        return (proxy_error, check_result)
+
+    # Evaluate response status code.
+    niantic_status = niantic_response.status_code
+
+    banned_status_codes = [403, 409]
+
+    if niantic_status == 200:
+        log.debug('Proxy %s is ok.', proxy)
+    elif niantic_status in banned_status_codes:
+        proxy_error = ('Proxy {} is banned - got Niantic status'
+                       + ' code: {}.').format(proxy,
+                                              niantic_status)
+        check_result = check_result_banned
+    else:
+        proxy_error = ('Wrong Niantic status code -'
+                       + ' {}.').format(niantic_status)
+        check_result = check_result_wrong
+
+    # Explicitly release connection back to the pool, because we don't need
+    # or want to consume the content.
     niantic_response.close()
 
     return (proxy_error, check_result)
 
 
 # Requests to send for testing, which returns futures for Niantic and PTC.
-def start_request_futures(ptc_session, niantic_session, proxy, timeout):
+def start_request_futures_auth(ptc_session, proxy, timeout):
     # URLs for proxy testing.
-    proxy_test_url = 'https://pgorelease.nianticlabs.com/plfe/rpc'
     proxy_test_ptc_url = 'https://sso.pokemon.com/sso/oauth2.0/authorize?' \
                          'client_id=mobile-app_pokemon-go&redirect_uri=' \
                          'https%3A%2F%2Fwww.nianticlabs.com%2Fpokemongo' \
@@ -112,6 +154,16 @@ def start_request_futures(ptc_session, niantic_session, proxy, timeout):
         background_callback=__proxy_check_completed,
         stream=True)
 
+    # Return futures.
+    return (future_ptc)
+
+
+# Requests to send for testing, which returns futures for Niantic and PTC.
+def start_request_futures(niantic_session, proxy, timeout):
+    # URLs for proxy testing.
+    proxy_test_url = 'https://pgorelease.nianticlabs.com/plfe/rpc'
+    log.debug('Checking proxy: %s.', proxy)
+
     # Send request to nianticlabs.com.
     future_niantic = niantic_session.post(
         proxy_test_url,
@@ -123,7 +175,7 @@ def start_request_futures(ptc_session, niantic_session, proxy, timeout):
         stream=True)
 
     # Return futures.
-    return (future_ptc, future_niantic)
+    return (future_niantic)
 
 
 # Load proxies and return a list.
@@ -164,8 +216,131 @@ def load_proxies(args):
     return proxies
 
 
+# Load auth proxies and return a list.
+def load_proxiesauth(args):
+    proxies = []
+
+    # Load proxies from the file. Override args.proxy if specified.
+    if args.proxyauth_file is not None:
+        log.info('Loading auth proxies from file.')
+
+        with open(args.proxyauth_file) as f:
+            for line in f:
+                stripped = line.strip()
+
+                # Ignore blank lines and comment lines.
+                if len(stripped) == 0 or line.startswith('#'):
+                    continue
+
+                proxies.append(stripped)
+
+        log.info('Loaded %d auth proxies.', len(proxies))
+
+        if len(proxies) == 0:
+            log.error('Proxy auth file was configured but ' +
+                      'no proxies were loaded. Aborting.')
+            sys.exit(1)
+    elif args.proxyauth:
+        if isinstance(args.proxyauth, list):
+            proxies = args.proxyauth
+        else:
+            proxies.append(args.proxyauth)
+
+    # No proxies - no cookies.
+    if (proxies is None) or (len(proxies) == 0):
+        log.info('No auth proxies are configured.')
+        return None
+
+    return proxies
+
+
 # Check all proxies and return a working list with proxies.
 def check_proxies(args, proxies):
+    total_proxies = len(proxies)
+
+    # Store counter per result type.
+    check_results = [0] * (check_result_max + 1)
+
+    # If proxy testing concurrency is set to automatic, use max.
+    proxy_concurrency = args.proxy_test_concurrency
+
+    if args.proxy_test_concurrency == 0:
+        proxy_concurrency = total_proxies
+
+    if proxy_concurrency >= 100:
+        log.warning(
+            "Starting proxy test for %d proxies with %d concurrency. If this" +
+            " concurrency level breaks the map for you, consider lowering it.",
+            total_proxies, proxy_concurrency)
+
+    # Get persistent session per host.
+    # TODO: Rework API request wrapper so requests are retried, then increase
+    # the # of retries to allow for proxies.
+    niantic_session = get_async_requests_session(
+        args.proxy_test_retries,
+        args.proxy_test_backoff_factor,
+        proxy_concurrency)
+
+    # List to hold background workers.
+    proxy_queue = []
+    working_proxies = []
+    show_warnings = total_proxies <= 10
+
+    log.info('Checking %d proxies...', total_proxies)
+    if not show_warnings:
+        log.info('Enable -v or -vv to see proxy testing details.')
+
+    # Start async requests & store futures.
+    for proxy in proxies:
+        future_niantic = start_request_futures(
+            niantic_session,
+            proxy,
+            args.proxy_test_timeout)
+
+        proxy_queue.append((proxy, future_niantic))
+
+    # Wait here until all items in proxy_queue are processed, so we have a list
+    # of working proxies. We intentionally start all requests before handling
+    # them so they can asynchronously continue in the background, even as we're
+    # blocking to wait for one. The double loop is intentional.
+    for proxy, future_niantic in proxy_queue:
+        error, result = get_proxy_test_status(proxy,
+                                              future_niantic)
+
+        check_results[result] += 1
+
+        if error:
+            # Decrease output amount if there are a lot of proxies.
+            if show_warnings:
+                log.warning(error)
+            else:
+                log.debug(error)
+        else:
+            working_proxies.append(proxy)
+
+    num_working_proxies = len(working_proxies)
+
+    if num_working_proxies == 0:
+        log.error('Proxy was configured but no working'
+                  + ' proxies were found. Exiting process.')
+        sys.exit(1)
+    else:
+        other_fails = (check_results[check_result_failed] +
+                       check_results[check_result_wrong] +
+                       check_results[check_result_exception] +
+                       check_results[check_result_empty])
+        log.info('Proxy check completed. Working: %d, banned: %d,'
+                 + ' timeout: %d, other fails: %d of total %d configured.',
+                 num_working_proxies, check_results[check_result_banned],
+                 check_results[check_result_timeout],
+                 other_fails,
+                 total_proxies)
+
+        return working_proxies
+
+
+# Check all proxies and return a working list with proxies.
+def check_proxiesauth(args, proxies):
     total_proxies = len(proxies)
 
     # Store counter per result type.
@@ -190,38 +365,32 @@ def check_proxies(args, proxies):
         args.proxy_test_retries,
         args.proxy_test_backoff_factor,
         proxy_concurrency)
-    niantic_session = get_async_requests_session(
-        args.proxy_test_retries,
-        args.proxy_test_backoff_factor,
-        proxy_concurrency)
 
     # List to hold background workers.
     proxy_queue = []
     working_proxies = []
     show_warnings = total_proxies <= 10
 
-    log.info('Checking %d proxies...', total_proxies)
+    log.info('Checking %d auth proxies...', total_proxies)
     if not show_warnings:
         log.info('Enable -v or -vv to see proxy testing details.')
 
     # Start async requests & store futures.
     for proxy in proxies:
-        future_ptc, future_niantic = start_request_futures(
+        future_ptc = start_request_futures(
             ptc_session,
-            niantic_session,
             proxy,
             args.proxy_test_timeout)
 
-        proxy_queue.append((proxy, future_ptc, future_niantic))
+        proxy_queue.append((proxy, future_ptc))
 
     # Wait here until all items in proxy_queue are processed, so we have a list
     # of working proxies. We intentionally start all requests before handling
     # them so they can asynchronously continue in the background, even as we're
     # blocking to wait for one. The double loop is intentional.
-    for proxy, future_ptc, future_niantic in proxy_queue:
-        error, result = get_proxy_test_status(proxy,
-                                              future_ptc,
-                                              future_niantic)
+    for proxy, future_ptc in proxy_queue:
+        error, result = get_proxyauth_test_status(proxy,
+                                                  future_ptc)
 
         check_results[result] += 1
 
@@ -277,6 +446,28 @@ def proxies_refresher(args):
             log.exception('Exception while refreshing proxies: %s.', e)
 
 
+# Thread function for periodical proxy updating.
+def proxiesauth_refresher(args):
+    while True:
+        # Wait before refresh, because initial refresh is done at startup.
+        time.sleep(args.proxy_refresh)
+
+        try:
+            proxiesauth = load_proxiesauth(args)
+
+            if not args.proxy_skip_check:
+                proxiesauth = check_proxiesauth(args, proxiesauth)
+
+            # If we've arrived here, we're guaranteed to have at least one
+            # working proxy. check_proxies stops the process if no proxies
+            # are left.
+
+            args.proxyauth = proxiesauth
+            log.info('Regular auth proxy refresh complete.')
+        except Exception as e:
+            log.exception('Exception while refreshing auth proxies: %s.', e)
+
+
 # Provide new proxy for a search thread.
 def get_new_proxy(args):
     global last_proxy
@@ -297,6 +488,28 @@ def get_new_proxy(args):
         lp = 0
 
     return lp, args.proxy[lp]
+
+
+# Provide new auth proxy for a search thread.
+def get_new_proxyauth(args):
+    global last_proxyauth
+
+    # If round - simply get next proxy.
+    if (args.proxy_rotation == 'round'):
+        if last_proxyauth >= len(args.proxyauth) - 1:
+            last_proxyauth = 0
+        else:
+            last_proxyauth = last_proxyauth + 1
+        lp = last_proxyauth
+    # If random - get random one.
+    elif (args.proxy_rotation == 'random'):
+        lp = randint(0, len(args.proxyauth) - 1)
+    else:
+        log.warning('Parameter -pxo/--proxy-rotation has wrong value. ' +
+                    'Use only first proxy.')
+        lp = 0
+
+    return lp, args.proxyauth[lp]
 
 
 # Background handler for completed proxy check requests.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -435,7 +435,6 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
         # Set proxy for each worker, using round robin.
         proxy_display = 'No'
         proxy_url = False    # Will be assigned inside a search thread.
-        proxyauth_url = False    # Will be assigned inside a search thread.
 
         workerId = 'Worker {:03}'.format(i)
         threadStatus[workerId] = {
@@ -448,8 +447,7 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
             'captcha': 0,
             'username': '',
             'proxy_display': proxy_display,
-            'proxy_url': proxy_url,
-            'proxyauth_url': proxyauth_url
+            'proxy_url': proxy_url
         }
 
         t = Thread(target=search_worker_thread,
@@ -934,7 +932,7 @@ def search_worker_thread(args, account_queue, account_sets,
 
                 # Ok, let's get started -- check our login status.
                 status['message'] = 'Logging in...'
-                check_login(args, account, api, status['proxyauth_url'])
+                check_login(args, account, api)
 
                 # Only run this when it's the account's first login, after
                 # check_login().

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -435,6 +435,7 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
         # Set proxy for each worker, using round robin.
         proxy_display = 'No'
         proxy_url = False    # Will be assigned inside a search thread.
+        proxyauth_url = False    # Will be assigned inside a search thread.
 
         workerId = 'Worker {:03}'.format(i)
         threadStatus[workerId] = {
@@ -448,6 +449,7 @@ def search_overseer_thread(args, new_location_queue, control_flags, heartb,
             'username': '',
             'proxy_display': proxy_display,
             'proxy_url': proxy_url,
+            'proxyauth_url': proxyauth_url
         }
 
         t = Thread(target=search_worker_thread,
@@ -932,7 +934,7 @@ def search_worker_thread(args, account_queue, account_sets,
 
                 # Ok, let's get started -- check our login status.
                 status['message'] = 'Logging in...'
-                check_login(args, account, api, status['proxy_url'])
+                check_login(args, account, api, status['proxyauth_url'])
 
                 # Only run this when it's the account's first login, after
                 # check_login().

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -333,6 +333,9 @@ def get_args():
     parser.add_argument('-px', '--proxy',
                         help='Proxy url (e.g. socks5://127.0.0.1:9050)',
                         action='append')
+    parser.add_argument('-pxa', '--proxyauth',
+                        help='Proxy auth url (e.g. socks5://127.0.0.1:9050)',
+                        action='append')
     parser.add_argument('-pxsc', '--proxy-skip-check',
                         help='Disable checking of proxies before start.',
                         action='store_true', default=False)
@@ -357,6 +360,9 @@ def get_args():
     parser.add_argument('-pxf', '--proxy-file',
                         help=('Load proxy list from text file (one proxy ' +
                               'per line), overrides -px/--proxy.'))
+    parser.add_argument('-pxaf', '--proxyauth-file',
+                        help=('Load proxy auth list from text file (one ' +
+                              'proxy per line), overrides -pxa/--proxyauth.'))
     parser.add_argument('-pxr', '--proxy-refresh',
                         help=('Period of proxy file reloading, in seconds. ' +
                               'Works only with -pxf/--proxy-file. ' +


### PR DESCRIPTION
## Description
Recently PTC login server has started to ban IPs like Niantic did, but the banned IP may be not banned by Niantic and the other way around. With this PR we have two different lists that apply to login or to session when necessary.
Also, check login changed to avoid login in after 30 minutes, we use oauth token instead to refresh session.

## Motivation and Context
We can reuse some PTC banned proxies for  Niantic sessions and the other way around.

## How Has This Been Tested?
Local map

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
