### PR TITLE
Don't use toastr when notifications are blocked.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1909,9 +1909,9 @@ function sendNotification(title, text, icon, lat, lon) {
     /* Push.js requests the Notification permission automatically if
      * necessary. */
     Push.create(title, notificationDetails).catch(function () {
-        /* Push.js doesn't fall back automatically if the user denies the
-         * Notifications permission. */
-        sendToastrPokemonNotification(title, text, icon, lat, lon)
+        /* Don't do anything if the user denies the Notifications
+         * permission, it means they don't want notifications. Push.js
+         * will fall back to toastr if Notifications are not supported. */
     })
 }
 


### PR DESCRIPTION
## Description
When a client denies Notifications permission, we shouldn't show any notifications at all. We should assume the user intentionally blocked them so they wouldn't see any notifications at all.

toastr fallback is still enabled for browsers that don't support the Notifications API.

## Motivation and Context
By popular demand.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
