### PR TITLE
Handle Flask's broken pipe error.

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -91,7 +91,8 @@ def install_thread_excepthook():
         except:
             exc_type, exc_value, exc_trace = sys.exc_info()
 
-            # Handle Flask's broken pipe when a client prematurely ends the connection.
+            # Handle Flask's broken pipe when a client prematurely ends
+            # the connection.
             if exc_value == '[Errno 32] Broken pipe':
                 pass
             else:

--- a/runserver.py
+++ b/runserver.py
@@ -93,7 +93,7 @@ def install_thread_excepthook():
 
             # Handle Flask's broken pipe when a client prematurely ends
             # the connection.
-            if exc_value == '[Errno 32] Broken pipe':
+            if str(exc_value) == '[Errno 32] Broken pipe':
                 pass
             else:
                 log.critical('Unhandled patched exception (%s): "%s".',

--- a/runserver.py
+++ b/runserver.py
@@ -90,9 +90,14 @@ def install_thread_excepthook():
             raise
         except:
             exc_type, exc_value, exc_trace = sys.exc_info()
-            log.critical('Unhandled patched exception (%s): "%s".',
-                         exc_type, exc_value)
-            sys.excepthook(exc_type, exc_value, exc_trace)
+
+            # Handle Flask's broken pipe when a client prematurely ends the connection.
+            if exc_value == '[Errno 32] Broken pipe':
+                pass
+            else:
+                log.critical('Unhandled patched exception (%s): "%s".',
+                             exc_type, exc_value)
+                sys.excepthook(exc_type, exc_value, exc_trace)
     Thread.run = run
 
 


### PR DESCRIPTION
## Description
Hide Flask broken pipe exceptions (clients prematurely ending a connection).

Fixes #2277.

## Motivation and Context
Broken pipe = client prematurely ended the connection. It's not an exception that the host can do anything about, so to avoid confusion we're hiding it.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
