### PR TITLE
Fix UnboundLocalError: cleanup/referencing of response_dict.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1007,7 +1007,7 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                     parsed = parse_map(args, response_dict, step_location,
                                        dbq, whq, key_scheduler, api, status,
                                        scan_date, account, account_sets)
-                    del response_dict
+
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1
@@ -1034,6 +1034,7 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                                                            account['username'])
                     log.exception('{}. Exception message: {}'.format(
                         status['message'], repr(e)))
+                finally:
                     if response_dict is not None:
                         del response_dict
 


### PR DESCRIPTION
## Description
When you `del` an object, its definition is also removed, so trying to reference it again later with `if response_dict is not None:` will result in an UnboundLocalError.

Removed the double `del response_dict` and moved one to a `finally:` block to make sure it's cleaned up.

## Motivation and Context
Fixes #2330.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
