### PR TITLE
More robust object checking for raid in JS.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -612,10 +612,10 @@ function isValidRaid(raid) {
 }
 
 function isGymSatisfiesRaidMinMaxFilter(raid) {
-    if (raid === null) {
-        return 0
-    } else {
+    if (raid) {
         return (raid['level'] <= Store.get('showRaidMaxLevel') && raid['level'] >= Store.get('showRaidMinLevel')) ? 1 : 0
+    } else {
+        return 0
     }
 }
 
@@ -927,11 +927,7 @@ function getGymLevel(gym) {
 }
 
 function getRaidLevel(raid) {
-    if (raid === null) {
-        return 0
-    } else {
-        return raid['level']
-    }
+    return raid['level'] || 0
 }
 
 function lpad(str, len, padstr) {


### PR DESCRIPTION
## Description
More robust checking for the raid object. This didn't cause a problem because we send `null` specifically via Python's Flask, but moving on to future releases or alternative webservers we might want to omit the `raid` field entirely if there is none on the gym.

## Motivation and Context
Checking for `null` misses `undefined`.

## How Has This Been Tested?
Local server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
