### PR TITLE
Don't allow -ns and -os to be used together

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -487,11 +487,6 @@ def get_args():
 
     args = parser.parse_args()
 
-    if args.only_server and args.no_server:
-        print("Error: You can't use no-server and only-server at the same "
-              "time, silly.")
-        sys.exit(1)
-
     if args.only_server:
         if args.location is None:
             parser.print_usage()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -487,6 +487,11 @@ def get_args():
 
     args = parser.parse_args()
 
+    if (args.only_server and args.no_server):
+        print("Error: You can't use no-server and only-server at the same "
+              "time silly.")
+        sys.exit(1)
+
     if args.only_server:
         if args.location is None:
             parser.print_usage()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -487,7 +487,7 @@ def get_args():
 
     args = parser.parse_args()
 
-    if (args.only_server and args.no_server):
+    if args.only_server and args.no_server:
         print("Error: You can't use no-server and only-server at the same "
               "time, silly.")
         sys.exit(1)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -489,7 +489,7 @@ def get_args():
 
     if (args.only_server and args.no_server):
         print("Error: You can't use no-server and only-server at the same "
-              "time silly.")
+              "time, silly.")
         sys.exit(1)
 
     if args.only_server:

--- a/runserver.py
+++ b/runserver.py
@@ -203,6 +203,13 @@ def main():
 
     args = get_args()
 
+    # Abort if only-server and no-server are used together
+
+    if args.only_server and args.no_server:
+        log.critical(
+            "You can't use no-server and only-server at the same time, silly.")
+        sys.exit(1)
+
     # Abort if status name is not valid.
     regexp = re.compile('^([\w\s\-.]+)$')
     if not regexp.match(args.status_name):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a user forgets `only-server` in their config and launches with -ns (or vice versa)
there's an Uncaught exception:
```
2017-09-29 22:30:18,938 [        MainThread][     runserver][   ERROR] Uncaught exception
Traceback (most recent call last):
  File "runserver.py", line 505, in <module>
    main()
  File "runserver.py", line 415, in main
    while search_thread.is_alive():
UnboundLocalError: local variable 'search_thread' referenced before assignment
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Pebcak makes console unhappy and users confused.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local test build in linux 14.04, Python 2.7.6.
launched with `-ns -os`
Tried `only-server` in config and `-ns` in console 
Tried `-os` & `-ns` alone to check that it still launches. 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
