### PR TITLE
Add --dump: dump censored debug info to hastebin.

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -45,8 +45,8 @@
                     [-vci VERSION_CHECK_INTERVAL] [-el ENCRYPT_LIB]
                     [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
                     [-tp TRUSTED_PROXIES] [--api-version API_VERSION]
-                    [-v | --verbosity VERBOSE] [--no-file-logs]
-                    [--log-path LOG_PATH]
+                    [--no-file-logs] [--log-path LOG_PATH] [--needful]
+                    [-v | --verbosity VERBOSE]
 
     Args that start with '--' (eg. -a) can also be set in a config file
     (/config/config.ini or
@@ -400,11 +400,13 @@
       --api-version API_VERSION
                             API version currently in use. [env var:
                             POGOMAP_API_VERSION]
-      -v                    Show debug messages from RocketMap and pgoapi. Can be
-                            repeated up to 3 times.
-      --verbosity VERBOSE   Show debug messages from RocketMap and pgoapi. [env
-                            var: POGOMAP_VERBOSITY]
       --no-file-logs        Disable logging to files. Does not disable --access-
                             logs. [env var: POGOMAP_NO_FILE_LOGS]
       --log-path LOG_PATH   Defines directory to save log files to. [env var:
                             POGOMAP_LOG_PATH]
+      --needful             Dump censored debug info about the environment and
+                            auto-upload to hasteb.in. [env var: POGOMAP_NEEDFUL]
+      -v                    Show debug messages from RocketMap and pgoapi. Can be
+                            repeated up to 3 times.
+      --verbosity VERBOSE   Show debug messages from RocketMap and pgoapi. [env
+                            var: POGOMAP_VERBOSITY]

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -45,7 +45,7 @@
                     [-vci VERSION_CHECK_INTERVAL] [-el ENCRYPT_LIB]
                     [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
                     [-tp TRUSTED_PROXIES] [--api-version API_VERSION]
-                    [--no-file-logs] [--log-path LOG_PATH] [--needful]
+                    [--no-file-logs] [--log-path LOG_PATH] [--dump]
                     [-v | --verbosity VERBOSE]
 
     Args that start with '--' (eg. -a) can also be set in a config file
@@ -404,9 +404,8 @@
                             logs. [env var: POGOMAP_NO_FILE_LOGS]
       --log-path LOG_PATH   Defines directory to save log files to. [env var:
                             POGOMAP_LOG_PATH]
-      --needful             Dump censored debug info about the environment and
-                            auto-upload to hastebin.com. [env var:
-                            POGOMAP_NEEDFUL]
+      --dump                Dump censored debug info about the environment and
+                            auto-upload to hastebin.com. [env var: POGOMAP_DUMP]
       -v                    Show debug messages from RocketMap and pgoapi. Can be
                             repeated up to 3 times.
       --verbosity VERBOSE   Show debug messages from RocketMap and pgoapi. [env

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -405,7 +405,8 @@
       --log-path LOG_PATH   Defines directory to save log files to. [env var:
                             POGOMAP_LOG_PATH]
       --needful             Dump censored debug info about the environment and
-                            auto-upload to hasteb.in. [env var: POGOMAP_NEEDFUL]
+                            auto-upload to hastebin.com. [env var:
+                            POGOMAP_NEEDFUL]
       -v                    Show debug messages from RocketMap and pgoapi. Can be
                             repeated up to 3 times.
       --verbosity VERBOSE   Show debug messages from RocketMap and pgoapi. [env

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -479,7 +479,7 @@ def get_args():
     parser.add_argument('--log-path',
                         help=('Defines directory to save log files to.'),
                         default='logs/')
-    parser.add_argument('--needful',
+    parser.add_argument('--dump',
                         help=('Dump censored debug info about the ' +
                               'environment and auto-upload to ' +
                               'hastebin.com.'),
@@ -1246,7 +1246,7 @@ def upload_to_hastebin(text):
 
 
 # Get censored debug info & auto-upload to hasteb.in.
-def get_needful_link():
+def get_debug_dump_link():
     debug = get_censored_debug_info()
     args = debug['args']
     git = debug['git']

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1153,7 +1153,6 @@ def get_censored_debug_info():
     CENSORED_TAG = '<censored>'
 
     # Remove or replace sensitive information in args.
-    
     if args.accounts:
         args.accounts = len(args.accounts)
     if args.username:
@@ -1170,8 +1169,8 @@ def get_censored_debug_info():
         args.webhook_blacklist = len(args.webhook_blacklist)
     if args.webhook_whitelist:
         args.webhook_whitelist = len(args.webhook_whitelist)
-    
-    # Files paths.
+
+    # Filepaths.
     args.config = CENSORED_TAG
     args.accountcsv = CENSORED_TAG
     args.high_lvl_accounts = CENSORED_TAG

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -482,7 +482,7 @@ def get_args():
     parser.add_argument('--needful',
                         help=('Dump censored debug info about the ' +
                               'environment and auto-upload to ' +
-                              'hasteb.in.'),
+                              'hastebin.com.'),
                         action='store_true', default=False)
     verbose = parser.add_mutually_exclusive_group()
     verbose.add_argument('-v',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1164,7 +1164,7 @@ def get_censored_debug_info():
     if args.proxy:
         args.proxy = len(args.proxy)
     if args.webhooks:
-        args.webhooks = len(args.webhook)
+        args.webhooks = len(args.webhooks)
     if args.webhook_blacklist:
         args.webhook_blacklist = len(args.webhook_blacklist)
     if args.webhook_whitelist:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ sphinx==1.4.5
 sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
-requests==2.18.4
+requests[security]==2.18.4
 requests-futures==0.9.7
 PySocks==1.5.6
 git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ sphinx==1.4.5
 sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
-requests==2.13.0
+requests==2.18.4
 requests-futures==0.9.7
 PySocks==1.5.6
 git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust

--- a/runserver.py
+++ b/runserver.py
@@ -19,7 +19,7 @@ from flask_cache_bust import init_cache_busting
 
 from pogom.app import Pogom
 from pogom.utils import (get_args, now, gmaps_reverse_geolocate,
-                         log_resource_usage_loop, get_needful_link)
+                         log_resource_usage_loop, get_debug_dump_link)
 from pogom.altitude import get_gmaps_altitude
 
 from pogom.models import (init_database, create_tables, drop_tables,
@@ -219,9 +219,9 @@ def main():
         sys.exit(1)
 
     # Stop if we're just looking for a debug dump.
-    if args.needful:
+    if args.dump:
         log.info('Retrieving environment info...')
-        hastebin = get_needful_link()
+        hastebin = get_debug_dump_link()
         log.info('Done! Your debug link: https://hastebin.com/%s.txt',
                  hastebin)
         sys.exit(1)

--- a/runserver.py
+++ b/runserver.py
@@ -222,7 +222,8 @@ def main():
     if args.needful:
         log.info('Retrieving environment info...')
         hastebin = get_needful_link()
-        log.info('Done! Your debug link: https://hastebin.com/%s.txt', hastebin)
+        log.info('Done! Your debug link: https://hastebin.com/%s.txt',
+                 hastebin)
         sys.exit(1)
 
     # Let's not forget to run Grunt / Only needed when running with webserver.

--- a/runserver.py
+++ b/runserver.py
@@ -19,7 +19,7 @@ from flask_cache_bust import init_cache_busting
 
 from pogom.app import Pogom
 from pogom.utils import (get_args, now, gmaps_reverse_geolocate,
-                         log_resource_usage_loop)
+                         log_resource_usage_loop, get_needful_link)
 from pogom.altitude import get_gmaps_altitude
 
 from pogom.models import (init_database, create_tables, drop_tables,
@@ -204,8 +204,9 @@ def main():
 
     args = get_args()
 
-    # Abort if only-server and no-server are used together
+    set_log_and_verbosity(log)
 
+    # Abort if only-server and no-server are used together
     if args.only_server and args.no_server:
         log.critical(
             "You can't use no-server and only-server at the same time, silly.")
@@ -217,7 +218,12 @@ def main():
         log.critical('Status name contains illegal characters.')
         sys.exit(1)
 
-    set_log_and_verbosity(log)
+    # Stop if we're just looking for a debug dump.
+    if args.needful:
+        log.info('Retrieving environment info...')
+        hastebin = get_needful_link()
+        log.info('Done! Your debug link: https://hastebin.com/%s.txt', hastebin)
+        sys.exit(1)
 
     # Let's not forget to run Grunt / Only needed when running with webserver.
     if not args.no_server and not validate_assets(args):


### PR DESCRIPTION
## Description
* New feature: `--dump`: dump debug info about the environment (e.g. censored config files, number of accounts (individual count for usernames & count for passwords)). Includes info about git, node, npm, python, pip. Auto-uploads to https://hastebin.com.
* I also took the opportunity to upgrade `requests` from 2.13 to 2.18.4.
* I've replaced `requests` with `requests[security]`, which includes some extras related to SSL and `urllib3`. **This fixes a lot of SSL errors for people running certain setups/distros, but comes with the added Linux requirements of `sudo apt-get install build-essential python-dev libssl-dev libffi-dev`.**

## Motivation and Context
Easy debugging in #help.

## How Has This Been Tested?
Local instance.
```
$ python runserver.py --dump
2017-09-30 16:15:08,059 [        MainThread][     runserver][    INFO] Retrieving environment info...
2017-09-30 16:15:09,990 [        MainThread][         utils][    INFO] Uploading info to hastebin.com...
2017-09-30 16:15:10,272 [        MainThread][     runserver][    INFO] Done! Your debug link: https://hastebin.com/lezuvupebi.txt
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
