### PR TITLE
Fix score calculation when distance is 0

### DIFF
--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -974,7 +974,7 @@ class SpeedScan(HexSearch):
 
                 # For spawns, score is purely based on how close they are to
                 # last worker position
-                score = score / (meters + 10)
+                score = score / (meters + 10.0)
 
                 if score > best.get('score', 0):
                     best = {'score': score, 'i': i,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Forces score calculation to be done in float mode

## Motivation and Context
Score will be done in int mode when distance is 0 (maybe distance can also return ints in other cases) that leads to a score of 0 if the point is not a band or tth and as 0 is not greater than 0 next will never return the same position as the worker is.
This in general is an bug but if you use -bh with speed it will lead to nothing to scan (maybe jitter hides the issue).
Found working on #2273 as it does set all distances to 0 during startaup but I think it deserves an stand alone PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runing in main instance

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
