### PR TITLE
Improve handling of webhook errors.

### DIFF
--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -180,13 +180,16 @@ def wh_updater(args, queue, key_caches):
 
 # Helpers
 
-# Background handler for complete webhook futures.
+# Background handler for completed webhook futures.
 def __wh_future_completed(future):
     # Handle any exceptions that might've occurred.
     try:
-        future.exception(timeout=0)
+        exc = future.exception(timeout=0)
+
+        if exc:
+            log.exception("Something's wrong with your webhook: %s.", exc)
     except Exception as ex:
-        log.exception("Something's wrong with your webhook: %s.", ex)
+        log.exception('Unexpected exception in exception info: %s.', ex)
 
 
 # Background handler for completed webhook requests from requests lib.

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -4,9 +4,12 @@
 import logging
 import requests
 import threading
+
 from queue import Empty
 from cachetools import LFUCache
 from timeit import default_timer
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 from .utils import get_async_requests_session
 
 log = logging.getLogger(__name__)
@@ -17,7 +20,7 @@ wh_lock = threading.Lock()
 def send_to_webhooks(args, session, message_frame):
     if not args.webhooks:
         # What are you even doing here...
-        log.warning('Called send_to_webhook() without webhooks.')
+        log.critical('Called send_to_webhook() without webhooks.')
         return
 
     req_timeout = args.wh_timeout
@@ -26,15 +29,16 @@ def send_to_webhooks(args, session, message_frame):
         try:
             # Disable keep-alive and set streaming to True, so we can skip
             # the response content.
-            session.post(w, json=message_frame,
-                         timeout=(None, req_timeout),
-                         background_callback=__wh_completed,
-                         headers={'Connection': 'close'},
-                         stream=True)
+            future = session.post(w, json=message_frame,
+                                  timeout=(None, req_timeout),
+                                  background_callback=__wh_request_completed,
+                                  headers={'Connection': 'close'},
+                                  stream=True)
+            future.add_done_callback(__wh_future_completed)
         except requests.exceptions.ReadTimeout:
             log.exception('Response timeout on webhook endpoint %s.', w)
         except requests.exceptions.RequestException as e:
-            log.exception(e)
+            log.exception('Request exception on webhook: %s.', e)
 
 
 def wh_updater(args, queue, key_caches):
@@ -176,8 +180,18 @@ def wh_updater(args, queue, key_caches):
 
 
 # Helpers
-# Background handler for completed webhook requests.
-def __wh_completed(sess, resp):
+
+# Background handler for complete webhook futures.
+def __wh_future_completed(future):
+    # Handle any exceptions that might've occurred.
+    try:
+        future.exception(timeout=0)
+    except Exception as ex:
+        log.exception("Something's wrong with your webhook: %s.", ex)
+
+
+# Background handler for completed webhook requests from requests lib.
+def __wh_request_completed(sess, resp):
     # Instantly close the response to release the connection back to the pool.
     resp.close()
 

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -8,7 +8,6 @@ import threading
 from queue import Empty
 from cachetools import LFUCache
 from timeit import default_timer
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .utils import get_async_requests_session
 

--- a/runserver.py
+++ b/runserver.py
@@ -8,6 +8,7 @@ import time
 import re
 import ssl
 import json
+import requests
 
 from distutils.version import StrictVersion
 
@@ -481,6 +482,10 @@ def set_log_and_verbosity(log):
     logging.getLogger('pgoapi.rpc_api').setLevel(logging.INFO)
     logging.getLogger('werkzeug').setLevel(logging.ERROR)
     logging.getLogger('pogom.apiRequests').setLevel(logging.INFO)
+
+    # This sneaky one calls log.warning() on every retry.
+    urllib3_logger = logging.getLogger(requests.packages.urllib3.__package__)
+    urllib3_logger.setLevel(logging.ERROR)
 
     # Turn these back up if debugging.
     if args.verbose >= 2:

--- a/runserver.py
+++ b/runserver.py
@@ -492,6 +492,7 @@ def set_log_and_verbosity(log):
         logging.getLogger('pgoapi').setLevel(logging.DEBUG)
         logging.getLogger('pgoapi.pgoapi').setLevel(logging.DEBUG)
         logging.getLogger('requests').setLevel(logging.DEBUG)
+        urllib3_logger.setLevel(logging.INFO)
 
     if args.verbose >= 3:
         logging.getLogger('peewee').setLevel(logging.DEBUG)


### PR DESCRIPTION
## Description
* Changed one error from "warning" to "critical".
* Changed urllib3's default log level from `INFO` to `ERROR` to hide all the "Retry" exceptions. `-v >= 2` will re-enable `INFO`.
* Added callback when a future completes so we can properly handle any exception caught by the future executor.

**While testing,** please make sure that retries aren't logged and that final exceptions (e.g. webhook server is down, retries have been exhausted, ...) are properly logged as exceptions.

## Motivation and Context
Fixes #2279.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
