### PR TITLE
Webserver blacklist via request fingerprint.

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -19,7 +19,7 @@ from .models import (Pokemon, Gym, Pokestop, ScannedLocation,
                      MainWorker, WorkerStatus, Token, HashKeys,
                      SpawnPoint)
 from .utils import now, dottedQuadToNum
-from .blacklist import fingerprints, get_blacklist
+from .blacklist import fingerprints, get_ip_blacklist
 log = logging.getLogger(__name__)
 compress = Compress()
 
@@ -35,7 +35,7 @@ class Pogom(Flask):
         # Global blist
         if not args.disable_blacklist:
             log.info('Retrieving blacklist...')
-            self.blacklist = get_blacklist()
+            self.blacklist = get_ip_blacklist()
             # Sort & index for binary search
             self.blacklist.sort(key=lambda r: r[0])
             self.blacklist_keys = [

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -23,21 +23,24 @@ def get_ip_blacklist():
 # argument and return True when a blacklisted fingerprint
 # matches.
 
-# jQuery includes Origin.
-def no_origin(request):
-    return 'Origin' not in request.headers
-
 
 # No referrer = request w/o being on a website.
-def no_referrer(request):
+def _no_referrer(request):
     return not request.referrer
 
 
 # iPokeGo.
-def iPokeGo(request):
+def _iPokeGo(request):
     user_agent = request.headers.get('User-Agent', False)
 
     if not user_agent:
         return False
 
     return 'ipokego' in user_agent.lower()
+
+
+# Fingerprints dict for easy scoping on imports.
+fingerprints = {
+    'no_referrer': _no_referrer,
+    'iPokeGo': _iPokeGo
+}

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 # Global IP blacklist.
-def get_blacklist():
+def get_ip_blacklist():
     try:
         url = 'https://blist.devkat.org/blacklist.json'
         blacklist = requests.get(url, timeout=5).json()

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -1,6 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import logging
+import requests
+
+log = logging.getLogger(__name__)
+
 
 # Global IP blacklist.
 def get_blacklist():

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -23,17 +23,17 @@ def get_ip_blacklist():
 # argument.
 
 # jQuery includes Origin.
-def _no_origin(request):
+def no_origin(request):
     return 'Origin' not in request.headers
 
 
 # No referrer = request w/o being on a website.
-def _no_referrer(request):
+def no_referrer(request):
     return not request.referrer
 
 
 # iPokeGo.
-def _iPokeGo(request):
+def iPokeGo(request):
     user_agent = request.headers.get('User-Agent', False)
 
     if not user_agent:
@@ -42,11 +42,11 @@ def _iPokeGo(request):
     return 'ipokego' in user_agent.lower()
 
 
-# Prepare blacklisted fingerprints. A list of functions that
+# Prepare blacklisted fingerprints. A dict of functions that
 # return True when the fingerprint matches. The function
-# receives Flask's request object as argument.
-fingerprints = [
-    _no_referrer,
-    _no_origin,
-    _iPokeGo
-]
+# should receive Flask's request object as argument.
+fingerprints = {
+    'no_origin': no_origin,
+    'no_referrer': no_referrer,
+    'iPokeGo': iPokeGo
+}

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -20,7 +20,8 @@ def get_ip_blacklist():
 
 
 # Fingerprinting methods. They receive Flask's request object as
-# argument.
+# argument and return True when a blacklisted fingerprint
+# matches.
 
 # jQuery includes Origin.
 def no_origin(request):
@@ -40,13 +41,3 @@ def iPokeGo(request):
         return False
 
     return 'ipokego' in user_agent.lower()
-
-
-# Prepare blacklisted fingerprints. A dict of functions that
-# return True when the fingerprint matches. The function
-# should receive Flask's request object as argument.
-fingerprints = {
-    'no_origin': no_origin,
-    'no_referrer': no_referrer,
-    'iPokeGo': iPokeGo
-}

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -22,6 +22,11 @@ def get_blacklist():
 # Fingerprinting methods. They receive Flask's request object as
 # argument.
 
+# jQuery includes Origin.
+def _no_origin(request):
+    return 'Origin' not in request.headers
+
+
 # No referrer = request w/o being on a website.
 def _no_referrer(request):
     return not request.referrer
@@ -29,10 +34,12 @@ def _no_referrer(request):
 
 # iPokeGo.
 def _iPokeGo(request):
-    if not request.referrer:
+    user_agent = request.headers.get('User-Agent', False)
+
+    if not user_agent:
         return False
 
-    return 'ipokego' in request.referrer.lower()
+    return 'ipokego' in user_agent.lower()
 
 
 # Prepare blacklisted fingerprints. A list of functions that
@@ -40,5 +47,6 @@ def _iPokeGo(request):
 # receives Flask's request object as argument.
 fingerprints = [
     _no_referrer,
+    _no_origin,
     _iPokeGo
 ]

--- a/pogom/blacklist.py
+++ b/pogom/blacklist.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+# Global IP blacklist.
+def get_blacklist():
+    try:
+        url = 'https://blist.devkat.org/blacklist.json'
+        blacklist = requests.get(url, timeout=5).json()
+        log.debug('Entries in blacklist: %s.', len(blacklist))
+        return blacklist
+    except (requests.exceptions.RequestException, IndexError, KeyError):
+        log.error('Unable to retrieve blacklist, setting to empty.')
+        return []
+
+
+# Fingerprinting methods. They receive Flask's request object as
+# argument.
+
+# No referrer = request w/o being on a website.
+def _no_referrer(request):
+    return not request.referrer
+
+
+# iPokeGo.
+def _iPokeGo(request):
+    if not request.referrer:
+        return False
+
+    return 'ipokego' in request.referrer.lower()
+
+
+# Prepare blacklisted fingerprints. A list of functions that
+# return True when the fingerprint matches. The function
+# receives Flask's request object as argument.
+fingerprints = [
+    _no_referrer,
+    _iPokeGo
+]

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -896,17 +896,6 @@ def dottedQuadToNum(ip):
     return struct.unpack("!L", socket.inet_aton(ip))[0]
 
 
-def get_blacklist():
-    try:
-        url = 'https://blist.devkat.org/blacklist.json'
-        blacklist = requests.get(url, timeout=5).json()
-        log.debug('Entries in blacklist: %s.', len(blacklist))
-        return blacklist
-    except (requests.exceptions.RequestException, IndexError, KeyError):
-        log.error('Unable to retrieve blacklist, setting to empty.')
-        return []
-
-
 # Generate random device info.
 # Original by Noctem.
 IPHONES = {'iPhone5,1': 'N41AP',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -10,7 +10,6 @@ import random
 import time
 import socket
 import struct
-import requests
 import hashlib
 import psutil
 


### PR DESCRIPTION
## Description
Block incoming requests based on their request fingerprint.

## Motivation and Context
* Block invalid requests, e.g. requests not coming from any website (= direct access) or requests from disapproved 3rd party projects.
* Per RM community policy, 3rd party projects using RM-hosted websites need to have an explicit opt-in from the server owner. Preferably they also contact us via our Discord (https://discord.gg/rocketmap) to get official support, but this isn't required. `iPokeGo` does not work via opt-in and has no opt-out.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
