### PR TITLE
Fix stats order.

### DIFF
--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -67,7 +67,7 @@ function processSeen(seen) {
                                 ${pokemonItem.pokemon_name}
                             </a>
                         </td>
-                        <td class="status_cell">
+                        <td class="status_cell" data-sort="${pokemonItem.count}">
                             ${pokemonItem.count.toLocaleString()}
                         </td>
                         <td class="status_cell">

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -53,6 +53,7 @@ function processSeen(seen) {
 
     for (var i = 0; i < seen.pokemon.length; i++) {
         var pokemonItem = seen.pokemon[i]
+        var seenPercent = (pokemonItem.count / seen.total) * 100
 
         $('#stats_table > tbody')
             .append(`<tr class="status_row">
@@ -70,8 +71,8 @@ function processSeen(seen) {
                         <td class="status_cell" data-sort="${pokemonItem.count}">
                             ${pokemonItem.count.toLocaleString()}
                         </td>
-                        <td class="status_cell">
-                            ${(pokemonItem.count / seen.total * 100).toFixed(4)}
+                        <td class="status_cell" data-sort="${seenPercent}">
+                            ${seenPercent.toLocaleString(undefined, {minimumFractionDigits: 4, maximumFractionDigits: 4})}
                         </td>
                         <td class="status_cell">
                             ${moment(pokemonItem.disappear_time).format('H:mm:ss D MMM YYYY')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a `data-sort` attribute to the `Seen` column on the stats page.

## Motivation and Context
Some (mostly european) locales use `,` (commas) as thousands-delimiters and `.` (periods) as decimal-delimiters. DataTables does not handle this correctly so an unformatted number is now provided for sorting purposes.

Fixes #2326.

## How Has This Been Tested?
Small local map.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
