### PR TITLE
[In progress] Optimize L30 account selection

### DIFF
--- a/pogom/account.py
+++ b/pogom/account.py
@@ -723,8 +723,6 @@ class AccountSet(object):
                         best_distance = distance_m
                         best_account = account
 
-                continue
-
             if best_account:
                 account = best_account
             elif empty_account:

--- a/pogom/account.py
+++ b/pogom/account.py
@@ -685,6 +685,11 @@ class AccountSet(object):
             # Loop all accounts for a good one.
             now = default_timer()
 
+            # We set a big default distance value to get the best one
+            empty_account = False
+            best_account = False
+            best_distance = 1000000
+
             for i in range(len(account_set)):
                 account = account_set[i]
 
@@ -699,25 +704,40 @@ class AccountSet(object):
                 # Check if we're below speed limit for account.
                 last_scanned = account.get('last_scanned', False)
 
-                if last_scanned:
+                # If account has never been used we save it in case we don't
+                # have another account available
+                if not last_scanned:
+                    if not empty_account:
+                        empty_account = account
+                    continue
+
+                else:
                     seconds_passed = now - last_scanned
                     old_coords = account.get('last_coords', coords_to_scan)
-
                     distance_m = distance(old_coords, coords_to_scan)
                     cooldown_time_sec = distance_m / self.kph * 3.6
 
-                    # Not enough time has passed for this one.
-                    if seconds_passed < cooldown_time_sec:
-                        continue
+                    # Closer account? Great!
+                    if (seconds_passed >= cooldown_time_sec and
+                            distance_m < best_distance):
+                        best_distance = distance_m
+                        best_account = account
 
-                # We've found an account that's ready.
-                account['last_scanned'] = now
-                account['last_coords'] = coords_to_scan
-                account['in_use'] = True
+                continue
 
-                return account
+            if best_account:
+                account = best_account
+            elif empty_account:
+                account = empty_account
+            else:
+                # TODO: Instead of returning False, return the amount of min.
+                # seconds the instance needs to wait until the first account
+                # becomes available, so it doesn't need to keep asking if we
+                # know we need to wait.
+                return False
 
-        # TODO: Instead of returning False, return the amount of min. seconds
-        # the instance needs to wait until the first account becomes available,
-        # so it doesn't need to keep asking if we know we need to wait.
-        return False
+            account['last_scanned'] = now
+            account['last_coords'] = coords_to_scan
+            account['in_use'] = True
+
+            return account


### PR DESCRIPTION
## Description
**[In progress]** Using this PR uses more L30 accounts than default account selection.

With this PR we improve the seleccion of level 30 accounts, not picking just the first one but the closest one within range. Combining this PR with #2336 improves greatly the amount of encounters that you can have with the same amount of accounts.

## Motivation and Context
The change potentially optimizes the usage of level 30 accounts.

## How Has This Been Tested?
Local testing map.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
