### PR TITLE
Disable CTRL + Zoom, allow normal pinch gestures in map.js

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -133,6 +133,7 @@ function initMap() { // eslint-disable-line no-unused-vars
             lng: Number(getParameterByName('lon')) || centerLng
         },
         zoom: Number(getParameterByName('zoom')) || Store.get('zoomLevel'),
+        gestureHandling: 'greedy',
         fullscreenControl: true,
         streetViewControl: false,
         mapTypeControl: false,


### PR DESCRIPTION
setting gesteureHandling to 'greedy' should allow users to always be able to pinch, zoom, and scroll in the normally expected ways on both PC and mobile.

Documentation: https://developers.google.com/maps/documentation/javascript/interaction#gestureHandling


## Description
set gesteureHandling to 'greedy' 
## Motivation and Context
A more natural feel navigating the map

## How Has This Been Tested?
Working locally for me, simpler, less nagging

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
