### PR TITLE
Webhook documentation update

### DIFF
--- a/docs/extras/webhooks.md
+++ b/docs/extras/webhooks.md
@@ -45,7 +45,7 @@ To start sending data to a webhook:
 
 **If no webhook types are set, no webhook data will be sent.**
 
-### Setting webhook urls
+### Setting webhook URLs
 
 #### Using the command line
 
@@ -246,7 +246,7 @@ A `pokemon` event is sent every time RocketMap detects that a Pokémon has spawn
 | `2`     | Female     |
 | `3`     | Genderless |
 
-2. These fields will be empty unless the Pokémon has been [encountered](https://rocketmap.readthedocs.io/en/develop/extras/encounters.html)
+2. These fields will be empty unless the Pokémon has been [encountered](https://rocketmap.readthedocs.io/en/develop/extras/encounters.html).
 
 ### `pokestop`
 
@@ -270,7 +270,7 @@ A `lure` event is sent whenever RocketMap scans a pokestop **if that pokestop ha
 
 Note: if you add `lure` events to your `wh_types` you will receive them even if you have not enabled `pokestop` events.
                                                        
-Lure events contain the same fields as `pokestop` events (decribed above).
+Lure events contain the same fields as `pokestop` events (described above).
 
 ### `gym`
 
@@ -288,7 +288,7 @@ A `gym` event is sent whenever RocketMap scans a gym.
 | `guard_pokemon_id`          | The ID of the Pokémon which is displayed on top of the gym |               `149` |
 | `total_cp`                  | The total of the defending Pokémons' CPs                   |              `3853` |
 | `slots_available`           | The number of spaces available                             |                 `4` |
-| `lowest_pokemon_motivation` | The lowest of the defending Pokémons' motivtations         | `0.892739474773407` |
+| `lowest_pokemon_motivation` | The lowest of the defending Pokémons' motivations         | `0.892739474773407` |
 | `raid_active_until`         | The time at which the current raid finishes<sup>3</sup>    |                 `0` |
 
 
@@ -302,7 +302,7 @@ A `gym` event is sent whenever RocketMap scans a gym.
 | `3`     | Instinct    |
 
 2. Gym changes include: Pokémon being added, Pokémon being knocked out, gym control changing etc.
-3. If there is no raid at the gym this value will be `0`
+3. If there is no raid at the gym this value will be `0`.
 
 ### `gym-info`
 
@@ -346,7 +346,7 @@ A `gym-info` event is sent whenever RocketMap fetches a gym's details.
 | `num_upgrades`             | The number of times that the Pokémon has been powered up |         `31` |
 | `deployment_time`          | The time at which the Pokémon was added to the gym       | `1504361277` |
 
-1. The trainer's level at the time that they added their Pokémon to the gym
+1. The trainer's level at the time that they added their Pokémon to the gym.
 
 ### `egg`
 
@@ -427,7 +427,7 @@ Note: at present it is not possible to disable `captcha` events: they will be se
 | `"encounter"` | A captcha has been detected                |
 | `"success"`   | The captcha has been solved                |
 | `"failure"`   | The captcha has not been solved            |
-| `"error"`     | An error occured while solving the captcha |
+| `"error"`     | An error occurred while solving the captcha |
 
 ## PokeAlarm
 

--- a/docs/extras/webhooks.md
+++ b/docs/extras/webhooks.md
@@ -1,116 +1,414 @@
 # Webhooks
 
-Webhooks have been implemented into RocketMap. Using these webhooks are simple, and opens up a new realm of possibilities for over almost anything related to RocketMap.
+RocketMap can send map information such as Pokémon spawns, gym details, raid appearances and pokestop lures to other applications through webhooks.
 
-## How Do RocketMap Webhooks Work?
+Every time a webhook-enabled event occurs (for example a new Pokémon appearing) a web request will be sent to a provided URL containing information about that event.
 
-Every time an event occurs (e.g. a Pokemon spawns) a POST request will be sent to a provided URL containing information about that event. A developer may create a listener in whatever language they feel most comfortable in (it just has to handle incoming connections, after all) and do certain things when information from the webhook is received. For example, a developer would be able to wait for a Dragonite to spawn, then play a loud alarm throughout the house and flash the lights in order to get their attention. All of this could be done without even the slightest touch to the internal RocketMap code, so there's no risk to break anything.
+## What Do Webhooks Do?
 
-## Types of Webhooks
+Webhooks allow developers to send data from RocketMap to other applications.
 
-Pokemon Spawn webhooks are available. 
-If you're a developer, feel free to contribute by creating some more webhooks.
+A simple example would be an application that receives Pokémon spawn events, checks if the Pokémon that's appeared is a Dragonite, and if so plays an alarm sound.
 
-* `pokemon` - Emitted every time a Pokemon spawns.
-* `gym` - Emitted when finding a gym.
-* `pokestop` - Emitted when finding a pokestop.
-* `pokestop_lured` - Emitted every time a Pokestop is lured.
-* `gym_defeated` -  Emitted every time a Gym is defeated (prestige changes)
-* `gym_conquered` -  Emitted every time the owner of a Gym is changed
+## Setting Up a Webhook
 
-## Configuring Webhooks
-Add `-wh http://my-webhook/location` argument when starting RocketMap (runserver.py) to define the location of your webhook. You can add multiple webhook locations to a single -wh argument to define multiple webhooks.
+To start sending data to a webhook:
+1. set a webhook url (or list of webhook urls) to send data to
+2. set the webhook types to be received
+3. (optional) set up a whitelist or blacklist
 
+**If no webhook types are set, no webhook data will be sent.**
 
-### To use this, RocketMap would be run with the following parameters:
+### Setting webhook urls
 
+#### Using the command line
+
+Add `-wh http://YOUR_WEBHOOK_URL` to your existing command line.
+
+To send data to multiple URLs, add a new `-wh ...` string for each URL, for example:
 ```
-python runserver.py -a ptc -u [username] -p [password] -l "Location or lat/lon" -st 15 -k [google maps api key] -wh http://localhost:9876
-```
-
-## Configuring Webhook filter types
-Use `wh-types` to configure webhook types that should get sent.
-
-The list of valid types are:
-* `pokemon`
-* `gym`
-* `raid`
-* `egg`
-* `tth`
-* `gym-info`
-* `pokestop`
-* `lure`
-
-Example to send the webhook messages pokemon, gym, raid and gym-info:
-
-```
-wh-types: [pokemon, gym, raid, gym-info]
+-wh http://YOUR_FIRST_WEBHOOK_URL -wh http://YOUR_SECOND_WEBHOOK_URL
 ```
 
-## Filtering Pokémon
-To filter what Pokémon get sent to the webhooks, you can configure a whitelist of Pokémon IDs (one per line).
+#### Using a config file
 
-For example, if we only want to sent data on dratini, dragonair, dragonite, larvitar, pupitar and tyranitar, add this to your configuration:
-
+Add a new line to your config file:
 ```
-webhook-whitelist-file: pokemon-whitelist.txt
+webhook: http://YOUR_WEBHOOK_URL
 ```
 
-And add the Pokémon IDs to the pokemon-whitelist.txt file:
-
+To send data to multiple URLs, use an array:
 ```
-147
-148
-149
-246
-247
-248
+webhook: [ http://YOUR_FIRST_WEBHOOK_URL, http://YOUR_SECOND_WEBHOOK_URL ]
 ```
 
-## RocketMap Public Webhook
+### Setting webhook types
 
-RM is collecting data for an upcoming project. If you would like to donate your data, please fill out [this form](https://goo.gl/forms/ZCx6mQNngr0bAvRY2) and add `-wh [your webhook URL here]` to your command line. 
+#### Using the command line
+
+Add `--wh-types WEBHOOK_TYPE` to your existing command line.
+
+To set multiple webhook types, add a new `--wh-types ...` string for each URL, for example:
+```
+--wh-types pokemon --wh-types raid
+```
+
+#### Using a config file
+
+Add a new line to your config file:
+```
+wh-types: WEBHOOK_TYPE
+```
+
+To set multiple webhook types, use an array:
+```
+wh-types: [ pokemon, raid ]
+```
+
+### Filtering Pokémon
+
+To limit the Pokémon that get sent to webhooks you can:
+* whitelist specific Pokémon IDs, **or**
+* blacklist specific Pokémon IDs
+
+**If you use a whitelist you cannot also use a blacklist (and vice-versa).**
+
+You can whitelist/blacklist Pokémon IDs using either a list or a file. You can use **either** a list **or** a file, but **not both**.
+
+#### Whitelisting Pokémon
+
+If you want to send webhook data for specific Pokémon (and no other Pokémon) you can use a Pokémon whitelist.
+
+**Using a string**
+
+You can a string of Pokémon IDs to whitelist using:
+```
+webhook-whitelist: [ POKEMON_ID_1, POKEMON_ID_2, POKEMON_ID_3 ]
+```
+
+**Using a file**
+
+You can set a whitelist file using:
+```
+webhook-whitelist-file: WHITELIST_FILE
+```
+
+Note: each Pokémon ID must be on a new line.
+
+**Example**
+
+Whitelisting Dratini, Dragonair, Dragonite, Larvitar, Pupitar and Tyranitar using a whitelist array:
+
+`config.ini`:
+```
+webhook-whitelist: [ 147, 148, 149, 246, 247, 248 ]
+```
+
+#### Blacklisting Pokémon
+
+If you want to exclude specific Pokémon from being set to webhooks you can use a Pokémon blacklist.
+
+**Using a string**
+
+You can a string of Pokémon IDs to blacklist using:
+```
+webhook-blacklist: [ POKEMON_ID_1, POKEMON_ID_2, POKEMON_ID_3 ]
+```
+
+**Using a file**
+
+You can set a blacklist file using:
+```
+webhook-blacklist-file: BLACKLIST_FILE
+```
+Note: each Pokémon ID must be on a new line.
+
+**Example**
+
+Blacklisting Pidgey, Spearow, Caterpie and Weedle using a blacklist file:
+
+`config.ini`:
+```
+webhook-blacklist-file: pokemon-blacklist.txt
+```
+
+`pokemon-blacklist.txt`:
+```
+10
+13
+16
+21
+```
+
+## Webhook Types
+
+Data is sent to webhooks as a JSON object containing an array of webhook events.
+
+Each webhook event has the structure:
+```
+{
+  "type":    EVENT_TYPE,
+  "message": EVENT_DATA
+}
+```
+
+For example:
+```
+[
+  {
+    "type":    "pokemon",
+    "message": { ... }
+  },
+  {
+    "type":    "pokemon",
+    "message": { ... }
+  },
+  {
+    "type":    "pokemon",
+    "message": { ... }
+  },
+  {
+    "type":    "gym",
+    "message": { ... }
+  }
+]
+```
+
+The sections below outline the different webhook types and the data that gets sent for each event. Please note that as RocketMap evolves more webhook types may be added.
+
+If you are a developer please feel free to contribute new webhook types through the usual [RocketMap development process](https://github.com/RocketMap/RocketMap/blob/develop/CONTRIBUTING.md#contributing-code).
+
+### `pokemon`
+
+A `pokemon` event is sent every time RocketMap detects that a Pokémon has spawned.
+
+| Field                   | Details                                                               | Example   |
+| ----------------------- | --------------------------------------------------------------------- | --------- |
+| `spawnpoint_id`         | The spawnpoint that the Pokémon has appeared at                 | `"47d9e3e05a7"` |
+| `encounter_id`          | The unique ID of this Pokémon spawn            | `"MTExMjE5MDExODAyNTczOTg4MjM="` |
+| `pokemon_id`            | The Pokémon's ID                                           |                 `91` |
+| `latitude`              | The Pokémon's latitude                                     |  `43.62969347887845` |
+| `longitude`             | The Pokémon's longitude                                    | `5.2886973939569513` |
+| `disappear_time`        | The time at which the Pokémon will disappear (in unix time)     |    `1504056600` |
+| `time_until_hidden_ms`  | ???                                                             |    `-809985329` |
+| `last_modified_time`    | The time at which the Pokémon was detected                      | `1504048538928` |
+| `seconds_until_despawn` | The current number of seconds remaining before the Pokémon disappears |    `1772` |
+| `spawn_start`           | The number of seconds past the hour at which the Pokémon appears      |     `911` |
+| `spawn_end`             | The number of seconds past the hour at which the Pokémon disappears   |    `2710` |
+| `gender`                | The Pokémon's gender<sup>1</sup>                                    |       `2` |
+| `cp`                    | The Pokémon's CP<sup>2</sup>                                          |      `""` |
+| `form`                  | The Pokémon's form<sup>2</sup>                                        |      `""` |
+| `individual_attack`     | The Pokémon's attack IV<sup>2</sup>                                   |      `""` |
+| `individual_defense`    | The Pokémon's defence IV<sup>2</sup>                                  |      `""` |
+| `individual_stamina`    | The Pokémon's stamina IV<sup>2</sup>                                  |      `""` |
+| `cp_multiplier`         | The Pokémon's CP multiplier<sup>2</sup>                               |      `""` |
+| `move_1`                | The Pokémon's quick move<sup>2</sup>                                  |      `""` |
+| `move_2`                | The Pokémon's charge move<sup>2</sup>                                 |      `""` |
+| `weight`                | The Pokémon's weight<sup>2</sup>                                      |      `""` |
+| `height`                | The Pokémon's height<sup>2</sup>                                      |      `""` |
+| `player_level`          | The level of the account that found the Pokémon                       |       `2` |
+| `verified`              | Whether the TTH for the spawn has been identified                     |    `true` |
+
+1. Pokémon genders are represented by the values:
+
+| Value   | Gender     |
+| ------- | ---------- |
+| `0`     | Unset      |
+| `1`     | Male       |
+| `2`     | Female     |
+| `3`     | Genderless |
+
+2. These fields will be empty unless the Pokémon has been [encountered](https://rocketmap.readthedocs.io/en/develop/extras/encounters.html)
+
+### `pokestop`
+
+A `pokestop` event is sent whenever RocketMap scans a pokestop.
+
+| Field                  | Details                                                             | Example         |
+| ---------------------- | ------------------------------------------------------------------- | --------------- |
+| `pokestop_id`          | The pokestop's unique ID | `"ZmY2NjNmZGQxZTg1NDgxNG`<br>`E5MDAyNTkwM2ZkZjk2NTMuMTY="` |
+| `latitude`             | The pokestop's latitude                                             |      `43.62686` |
+| `longitude`            | The pokestop's longitude                                            |      `5.304069` |
+| `enabled`              | Whether the pokestop can be interacted with                         |          `true` |
+| `last_modified`        | The time at which the pokestop last changed                         | `1501611306167` |
+| `active_fort_modifier` | ???                                                                 |             ??? |
+| `lure_expiration`      | The time at which the current lure expires                          |             ??? |
+
+### `lure`
+
+A `lure` event is sent whenever RocketMap scans a pokestop **if that pokestop has been lured**.
+
+**Important: while the webhook type name for `lure` events is `lure`, when this data is sent to a webhook the `type` field will be `pokestop`.**
+
+Note: if you add `lure` events to your `wh_types` you will receive them even if you have not enabled `pokestop` events.
+                                                       
+Lure events contain the same fields as `pokestop` events (decribed above).
+
+### `gym`
+
+A `gym` event is sent whenever RocketMap scans a gym.
+
+| Field                       | Details                                                    | Example             |
+| --------------------------- | ---------------------------------------------------------- | ------------------- |
+| `gym_id`                    | The gym's unique ID | `"YmQ5MDc4ZjJiNTNjNGE0Ym`<br>`JhOGI0YTIyYzZjOTRhYmUuMTY="` |
+| `latitude`                  | The gym's latitude                                         |         `43.568213` |
+| `longitude`                 | The gym's longitude                                        |          `5.296438` |
+| `enabled`                   | Whether the gym can be interacted with                     |              `true` |
+| `team_id`                   | The team that currently controls the gym<sup>1</sup>       |                 `1` |
+| `occupied_since`            | The time at which the controlling team took the gym        |        `1504047118` |
+| `last_modified`             | The time at which the gym last changed<sup>2</sup>         |     `1504047134624` |
+| `guard_pokemon_id`          | The ID of the Pokémon which is displayed on top of the gym |               `149` |
+| `total_cp`                  | The total of the defending Pokémons' CPs                   |              `3853` |
+| `slots_available`           | The number of spaces available                             |                 `4` |
+| `lowest_pokemon_motivation` | The lowest of the defending Pokémons' motivtations         | `0.892739474773407` |
+| `raid_active_until`         | The time at which the current raid finishes<sup>3</sup>    |                 `0` |
+
+
+1. The teams are represented by the values:
+
+| Value   | Team        |
+| ------- | ----------- |
+| `0`     | Uncontested |
+| `1`     | Mystic      |
+| `2`     | Valor       |
+| `3`     | Instinct    |
+
+2. Gym changes include: Pokémon being added, Pokémon being knocked out, gym control changing etc.
+3. If there is no raid at the gym this value will be `0`
+
+### `gym-info`
+
+A `gym-info` event is sent whenever RocketMap fetches a gym's details.
+
+**Important: while the webhook type name for `gym-info` events is `gym-info`, when this data is sent to a webhook the `type` field will be `gym_details`.**
+
+| Field         | Details                                                | Example                 |
+| ------------- | ------------------------------------------------------ | ----------------------- |
+| `id`          | The gym's unique ID | `"MzcwNGE0MjgyNThiNGE5NW`<br>`FkZWIwYTBmOGM1Yzc2ODcuMTE="` |
+| `name`        | The gym's name                                         | `"St. Clements Church"` |
+| `description` | The gym's description                                  |                    `""` |
+| `url`         | A URL to the gym's image        | `"http://lh3.googleusercontent.com/image_url"` |
+| `latitude`    | The gym's latitude                                     |             `43.633181` |
+| `longitude`   | The gym's longitude                                    |              `5.296836` |
+| `team`        | The team that currently controls the gym               |                     `1` |
+| `pokemon`     | An array containing the Pokémon currently in the gym   |                    `[]` |
+
+**Gym Pokémon:**
+
+| Field                      | Details                                                  | Example      |
+| -------------------------- | -------------------------------------------------------- | ------------ |
+| `trainer_name`             | The name of the trainer that the Pokémon belongs to   | `"johndoe9876"` |
+| `trainer_level`            | The trainer's level<sup>1</sup>                          |         `34` |
+| `pokemon_uid`              | The Pokémon's unique ID                         | `4348002772281054056` |
+| `pokemon_id`               | The Pokémon's ID                                         |        `242` |
+| `cp`                       | The Pokémon's base CP                                    |       `2940` |
+| `cp_decayed`               | The Pokémon's current CP                                 |        `115` |
+| `stamina_max`              | The Pokémon's max stamina                                |        `500` |
+| `stamina`                  | The Pokémon's current stamina                            |        `500` |
+| `move_1`                   | The Pokémon's quick move                                 |        `234` |
+| `move_2`                   | The Pokémon's charge move                                |        `108` |
+| `height`                   | The Pokémon's height                              | `1.746612787246704` |
+| `weight`                   | The Pokémon's weight                              | `51.84344482421875` |
+| `form`                     | The Pokémon's form                                       |          `0` |
+| `iv_attack`                | The Pokémon's attack IV                                  |         `12` |
+| `iv_defense`               | The Pokémon's defense IV                                 |         `14` |
+| `iv_stamina`               | The Pokémon's stamina IV                                 |         `14` |
+| `cp_multiplier`            | The Pokémon's CP multiplier                      | `0.4785003960132599` |
+| `additional_cp_multiplier` | The Pokémon's additional CP multiplier                   |        `0.0` |
+| `num_upgrades`             | The number of times that the Pokémon has been powered up |         `31` |
+| `deployment_time`          | The time at which the Pokémon was added to the gym       | `1504361277` |
+
+1. The trainer's level at the time that they added their Pokémon to the gym
+
+### `egg`
+
+An `egg` event is sent whenever RocketMap detects that an egg has appeared at a gym.
+
+**Important: while the webhook type name for `egg` events is `egg`, when this data is sent to a webhook the `type` field will be `raid`.**
+
+Note: `egg` events use the same event type and fields as `raid` events, but the Pokémon-specific fields such as `pokemon_id` will be `null`.
+
+| Field        | Details                                                           | Example      |
+| ------------ | ----------------------------------------------------------------- | ------------ |
+| `gym_id`     | The gym's unique ID | `"NGY2ZjBjY2Y3OTUyNGQyZW`<br>`FlMjc3ODkzODM2YmI1Y2YuMTY="` |
+| `latitude`   | The gym's latitude                                                |  `43.599321` |
+| `longitude`  | The gym's longitude                                               |   `5.181415` |
+| `spawn`      | The time at which the raid spawned                                | `1500992342` |
+| `start`      | The time at which the raid starts                                 | `1501005600` |
+| `end`        | The time at which the raid ends                                   | `1501007400` |
+| `level`      | The raid's level                                                  |          `5` |
+| `pokemon_id` | For egg events this will always be `null`                         |       `null` |
+| `cp`         | For egg events this will always be `null`                         |       `null` |
+| `move_1`     | For egg events this will always be `null`                         |       `null` |
+| `move_2`     | For egg events this will always be `null`                         |       `null` |
+
+### `raid`
+
+A `raid` event is sent whenever RocketMap detects that a raid has started at a gym.
+
+Note: `raid` events use the same event type and fields as `egg` events, but the Pokémon-specific fields such as `pokemon_id` will be populated.
+
+| Field        | Details                                                           | Example      |
+| ------------ | ----------------------------------------------------------------- | ------------ |
+| `gym_id`     | The gym's unique ID | `"NGY2ZjBjY2Y3OTUyNGQyZW`<br>`FlMjc3ODkzODM2YmI1Y2YuMTY="` |
+| `latitude`   | The gym's latitude                                                |  `43.599321` |
+| `longitude`  | The gym's longitude                                               |   `5.181415` |
+| `spawn`      | The time at which the raid spawned                                | `1500992342` |
+| `start`      | The time at which the raid starts                                 | `1501005600` |
+| `end`        | The time at which the raid ends                                   | `1501007400` |
+| `level`      | The raid's level                                                  |          `5` |
+| `pokemon_id` | The raid boss's ID                                                |        `249` |
+| `cp`         | The raid boss's CP                                                |      `42753` |
+| `move_1`     | The raid boss's quick move                                        |        `274` |
+| `move_2`     | The raid boss's charge move                                       |        `275` |
+
+### `tth`
+
+A `tth` event is sent whenever a scan instance's TTH completion status changes by more than 1%.
+
+**Important: while the webhook type name for `tth` events is `tth`, when this data is sent to a webhook the `type` field will be `scheduler`.**
+
+Note: at present only the `speed-scan` scheduler sends `tth` events.
+
+| Field          | Details                                                     | Example       |
+| -------------- | ----------------------------------------------------------- | ------------- |
+| `name`         | The type of scheduler which performed the update            | `"SpeedScan"` |
+| `instance`     | The status name of scan instance which performed the update |  `"New York"` |
+| `tth_found`    | The completion status of the TTH scan                       |      `0.9965` |
+| `spawns_found` | The number of spawns found in this update                   |           `5` |
+
+### `captcha`
+
+A `captcha` event is sent whenever a scan worker encounters a captcha.
+
+Note: at present it is not possible to disable `captcha` events: they will be sent regardless of your `wh-types` settings.
+
+| Field         | Details                                                   | Example           |
+| ------------- | --------------------------------------------------------- | ----------------- |
+| `status_name` | The status name of the account which received the captcha |      '"New York"` |
+| `account`     | The name of the account that received the captcha         | `"silverwind268"` |
+| `status`      | The captchas status<sup>1</sup>                           |       `"success"` |
+| `captcha`     | The number of captchas that the account has received      |               `1` |
+| `time`        | The time taken to resolve the captcha                     |              `11` |
+| `mode`        | The captcha solving method, either `manual` or `2captcha` |      `"2captcha"` |
+
+1. Possible captcha statuses:
+
+| Status        | Description                                |
+| ------------- | ------------------------------------------ |
+| `"encounter"` | A captcha has been detected                |
+| `"success"`   | The captcha has been solved                |
+| `"failure"`   | The captcha has not been solved            |
+| `"error"`     | An error occured while solving the captcha |
 
 ## PokeAlarm
 
-PokeAlarm is an example of a script you can run to accept webhook data and send it elsewhere. In PokeAlarm's usage it is publishing that information on Facebook, Twitter, Discord, etc. 
+[PokeAlarm](https://github.com/RocketMap/PokeAlarm) is an application which can be used to send alerts for various events.
 
-[Learn More Here](https://github.com/RocketMap/PokeAlarm)
+PokeAlarm receives data from RocketMap through webhooks, processes and filters the data, and can then send event-specific alerts through messaging services such as Twitter and Discord.
 
+A full list of the events PokeAlarm can provide alerts for, as well as the messaging services that can be used, can be found in the [PokeAlarm wiki](https://github.com/RocketMap/PokeAlarm/wiki).
 
-## Webhook Data
+## RocketMap Public Webhook
 
-The POST request made by RocketMap will contain the following data for pokemon type webhooks:
-
-```json
-{
-   "message":{
-      "disappear_time":1493734519,
-      "form":null,
-      "seconds_until_despawn":1748,
-      "spawnpoint_id":"0d24fec01e7",
-      "cp_multiplier":null,
-      "move_2":null,
-      "height":null,
-      "time_until_hidden_ms":915847883,
-      "last_modified_time":1493732771124,
-      "cp":null,
-      "encounter_id":"AzMxMjYyNjhWeDI4ODgwNjI1Mg==",
-      "spawn_end":919,
-      "move_1":null,
-      "individual_defense":null,
-      "verified":true,
-      "weight":null,
-      "pokemon_id":187,
-      "player_level":6,
-      "individual_stamina":null,
-      "longitude":0,
-      "spawn_start":0,
-      "pokemon_level":null,
-      "gender":null,
-      "latitude":0,
-      "individual_attack":null
-   },
-   "type":"pokemon"
-}
-```
+RocketMap is collecting data for an upcoming project. If you would like to help our efforts please fill out [this form](https://goo.gl/forms/ZCx6mQNngr0bAvRY2). You will then receive an email with a webhook url which you can add to your list of webhooks.

--- a/docs/extras/webhooks.md
+++ b/docs/extras/webhooks.md
@@ -4,6 +4,32 @@ RocketMap can send map information such as Pokémon spawns, gym details, raid ap
 
 Every time a webhook-enabled event occurs (for example a new Pokémon appearing) a web request will be sent to a provided URL containing information about that event.
 
+## Table of Contents
+
+- [What Do Webhooks Do?](#what-do-webhooks-do)
+- [Setting Up a Webhook](#setting-up-a-webhook)
+  - [Setting webhook urls](#setting-webhook-urls)
+    - [Using the command line](#using-the-command-line)
+    - [Using a config file](#using-a-config-file)
+  - [Setting webhook types](#setting-webhook-types)
+    - [Using the command line](#using-the-command-line)
+    - [Using a config file](#using-a-config-file)
+  - [Filtering Pokémon](#filtering-pokemon)
+    - [Whitelisting Pokémon](#whitelisting-pokemon)
+    - [Blacklisting Pokémon](#blacklisting-pokemon)
+- [Webhook Types](#webhook-types)
+  - [`pokemon`](#pokemon)
+  - [`pokestop`](#pokestop)
+  - [`lure`](#lure)
+  - [`gym`](#gym)
+  - [`gym-info`](#gym-info)
+  - [`egg`](#egg)
+  - [`raid`](#raid)
+  - [`tth`](#tth)
+  - [`captcha`](#captcha)
+- [PokeAlarm](#pokealarm)
+- [RocketMap Public Webhook](#rocketmap-public-webhook)
+
 ## What Do Webhooks Do?
 
 Webhooks allow developers to send data from RocketMap to other applications.
@@ -174,9 +200,11 @@ For example:
 ]
 ```
 
-The sections below outline the different webhook types and the data that gets sent for each event. Please note that as RocketMap evolves more webhook types may be added.
+RocketMap currently provides the following webhook types: [`pokemon`](#pokemon), [`pokestop`](#pokestop), [`lure`](#lure), [`gym`](#gym), [`gym-info`](#gym-info), [`egg`](#egg), [`raid`](#raid), [`tth`](#tth), [`captcha`](#captcha). Please note that as RocketMap evolves more webhook types may be added.
 
 If you are a developer please feel free to contribute new webhook types through the usual [RocketMap development process](https://github.com/RocketMap/RocketMap/blob/develop/CONTRIBUTING.md#contributing-code).
+
+The sections below outline the different webhook types and the data that gets sent for each event.
 
 ### `pokemon`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the documentation for webhooks.

## Motivation and Context
The current documentation for webhooks doesn't include a great deal of detail, and in some cases is months out-of date (e.g. the references to `gym_defeated` and `gym_conquered` events).

Resolves #2203.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation update