### PR TITLE
Take into account jittered location for almost everything

### DIFF
--- a/pogom/apiRequests.py
+++ b/pogom/apiRequests.py
@@ -6,8 +6,6 @@ import logging
 from pgoapi.utilities import f2i, get_cell_ids
 from pgoapi.hash_server import BadHashRequestException, HashingOfflineException
 
-from .transform import jitter_location
-
 log = logging.getLogger(__name__)
 
 
@@ -237,24 +235,13 @@ def level_up_rewards(api, account):
 
 
 @catchRequestException('downloading map')
-def get_map_objects(api, account, position, no_jitter=False):
-    # Create scan_location to send to the api based off of position
-    # because tuples aren't mutable.
-    if no_jitter:
-        # Just use the original coordinates.
-        scan_location = position
-    else:
-        # Jitter it, just a little bit.
-        scan_location = jitter_location(position)
-        log.debug('Jittered to: %f/%f/%f', scan_location[0], scan_location[1],
-                  scan_location[2])
-
-    cell_ids = get_cell_ids(scan_location[0], scan_location[1])
+def get_map_objects(api, account, location):
+    cell_ids = get_cell_ids(location[0], location[1])
     timestamps = [0, ]*len(cell_ids)
     req = api.create_request()
     req.get_map_objects(
-        latitude=f2i(scan_location[0]),
-        longitude=f2i(scan_location[1]),
+        latitude=f2i(location[0]),
+        longitude=f2i(location[1]),
         since_timestamp_ms=timestamps,
         cell_id=cell_ids)
     return send_generic_request(req, account)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1845,8 +1845,9 @@ def hex_bounds(center, steps=None, radius=None):
 
 
 # todo: this probably shouldn't _really_ be in "models" anymore, but w/e.
-def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
-              key_scheduler, api, status, now_date, account, account_sets):
+def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
+              wh_update_queue, key_scheduler, api, status, now_date, account,
+              account_sets):
     pokemon = {}
     pokestops = {}
     gyms = {}
@@ -1912,10 +1913,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             log.warning('No nearby or wild Pokemon but there are visible '
                         'gyms or pokestops. Possible speed violation.')
 
-    scan_loc = ScannedLocation.get_by_loc(step_location)
-    done_already = scan_loc['done']
-    ScannedLocation.update_band(scan_loc, now_date)
-    just_completed = not done_already and scan_loc['done']
+    done_already = scan_location['done']
+    ScannedLocation.update_band(scan_location, now_date)
+    just_completed = not done_already and scan_location['done']
 
     if wild_pokemon and not args.no_pokemon:
         encounter_ids = [b64encode(str(p.encounter_id))
@@ -1971,9 +1971,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     sp['latest_seen'] = d_t_secs
                     sp['earliest_unseen'] = d_t_secs
 
-            scan_spawn_points[scan_loc['cellid'] + sp['id']] = {
+            scan_spawn_points[scan_location['cellid'] + sp['id']] = {
                 'spawnpoint': sp['id'],
-                'scannedlocation': scan_loc['cellid']}
+                'scannedlocation': scan_location['cellid']}
             if not sp['last_scanned']:
                 log.info('New Spawn Point found.')
                 new_spawn_points.append(sp)
@@ -1981,16 +1981,16 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 # If we found a new spawnpoint after the location was already
                 # fully scanned then either it's new, or we had a bad scan.
                 # Either way, rescan the location.
-                if scan_loc['done'] and not just_completed:
+                if scan_location['done'] and not just_completed:
                     log.warning('Location was fully scanned, and yet a brand '
                                 'new spawnpoint found.')
                     log.warning('Redoing scan of this location to identify '
                                 'new spawnpoint.')
-                    ScannedLocation.reset_bands(scan_loc)
+                    ScannedLocation.reset_bands(scan_location)
 
             if (not SpawnPoint.tth_found(sp) or sighting['tth_secs'] or
-                    not scan_loc['done'] or just_completed):
-                SpawnpointDetectionData.classify(sp, scan_loc, now_secs,
+                    not scan_location['done'] or just_completed):
+                SpawnpointDetectionData.classify(sp, scan_location, now_secs,
                                                  sighting)
                 sightings[p.encounter_id] = sighting
 
@@ -2258,8 +2258,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         if args.pokestop_spinning:
             for f in forts:
                 # Spin Pokestop with 50% chance.
-                if f.type == 1 and pokestop_spinnable(f, step_location):
-                    spin_pokestop(api, account, args, f, step_location)
+                if f.type == 1 and pokestop_spinnable(f, scan_coords):
+                    spin_pokestop(api, account, args, f, scan_coords)
 
         # Helping out the GC.
         del forts
@@ -2277,7 +2277,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
 
     # Look for spawnpoints within scan_loc that are not here to see if we
     # can narrow down tth window.
-    for sp in ScannedLocation.linked_spawn_points(scan_loc['cellid']):
+    for sp in ScannedLocation.linked_spawn_points(scan_location['cellid']):
         if sp['id'] in sp_id_list:
             # Don't overwrite changes from this parse with DB version.
             sp = spawn_points[sp['id']]
@@ -2285,7 +2285,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             # If the cell has completed, we need to classify all
             # the SPs that were not picked up in the scan
             if just_completed:
-                SpawnpointDetectionData.classify(sp, scan_loc, now_secs)
+                SpawnpointDetectionData.classify(sp, scan_location, now_secs)
                 spawn_points[sp['id']] = sp
             if SpawnpointDetectionData.unseen(sp, now_secs):
                 spawn_points[sp['id']] = sp
@@ -2301,7 +2301,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 log.info('hidden period, or Niantic has removed '
                          'spawnpoint.')
 
-        if (not SpawnPoint.tth_found(sp) and scan_loc['done'] and
+        if (not SpawnPoint.tth_found(sp) and scan_location['done'] and
                 (now_secs - sp['latest_seen'] -
                  args.spawn_delay) % 3600 < 60):
             log.warning('Spawnpoint %s was unable to locate a TTH, with '
@@ -2309,13 +2309,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         (now_secs - sp['latest_seen']) % 3600)
             log.info('Restarting current 15 minute search for TTH.')
             if sp['id'] not in sp_id_list:
-                SpawnpointDetectionData.classify(sp, scan_loc, now_secs)
+                SpawnpointDetectionData.classify(sp, scan_location, now_secs)
             sp['latest_seen'] = (sp['latest_seen'] - 60) % 3600
             sp['earliest_unseen'] = (
                 sp['earliest_unseen'] + 14 * 60) % 3600
             spawn_points[sp['id']] = sp
 
-    db_update_queue.put((ScannedLocation, {0: scan_loc}))
+    db_update_queue.put((ScannedLocation, {0: scan_location}))
 
     if pokemon:
         db_update_queue.put((Pokemon, pokemon))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move the jitter code the the search thread sadly a new param was needed to pass the ScannedLocation to parsemap, as otherwise it will get a wrong one.

## Motivation and Context
Currently jittered location was only used for the request, but it was not being used for distance calcs, waits, speed checks, etc.
This PR solves that except for the wait that comes from the scheduler as it does not know the jitter yet and I don't see moving the jitter to the scheduler.

Also made some changes to var names, scan_location is a ScannedLocation object and scan_coords are the location coords of the scan (step location or step + jitter), still it is not very clear as scan_location can be interpreted as both things if you don't take care, but couldn't find a better name for it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local instance

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
