### PR TITLE
Add proxy usage option, take 2

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -22,7 +22,7 @@
                     [-nr] [-nk] [-ss [SPAWNPOINT_SCANNING]] [-speed] [-spin]
                     [-ams ACCOUNT_MAX_SPINS] [-kph KPH] [-hkph HLVL_KPH]
                     [-ldur LURE_DURATION] [--dump-spawnpoints]
-                    [-pd PURGE_DATA] [-px PROXY] [-pxsc]
+                    [-pd PURGE_DATA] [-px PROXY] [-pxsc] [-pxu PROXY_USAGE]
                     [-pxt PROXY_TEST_TIMEOUT] [-pxre PROXY_TEST_RETRIES]
                     [-pxbf PROXY_TEST_BACKOFF_FACTOR]
                     [-pxc PROXY_TEST_CONCURRENCY] [-pxd PROXY_DISPLAY]
@@ -57,7 +57,7 @@
     ConfigArgParse documentation. If an arg is specified in more than one place,
     then commandline values override environment variables which override config
     file values which override defaults.
-    
+
     optional arguments:
       -h, --help            show this help message and exit [env var:
                             POGOMAP_HELP]
@@ -285,6 +285,9 @@
       -pxsc, --proxy-skip-check
                             Disable checking of proxies before start. [env var:
                             POGOMAP_PROXY_SKIP_CHECK]
+      -pxu PROXY_USAGE, --proxy-usage PROXY_USAGE
+                            Select which connections use proxy: ptc, niantic
+                            or all.  [env var: POGOMAP_PROXY_USAGE]
       -pxt PROXY_TEST_TIMEOUT, --proxy-test-timeout PROXY_TEST_TIMEOUT
                             Timeout settings for proxy checker in seconds. [env
                             var: POGOMAP_PROXY_TEST_TIMEOUT]
@@ -413,4 +416,3 @@
                             logs. [env var: POGOMAP_NO_FILE_LOGS]
       --log-path LOG_PATH   Defines directory to save log files to. [env var:
                             POGOMAP_LOG_PATH]
-    

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -41,7 +41,7 @@ def setup_api(args, status, account):
         api = PGoApiWrapper(PGoApi(device_info=device_info))
 
     # New account - new proxy.
-    if args.proxy:
+    if args.proxy and args.proxy_usage != 'ptc':
         # If proxy is not assigned yet or if proxy-rotation is defined
         # - query for new proxy.
         if ((not status['proxy_url']) or
@@ -60,16 +60,16 @@ def setup_api(args, status, account):
             'https': status['proxy_url']})
         if (status['proxy_url'] not in args.proxy):
             log.warning(
-                'Tried replacing proxy %s with a new proxy, but proxy ' +
-                'rotation is disabled ("none"). If this isn\'t intentional, ' +
-                'enable proxy rotation.',
+                'Tried replacing session proxy %s with a new proxy, but ' +
+                'proxy rotation is disabled ("none"). If this isn\'t ' +
+                'intentional, enable proxy rotation.',
                 status['proxy_url'])
 
     return api
 
 
 # Use API to check the login status, and retry the login if possible.
-def check_login(args, account, api, proxy_url):
+def check_login(args, account, api):
     # Logged in? Enough time left? Cool!
     if api._auth_provider and api._auth_provider._ticket_expire:
         remaining_time = api._auth_provider._ticket_expire / 1000 - time.time()
@@ -86,7 +86,21 @@ def check_login(args, account, api, proxy_url):
     # One initial try + login_retries.
     while num_tries < (args.login_retries + 1):
         try:
-            if proxy_url:
+            if args.proxy and args.proxy_usage != 'niantic':
+                # If we still dont have any auth proxy configured or
+                # proxy rotation set, we change the proxy
+                if (not api._auth_provider or
+                        api._auth_provider and args.proxy_rotation != 'none'):
+                    proxy_idx, proxy_url = get_new_proxy(args)
+                elif api._auth_provider:
+                    proxy_url = api._auth_provider._session.proxies['http']
+                    if proxy_url not in args.proxy:
+                        log.warning(
+                            'Tried replacing auth proxy %s with a new ' +
+                            'proxy, but proxy rotation is disabled ' +
+                            '("none". If this isn\'t intentional, enable ' +
+                            'proxy rotation.',
+                            proxy_url)
                 api.set_authentication(
                     provider=account['auth_service'],
                     username=account['username'],

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -44,8 +44,7 @@ def setup_api(args, status, account):
     if args.proxy and args.proxy_usage != 'ptc':
         # If proxy is not assigned yet or if proxy-rotation is defined
         # - query for new proxy.
-        if ((not status['proxy_url']) or
-                (args.proxy_rotation != 'none')):
+        if not status['proxy_url'] or args.proxy_rotation != 'none':
 
             proxy_num, status['proxy_url'] = get_new_proxy(args)
             if args.proxy_display.upper() != 'FULL':
@@ -88,17 +87,16 @@ def check_login(args, account, api):
         try:
             if args.proxy and args.proxy_usage != 'niantic':
                 # If we still dont have any auth proxy configured or
-                # proxy rotation set, we change the proxy
-                if (not api._auth_provider or
-                        api._auth_provider and args.proxy_rotation != 'none'):
+                # proxy rotation is set, we change the proxy
+                if not api._auth_provider or args.proxy_rotation != 'none':
                     proxy_idx, proxy_url = get_new_proxy(args)
                 elif api._auth_provider:
                     proxy_url = api._auth_provider._session.proxies['http']
                     if proxy_url not in args.proxy:
                         log.warning(
                             'Tried replacing auth proxy %s with a new ' +
-                            'proxy, but proxy rotation is disabled ' +
-                            '("none". If this isn\'t intentional, enable ' +
+                            'proxy, but proxy rotation is disabled  ' +
+                            '("none"). If this isn\'t intentional, enable ' +
                             'proxy rotation.',
                             proxy_url)
                 api.set_authentication(

--- a/pogom/captcha.py
+++ b/pogom/captcha.py
@@ -123,7 +123,7 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
         api.activate_hash_server(hash_key)
 
     proxy_url = False
-    if args.proxy:
+    if args.proxy and args.proxy_usage != 'ptc':
         # Try to fetch a new proxy
         proxy_num, proxy_url = get_new_proxy(args)
 
@@ -138,7 +138,7 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
         location = jitter_location(location)
 
     api.set_position(*location)
-    check_login(args, account, api, proxy_url)
+    check_login(args, account, api)
 
     wh_message = {'status_name': args.status_name,
                   'status': 'error',

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2386,13 +2386,10 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
 
         # If the already existent API is using a proxy but
         # it's not alive anymore, we need to get a new proxy.
-        elif (args.proxy and
+        elif (args.proxy and args.proxy_usage != 'ptc' and
               (hlvl_api._session.proxies['http'] not in args.proxy)):
             proxy_idx, proxy_new = get_new_proxy(args)
             hlvl_api.set_proxy({
-                'http': proxy_new,
-                'https': proxy_new})
-            hlvl_api._auth_provider.set_proxy({
                 'http': proxy_new,
                 'https': proxy_new})
 
@@ -2411,7 +2408,7 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
         hlvl_api.set_position(*scan_location)
 
         # Log in.
-        check_login(args, hlvl_account, hlvl_api, status['proxy_url'])
+        check_login(args, hlvl_account, hlvl_api)
         encounter_level = hlvl_account['level']
 
         # User error -> we skip freeing the account.

--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -92,7 +92,8 @@ class PGoRequestWrapper:
             # the proxy worked. The variable "rotate_proxy" may seem
             # unnecessary, but it's here for readability and avoiding problems
             # in the future.
-            if rotate_proxy and self.args.proxy:
+            if (rotate_proxy and self.args.proxy and
+                    self.args.proxy_usage != 'ptc'):
                 proxy_idx, proxy_url = get_new_proxy(get_args())
 
                 if proxy_url:
@@ -103,7 +104,6 @@ class PGoRequestWrapper:
                     }
                     parent = self.request.__parent__
                     parent.set_proxy(proxy_config)
-                    parent._auth_provider.set_proxy(proxy_config)
 
         # If we've reached here, we have no retries left and an exception
         # still occurred.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -851,7 +851,8 @@ def search_worker_thread(args, account_queue, account_sets,
                 # If used proxy disappears from "live list" after background
                 # checking - switch account but do not freeze it (it's not an
                 # account failure).
-                if args.proxy and status['proxy_url'] not in args.proxy:
+                if (args.proxy and args.proxy_usage != 'ptc' and
+                        status['proxy_url'] not in args.proxy):
                     status['message'] = (
                         'Account {} proxy {} is not in a live list any ' +
                         'more. Switching accounts...').format(
@@ -932,7 +933,7 @@ def search_worker_thread(args, account_queue, account_sets,
 
                 # Ok, let's get started -- check our login status.
                 status['message'] = 'Logging in...'
-                check_login(args, account, api, status['proxy_url'])
+                check_login(args, account, api)
 
                 # Only run this when it's the account's first login, after
                 # check_login().
@@ -1252,7 +1253,7 @@ def get_api_version(args):
     """
     proxies = {}
 
-    if args.proxy:
+    if args.proxy and args.proxy_usage != 'ptc':
         num, proxy = get_new_proxy(args)
         proxies = {
             'http': proxy,

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -333,6 +333,10 @@ def get_args():
     parser.add_argument('-px', '--proxy',
                         help='Proxy url (e.g. socks5://127.0.0.1:9050)',
                         action='append')
+    parser.add_argument('-pxu', '--proxy-usage',
+                        help=('Select which connections use proxy ' +
+                              '(all/ptc/niantic).'),
+                        type=str, default='all')
     parser.add_argument('-pxsc', '--proxy-skip-check',
                         help='Disable checking of proxies before start.',
                         action='store_true', default=False)


### PR DESCRIPTION
## Description
With this PR we can choose if we want to use the proxies for all connecions, only for ptc login or only for niantic connections

## Motivation and Context
We can use proxies only for ptc login or for niantic sessions if we have an IP banned for one of them, not both.

## How Has This Been Tested?
Local map

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
