### PR TITLE
0.75.0

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -468,7 +468,7 @@ def get_args():
                         help=('Enables the use of X-FORWARDED-FOR headers ' +
                               'to identify the IP of clients connecting ' +
                               'through these trusted proxies.'))
-    parser.add_argument('--api-version', default='0.69.1',
+    parser.add_argument('--api-version', default='0.75.0',
                         help=('API version currently in use.'))
     verbose = parser.add_mutually_exclusive_group()
     verbose.add_argument('-v',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/sebastienvercammen/pgoapi.git@e8bb81e780bc6c245ab0de43426b2643962e8c61#egg=pgoapi
+git+https://github.com/sebastienvercammen/pgoapi.git@54d0ed4bf2b1d784865160cd5010a6a4b548e345#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
pgoapi update.

**Warning:** Field UK27 from 0.73.1 is still missing. Even before 0.73.1 and UK27 a single login request was guaranteed to get accounts flagged, so the current situation is still not a good one.