### PR TITLE
Replace --disable-clean with --enable-clean.

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -333,7 +333,7 @@
                             var: POGOMAP_WEBHOOK]
       -gi, --gym-info       Get all details about gyms (causes an additional API
                             hit for every gym). [env var: POGOMAP_GYM_INFO]
-      -DC, --enable-clean   Enable DB cleaner. [env var: POGOMAP_DISABLE_CLEAN]
+      -DC, --enable-clean   Enable DB cleaner. [env var: POGOMAP_ENABLE_CLEAN]
       --wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure}
                             Defines the type of messages to send to webhooks. [env
                             var: POGOMAP_WH_TYPES]

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -33,7 +33,7 @@
                     [--db-port DB_PORT]
                     [--db-max_connections DB_MAX_CONNECTIONS]
                     [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi]
-                    [--disable-clean]
+                    [--enable-clean]
                     [--wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure}]
                     [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
                     [-whr WH_RETRIES] [-wht WH_TIMEOUT]
@@ -333,8 +333,7 @@
                             var: POGOMAP_WEBHOOK]
       -gi, --gym-info       Get all details about gyms (causes an additional API
                             hit for every gym). [env var: POGOMAP_GYM_INFO]
-      --disable-clean       Disable clean db loop. [env var:
-                            POGOMAP_DISABLE_CLEAN]
+      -DC, --enable-clean   Enable DB cleaner. [env var: POGOMAP_DISABLE_CLEAN]
       --wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure}
                             Defines the type of messages to send to webhooks. [env
                             var: POGOMAP_WH_TYPES]

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -389,7 +389,7 @@ def get_args():
                         help=('Get all details about gyms (causes an ' +
                               'additional API hit for every gym).'),
                         action='store_true', default=False)
-    parser.add_argument('--disable-clean', help='Disable clean db loop.',
+    parser.add_argument('-DC', '--enable-clean', help='Enable DB cleaner.',
                         action='store_true', default=False)
     parser.add_argument(
         '--wh-types',

--- a/runserver.py
+++ b/runserver.py
@@ -309,7 +309,7 @@ def main():
         t.start()
 
     # db cleaner; really only need one ever.
-    if not args.disable_clean:
+    if args.enable_clean:
         t = Thread(target=clean_db_loop, name='db-cleaner', args=(args,))
         t.daemon = True
         t.start()


### PR DESCRIPTION
## Description
Reverse the behavior for the config item of the background database cleaner.

## Motivation and Context
The DB cleaner should only be enabled on one instance, which fits better with `-DC, --enable-clean`. Too many people skipped `--disable-clean`, enabling the DB cleaner on all their instances and inevitably running into MySQL deadlocks.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
