### PR TITLE
[On Hold] Default icon generation tool.

### DIFF
--- a/Tools/Icon-Generation/README.md
+++ b/Tools/Icon-Generation/README.md
@@ -8,20 +8,34 @@ To use this tool you need:
 * Pillow - a python image library (a replacement for PIL)
 * The Arial Bold truetype font
 
-To install pillow run `pip install pillow`.
+To install pillow run `pip install --upgrade -r requirements.txt`.
 
-Installation of the Arial Bold font varies by platform. In Windows, it will typically be available by default. For linux systems, you may need to install the package `ttf-mscorefonts-installer` (or the equivallent package for your platform).
+Installation of the Arial Bold font varies by platform:
+
+### Windows
+
+Arial Bold is typically available by default.
+
+### Mac
+
+Arial Bold is typically available by default.
+
+### Linux
+
+You may need to install the package `ttf-mscorefonts-installer` (or the equivalent package for your platform) and accept the Microsoft EULA.
+
+e.g. `sudo apt-get install ttf-mscorefonts-installer`
 
 ## Usage
 
 To generate the standard 94x94 icons and save them to the `static/icons/` directory, run:
 
-`generate_icons.py`
+python `generate_icons.py`
 
 To set a different output location, set the `-o` parameter:
 
-`generate_icons.py -o OUTPUT_DIR`
+python `generate_icons.py -o OUTPUT_DIR`
 
 To generate icons of a different size, set the `-s` parameter:
 
-`generate_icons.py -s SIZE`
+python `generate_icons.py -s SIZE`

--- a/Tools/Icon-Generation/README.md
+++ b/Tools/Icon-Generation/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-This is a tool for generating RocketMap's base Pokémon icons.
+This is a tool to generate RocketMap's base Pokémon icons.
 
 ## Install
 

--- a/Tools/Icon-Generation/README.md
+++ b/Tools/Icon-Generation/README.md
@@ -1,0 +1,27 @@
+## Description
+
+This is a tool for generating RocketMap's base Pokémon icons.
+
+## Install
+
+To use this tool you need:
+* Pillow - a python image library (a replacement for PIL)
+* The Arial Bold truetype font
+
+To install pillow run `pip install pillow`.
+
+Installation of the Arial Bold font varies by platform. In Windows, it will typically be available by default. For linux systems, you may need to install the package `ttf-mscorefonts-installer` (or the equivallent package for your platform).
+
+## Usage
+
+To generate the standard 94x94 icons and save them to the `static/icons/` directory, run:
+
+`generate_icons.py`
+
+To set a different output location, set the `-o` parameter:
+
+`generate_icons.py -o OUTPUT_DIR`
+
+To generate icons of a different size, set the `-s` parameter:
+
+`generate_icons.py -s SIZE`

--- a/Tools/Icon-Generation/README.md
+++ b/Tools/Icon-Generation/README.md
@@ -8,19 +8,26 @@ To use this tool you need:
 * Pillow - a python image library (a replacement for PIL)
 * The Arial Bold truetype font
 
-To install pillow run `pip install --upgrade -r requirements.txt`.
+### Pillow
 
-Installation of the Arial Bold font varies by platform:
+Depending on your platform, you may need to install some dependencies first. Scripts which install the required dependencies (for some platforms) can be found at https://github.com/python-pillow/Pillow/tree/master/depends.
 
-### Windows
+Note: some platforms automatically install the required dependencies for you through pip. If you can't find an install script for your platform, it may be because it is not necessary for you to install the dependencies manually.
+
+Once you have the necessary dependencies installed, install pillow by running the command:
+`pip install --upgrade -r requirements.txt`.
+
+### Arial Bold
+
+#### Windows
 
 Arial Bold is typically available by default.
 
-### Mac
+#### OSX
 
 Arial Bold is typically available by default.
 
-### Linux
+#### Linux
 
 You may need to install the package `ttf-mscorefonts-installer` (or the equivalent package for your platform) and accept the Microsoft EULA.
 

--- a/Tools/Icon-Generation/generate_icons.py
+++ b/Tools/Icon-Generation/generate_icons.py
@@ -27,19 +27,22 @@ def create_icon(id, form=None, size=(94, 94), base_size=(300, 300),
     if form:
         font = FONTS['arial_bold_100']
         id_size = draw.textsize(id, font=font)
+        id_offset = font.getoffset(id)
         form_size = draw.textsize(form, font=font)
+        form_offset = font.getoffset(form)
         half_height = base_size[1] / 2.0
         draw.text(((base_size[0] - id_size[0]) / 2.0,
-                   (half_height - id_size[1] - 2)),
+                   (half_height - id_size[1] - (id_offset[1] / 2) - 2)),
                   id, text_color, font=font)
         draw.text(((base_size[0] - form_size[0]) / 2.0,
-                   (half_height + 2)),
+                   (half_height - (form_offset[1] / 2) + 2)),
                   form, text_color, font=font)
     else:
         font = FONTS['arial_bold_130']
         id_size = draw.textsize(id, font=font)
+        id_offset = font.getoffset(id)
         draw.text(((base_size[0] - id_size[0]) / 2.0,
-                   (base_size[1] - id_size[1]) / 2.0),
+                   (base_size[1] - id_size[1] - id_offset[1]) / 2.0),
                   id, text_color, font=font)
 
     if size != base_size:

--- a/Tools/Icon-Generation/generate_icons.py
+++ b/Tools/Icon-Generation/generate_icons.py
@@ -3,7 +3,6 @@ import os
 from argparse import ArgumentParser
 from json import load as load_json
 
-import PIL
 from PIL import Image
 from PIL import ImageDraw
 from PIL import ImageFont
@@ -20,7 +19,7 @@ def create_icon(id, form=None, size=(94, 94), base_size=(94, 94),
     id = str(id) if id else id
     form = str(form) if form else form
 
-    icon = PIL.Image.new('RGBA', (base_size[0], base_size[1]))
+    icon = Image.new('RGBA', (base_size[0], base_size[1]))
     draw = ImageDraw.Draw(icon)
 
     draw.ellipse((0, 0, base_size[0], base_size[1]), fill=background_color)

--- a/Tools/Icon-Generation/generate_icons.py
+++ b/Tools/Icon-Generation/generate_icons.py
@@ -49,6 +49,13 @@ def create_icon(id, form=None, size=(94, 94), base_size=(94, 94),
     return icon
 
 
+def form_to_filename(form):
+    if isinstance(form, tuple):
+        return form[1]
+    else:
+        return form.lower()
+
+
 if __name__ == "__main__":
     static_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           '..', '..', 'static')
@@ -75,7 +82,7 @@ if __name__ == "__main__":
     pokemon_forms = {
         201: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
               'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-              ('!', 'EXCL'), ('?', 'QUES')],
+              ('!', 'excl'), ('?', 'ques')],
         351: ['NML', 'SUN', 'RN', 'SNW'],
         386: ['NML', 'ATK', 'DEF', 'SPE']
     }
@@ -83,9 +90,8 @@ if __name__ == "__main__":
     for id, forms in pokemon_forms.iteritems():
         color = pokemon_data[str(id)]['types'][0]['color']
         for form in forms:
-            form_sym = form[0] if isinstance(form, tuple) else form
-            form_name = form[1] if isinstance(form, tuple) else form
-            icon = create_icon(id, form_sym, size=(args.size, args.size),
+            form_symbol = form[1] if isinstance(form, tuple) else form
+            icon = create_icon(id, form_symbol, size=(args.size, args.size),
                                background_color=color)
-            icon.save(os.path.join(
-                      args.output_dir, '{}-{}.png'.format(id, form_name)))
+            filename = '{}-{}.png'.format(id, form_to_filename(form))
+            icon.save(os.path.join(args.output_dir, filename))

--- a/Tools/Icon-Generation/generate_icons.py
+++ b/Tools/Icon-Generation/generate_icons.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     for id, forms in pokemon_forms.iteritems():
         color = pokemon_data[str(id)]['types'][0]['color']
         for form in forms:
-            form_symbol = form[1] if isinstance(form, tuple) else form
+            form_symbol = form[0] if isinstance(form, tuple) else form
             icon = create_icon(id, form_symbol, size=(args.size, args.size),
                                background_color=color)
             filename = '{}-{}.png'.format(id, form_to_filename(form))

--- a/Tools/Icon-Generation/generate_icons.py
+++ b/Tools/Icon-Generation/generate_icons.py
@@ -1,0 +1,91 @@
+import os
+
+from argparse import ArgumentParser
+from json import load as load_json
+
+import PIL
+from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageFont
+
+
+FONTS = {
+    'arial_bold_32': ImageFont.truetype('arialbd.ttf', 32),
+    'arial_bold_44': ImageFont.truetype('arialbd.ttf', 44)
+}
+
+
+def create_icon(id, form=None, size=(94, 94), base_size=(94, 94),
+                background_color='#000000', text_color='#FFFFFF'):
+    id = str(id) if id else id
+    form = str(form) if form else form
+
+    icon = PIL.Image.new('RGBA', (base_size[0], base_size[1]))
+    draw = ImageDraw.Draw(icon)
+
+    draw.ellipse((0, 0, base_size[0], base_size[1]), fill=background_color)
+
+    if form:
+        font = FONTS['arial_bold_32']
+        id_size = draw.textsize(id, font=font)
+        form_size = draw.textsize(form, font=font)
+        half_height = base_size[1] / 2.0
+        draw.text(((base_size[0] - id_size[0]) / 2.0,
+                   (half_height - id_size[1] - 2)),
+                  id, text_color, font=font)
+        draw.text(((base_size[0] - form_size[0]) / 2.0,
+                   (half_height + 2)),
+                  form, text_color, font=font)
+    else:
+        font = FONTS['arial_bold_44']
+        id_size = draw.textsize(id, font=font)
+        draw.text(((base_size[0] - id_size[0]) / 2.0,
+                   (base_size[1] - id_size[1]) / 2.0),
+                  id, text_color, font=font)
+
+    if size != base_size:
+        icon = icon.resize(size, Image.ANTIALIAS)
+
+    return icon
+
+
+if __name__ == "__main__":
+    static_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          '..', '..', 'static')
+
+    parser = ArgumentParser(description='Generate default icons.')
+    parser.add_argument('-o', '--output-dir',
+                        help='The directory to save the icons to.',
+                        default=os.path.join(static_dir, 'icons'))
+    parser.add_argument('-s', '--size', help='The size of the icons.',
+                        type=int, default=94)
+
+    args = parser.parse_args()
+
+    pokemon_data = {}
+    with open(os.path.join(static_dir, 'data', 'pokemon.json'), 'r') as f:
+        pokemon_data = load_json(f)
+
+    for id in range(1, 387):
+        color = pokemon_data[str(id)]['types'][0]['color']
+        icon = create_icon(id, size=(args.size, args.size),
+                           background_color=color)
+        icon.save(os.path.join(args.output_dir, '{}.png'.format(id)))
+
+    pokemon_forms = {
+        201: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+              'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+              ('!', 'EXCL'), ('?', 'QUES')],
+        351: ['NML', 'SUN', 'RN', 'SNW'],
+        386: ['NML', 'ATK', 'DEF', 'SPE']
+    }
+
+    for id, forms in pokemon_forms.iteritems():
+        color = pokemon_data[str(id)]['types'][0]['color']
+        for form in forms:
+            form_sym = form[0] if isinstance(form, tuple) else form
+            form_name = form[1] if isinstance(form, tuple) else form
+            icon = create_icon(id, form_sym, size=(args.size, args.size),
+                               background_color=color)
+            icon.save(os.path.join(
+                      args.output_dir, '{}-{}.png'.format(id, form_name)))

--- a/Tools/Icon-Generation/generate_icons.py
+++ b/Tools/Icon-Generation/generate_icons.py
@@ -9,12 +9,12 @@ from PIL import ImageFont
 
 
 FONTS = {
-    'arial_bold_32': ImageFont.truetype('arialbd.ttf', 32),
-    'arial_bold_44': ImageFont.truetype('arialbd.ttf', 44)
+    'arial_bold_100': ImageFont.truetype('arialbd.ttf', 100),
+    'arial_bold_130': ImageFont.truetype('arialbd.ttf', 130)
 }
 
 
-def create_icon(id, form=None, size=(94, 94), base_size=(94, 94),
+def create_icon(id, form=None, size=(94, 94), base_size=(300, 300),
                 background_color='#000000', text_color='#FFFFFF'):
     id = str(id) if id else id
     form = str(form) if form else form
@@ -25,7 +25,7 @@ def create_icon(id, form=None, size=(94, 94), base_size=(94, 94),
     draw.ellipse((0, 0, base_size[0], base_size[1]), fill=background_color)
 
     if form:
-        font = FONTS['arial_bold_32']
+        font = FONTS['arial_bold_100']
         id_size = draw.textsize(id, font=font)
         form_size = draw.textsize(form, font=font)
         half_height = base_size[1] / 2.0
@@ -36,7 +36,7 @@ def create_icon(id, form=None, size=(94, 94), base_size=(94, 94),
                    (half_height + 2)),
                   form, text_color, font=font)
     else:
-        font = FONTS['arial_bold_44']
+        font = FONTS['arial_bold_130']
         id_size = draw.textsize(id, font=font)
         draw.text(((base_size[0] - id_size[0]) / 2.0,
                    (base_size[1] - id_size[1]) / 2.0),

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb568774629
 cachetools==2.0.0
 cHaversine==0.3.0
 psutil==5.3.1
+pillow==3.1.2

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -1,6047 +1,8719 @@
 {
   "1": {
-    "name": "Bulbasaur",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "61"
+    "name": "Bulbasaur"
   },
   "2": {
-    "name": "Ivysaur",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "421"
+    "name": "Ivysaur"
   },
   "3": {
-    "name": "Venusaur",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "641"
+    "name": "Venusaur"
   },
   "4": {
-    "name": "Charmander",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "119"
+    "name": "Charmander"
   },
   "5": {
-    "name": "Charmeleon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1025"
+    "name": "Charmeleon"
   },
   "6": {
-    "name": "Charizard",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Charizard"
   },
   "7": {
-    "name": "Squirtle",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "65"
+    "name": "Squirtle"
   },
   "8": {
-    "name": "Wartortle",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "484"
+    "name": "Wartortle"
   },
   "9": {
-    "name": "Blastoise",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "843"
+    "name": "Blastoise"
   },
   "10": {
-    "name": "Caterpie",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "51"
+    "name": "Caterpie"
   },
   "11": {
-    "name": "Metapod",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "433"
+    "name": "Metapod"
   },
   "12": {
-    "name": "Butterfree",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "843"
+    "name": "Butterfree"
   },
   "13": {
-    "name": "Weedle",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "21"
+    "name": "Weedle"
   },
   "14": {
-    "name": "Kakuna",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "204"
+    "name": "Kakuna"
   },
   "15": {
-    "name": "Beedrill",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "377"
+    "name": "Beedrill"
   },
   "16": {
-    "name": "Pidgey",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "10"
+    "name": "Pidgey"
   },
   "17": {
-    "name": "Pidgeotto",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "75"
+    "name": "Pidgeotto"
   },
   "18": {
-    "name": "Pidgeot",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "203"
+    "name": "Pidgeot"
   },
   "19": {
-    "name": "Rattata",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "13"
+    "name": "Rattata"
   },
   "20": {
-    "name": "Raticate",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "159"
+    "name": "Raticate"
   },
   "21": {
-    "name": "Spearow",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "31"
+    "name": "Spearow"
   },
   "22": {
-    "name": "Fearow",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "221"
+    "name": "Fearow"
   },
   "23": {
-    "name": "Ekans",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "75"
+    "name": "Ekans"
   },
   "24": {
-    "name": "Arbok",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "544"
+    "name": "Arbok"
   },
   "25": {
-    "name": "Pikachu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "92"
+    "name": "Pikachu"
   },
   "26": {
-    "name": "Raichu",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Raichu"
   },
   "27": {
-    "name": "Sandshrew",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "163"
+    "name": "Sandshrew"
   },
   "28": {
-    "name": "Sandslash",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1619"
+    "name": "Sandslash"
   },
   "29": {
-    "name": "Nidoran♀",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Nidoran♀"
   },
   "30": {
-    "name": "Nidorina",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "504"
+    "name": "Nidorina"
   },
   "31": {
-    "name": "Nidoqueen",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1398"
+    "name": "Nidoqueen"
   },
   "32": {
-    "name": "Nidoran♂",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Nidoran♂"
   },
   "33": {
-    "name": "Nidorino",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "586"
+    "name": "Nidorino"
   },
   "34": {
-    "name": "Nidoking",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1025"
+    "name": "Nidoking"
   },
   "35": {
-    "name": "Clefairy",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "85"
+    "name": "Clefairy"
   },
   "36": {
-    "name": "Clefable",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "1309"
+    "name": "Clefable"
   },
   "37": {
-    "name": "Vulpix",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "188"
+    "name": "Vulpix"
   },
   "38": {
-    "name": "Ninetales",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1538"
+    "name": "Ninetales"
   },
   "39": {
-    "name": "Jigglypuff",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "101"
+    "name": "Jigglypuff"
   },
   "40": {
-    "name": "Wigglytuff",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Wigglytuff"
   },
   "41": {
-    "name": "Zubat",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "24"
+    "name": "Zubat"
   },
   "42": {
-    "name": "Golbat",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "209"
+    "name": "Golbat"
   },
   "43": {
-    "name": "Oddish",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "91"
+    "name": "Oddish"
   },
   "44": {
-    "name": "Gloom",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "592"
+    "name": "Gloom"
   },
   "45": {
-    "name": "Vileplume",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1864"
+    "name": "Vileplume"
   },
   "46": {
-    "name": "Paras",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "44"
+    "name": "Paras"
   },
   "47": {
-    "name": "Parasect",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "397"
+    "name": "Parasect"
   },
   "48": {
-    "name": "Venonat",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "38"
+    "name": "Venonat"
   },
   "49": {
-    "name": "Venomoth",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "300"
+    "name": "Venomoth"
   },
   "50": {
-    "name": "Diglett",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "211"
+    "name": "Diglett"
   },
   "51": {
-    "name": "Dugtrio",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1663"
+    "name": "Dugtrio"
   },
   "52": {
-    "name": "Meowth",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "106"
+    "name": "Meowth"
   },
   "53": {
-    "name": "Persian",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "1282"
+    "name": "Persian"
   },
   "54": {
-    "name": "Psyduck",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "108"
+    "name": "Psyduck"
   },
   "55": {
-    "name": "Golduck",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "707"
+    "name": "Golduck"
   },
   "56": {
-    "name": "Mankey",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "114"
+    "name": "Mankey"
   },
   "57": {
-    "name": "Primeape",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1061"
+    "name": "Primeape"
   },
   "58": {
-    "name": "Growlithe",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Growlithe"
   },
   "59": {
-    "name": "Arcanine",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "932"
+    "name": "Arcanine"
   },
   "60": {
-    "name": "Poliwag",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "95"
+    "name": "Poliwag"
   },
   "61": {
-    "name": "Poliwhirl",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "481"
+    "name": "Poliwhirl"
   },
   "62": {
-    "name": "Poliwrath",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1709"
+    "name": "Poliwrath"
   },
   "63": {
-    "name": "Abra",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "104"
+    "name": "Abra"
   },
   "64": {
-    "name": "Kadabra",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "779"
+    "name": "Kadabra"
   },
   "65": {
-    "name": "Alakazam",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "2461"
+    "name": "Alakazam"
   },
   "66": {
-    "name": "Machop",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "217"
+    "name": "Machop"
   },
   "67": {
-    "name": "Machoke",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1465"
+    "name": "Machoke"
   },
   "68": {
-    "name": "Machamp",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "3418"
+    "name": "Machamp"
   },
   "69": {
-    "name": "Bellsprout",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "86"
+    "name": "Bellsprout"
   },
   "70": {
-    "name": "Weepinbell",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "496"
+    "name": "Weepinbell"
   },
   "71": {
-    "name": "Victreebel",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Victreebel"
   },
   "72": {
-    "name": "Tentacool",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "275"
+    "name": "Tentacool"
   },
   "73": {
-    "name": "Tentacruel",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "615"
+    "name": "Tentacruel"
   },
   "74": {
-    "name": "Geodude",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "121"
+    "name": "Geodude"
   },
   "75": {
-    "name": "Graveler",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "707"
+    "name": "Graveler"
   },
   "76": {
-    "name": "Golem",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "2797"
+    "name": "Golem"
   },
   "77": {
-    "name": "Ponyta",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "121"
+    "name": "Ponyta"
   },
   "78": {
-    "name": "Rapidash",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "992"
+    "name": "Rapidash"
   },
   "79": {
-    "name": "Slowpoke",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "175"
+    "name": "Slowpoke"
   },
   "80": {
-    "name": "Slowbro",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "947"
+    "name": "Slowbro"
   },
   "81": {
-    "name": "Magnemite",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": "200"
+    "name": "Magnemite"
   },
   "82": {
-    "name": "Magneton",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Magneton"
   },
   "83": {
-    "name": "Farfetch'd",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "61527"
+    "name": "Farfetch'd"
   },
   "84": {
-    "name": "Doduo",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Doduo"
   },
   "85": {
-    "name": "Dodrio",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "634"
+    "name": "Dodrio"
   },
   "86": {
-    "name": "Seel",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "196"
+    "name": "Seel"
   },
   "87": {
-    "name": "Dewgong",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1578"
+    "name": "Dewgong"
   },
   "88": {
-    "name": "Grimer",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Grimer"
   },
   "89": {
-    "name": "Muk",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "7691"
+    "name": "Muk"
   },
   "90": {
-    "name": "Shellder",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "177"
+    "name": "Shellder"
   },
   "91": {
-    "name": "Cloyster",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1578"
+    "name": "Cloyster"
   },
   "92": {
-    "name": "Gastly",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Gastly"
   },
   "93": {
-    "name": "Haunter",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "419"
+    "name": "Haunter"
   },
   "94": {
-    "name": "Gengar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1758"
+    "name": "Gengar"
   },
   "95": {
-    "name": "Onix",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "269"
+    "name": "Onix"
   },
   "96": {
-    "name": "Drowzee",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "39"
+    "name": "Drowzee"
   },
   "97": {
-    "name": "Hypno",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "322"
+    "name": "Hypno"
   },
   "98": {
-    "name": "Krabby",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "73"
+    "name": "Krabby"
   },
   "99": {
-    "name": "Kingler",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "530"
+    "name": "Kingler"
   },
   "100": {
-    "name": "Voltorb",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "276"
+    "name": "Voltorb"
   },
   "101": {
-    "name": "Electrode",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "1985"
+    "name": "Electrode"
   },
   "102": {
-    "name": "Exeggcute",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "123"
+    "name": "Exeggcute"
   },
   "103": {
-    "name": "Exeggutor",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "1231"
+    "name": "Exeggutor"
   },
   "104": {
-    "name": "Cubone",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "163"
+    "name": "Cubone"
   },
   "105": {
-    "name": "Marowak",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1431"
+    "name": "Marowak"
   },
   "106": {
-    "name": "Hitmonlee",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "504"
+    "name": "Hitmonlee"
   },
   "107": {
-    "name": "Hitmonchan",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "446"
+    "name": "Hitmonchan"
   },
   "108": {
-    "name": "Lickitung",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "443"
+    "name": "Lickitung"
   },
   "109": {
-    "name": "Koffing",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "213"
+    "name": "Koffing"
   },
   "110": {
-    "name": "Weezing",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1398"
+    "name": "Weezing"
   },
   "111": {
-    "name": "Rhyhorn",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": "110"
+    "name": "Rhyhorn"
   },
   "112": {
-    "name": "Rhydon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": "867"
+    "name": "Rhydon"
   },
   "113": {
-    "name": "Chansey",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "1256"
+    "name": "Chansey"
   },
   "114": {
-    "name": "Tangela",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "346"
+    "name": "Tangela"
   },
   "115": {
-    "name": "Kangaskhan",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "2461"
+    "name": "Kangaskhan"
   },
   "116": {
-    "name": "Horsea",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "104"
+    "name": "Horsea"
   },
   "117": {
-    "name": "Seadra",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "760"
+    "name": "Seadra"
   },
   "118": {
-    "name": "Goldeen",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "103"
+    "name": "Goldeen"
   },
   "119": {
-    "name": "Seaking",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "684"
+    "name": "Seaking"
   },
   "120": {
-    "name": "Staryu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "97"
+    "name": "Staryu"
   },
   "121": {
-    "name": "Starmie",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "1206"
+    "name": "Starmie"
   },
   "122": {
-    "name": "Mr. Mime",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "1431"
+    "name": "Mr. Mime"
   },
   "123": {
-    "name": "Scyther",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "155"
+    "name": "Scyther"
   },
   "124": {
-    "name": "Jynx",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "152"
+    "name": "Jynx"
   },
   "125": {
-    "name": "Electabuzz",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "261"
+    "name": "Electabuzz"
   },
   "126": {
-    "name": "Magmar",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "213"
+    "name": "Magmar"
   },
   "127": {
-    "name": "Pinsir",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "99"
+    "name": "Pinsir"
   },
   "128": {
-    "name": "Tauros",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "153"
+    "name": "Tauros"
   },
   "129": {
-    "name": "Magikarp",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "79"
+    "name": "Magikarp"
   },
   "130": {
-    "name": "Gyarados",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "2279"
+    "name": "Gyarados"
   },
   "131": {
-    "name": "Lapras",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1183"
+    "name": "Lapras"
   },
   "132": {
-    "name": "Ditto",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "30764"
+    "name": "Ditto"
   },
   "133": {
-    "name": "Eevee",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "24"
+    "name": "Eevee"
   },
   "134": {
-    "name": "Vaporeon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "1465"
+    "name": "Vaporeon"
   },
   "135": {
-    "name": "Jolteon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "1309"
+    "name": "Jolteon"
   },
   "136": {
-    "name": "Flareon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1568"
+    "name": "Flareon"
   },
   "137": {
-    "name": "Porygon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "867"
+    "name": "Porygon"
   },
   "138": {
-    "name": "Omanyte",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "346"
+    "name": "Omanyte"
   },
   "139": {
-    "name": "Omastar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "6153"
+    "name": "Omastar"
   },
   "140": {
-    "name": "Kabuto",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "356"
+    "name": "Kabuto"
   },
   "141": {
-    "name": "Kabutops",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "2930"
+    "name": "Kabutops"
   },
   "142": {
-    "name": "Aerodactyl",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Aerodactyl"
   },
   "143": {
-    "name": "Snorlax",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "284"
+    "name": "Snorlax"
   },
   "144": {
-    "name": "Articuno",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Articuno"
   },
   "145": {
-    "name": "Zapdos",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Zapdos"
   },
   "146": {
-    "name": "Moltres",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Moltres"
   },
   "147": {
-    "name": "Dratini",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": "91"
+    "name": "Dratini"
   },
   "148": {
-    "name": "Dragonair",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": "699"
+    "name": "Dragonair"
   },
   "149": {
-    "name": "Dragonite",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "580"
+    "name": "Dragonite"
   },
   "150": {
-    "name": "Mewtwo",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Mewtwo"
   },
   "151": {
-    "name": "Mew",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Mew"
   },
   "152": {
-    "name": "Chikorita",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chikorita"
   },
   "153": {
-    "name": "Bayleef",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bayleef"
   },
   "154": {
-    "name": "Meganium",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Meganium"
   },
   "155": {
-    "name": "Cyndaquil",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cyndaquil"
   },
   "156": {
-    "name": "Quilava",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quilava"
   },
   "157": {
-    "name": "Typhlosion",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Typhlosion"
   },
   "158": {
-    "name": "Totodile",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Totodile"
   },
   "159": {
-    "name": "Croconaw",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Croconaw"
   },
   "160": {
-    "name": "Feraligatr",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Feraligatr"
   },
   "161": {
-    "name": "Sentret",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sentret"
   },
   "162": {
-    "name": "Furret",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Furret"
   },
   "163": {
-    "name": "Hoothoot",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hoothoot"
   },
   "164": {
-    "name": "Noctowl",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Noctowl"
   },
   "165": {
-    "name": "Ledyba",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ledyba"
   },
   "166": {
-    "name": "Ledian",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ledian"
   },
   "167": {
-    "name": "Spinarak",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spinarak"
   },
   "168": {
-    "name": "Ariados",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ariados"
   },
   "169": {
-    "name": "Crobat",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Crobat"
   },
   "170": {
-    "name": "Chinchou",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chinchou"
   },
   "171": {
-    "name": "Lanturn",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lanturn"
   },
   "172": {
-    "name": "Pichu",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pichu"
   },
   "173": {
-    "name": "Cleffa",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cleffa"
   },
   "174": {
-    "name": "Igglybuff",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Igglybuff"
   },
   "175": {
-    "name": "Togepi",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togepi"
   },
   "176": {
-    "name": "Togetic",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togetic"
   },
   "177": {
-    "name": "Natu",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Natu"
   },
   "178": {
-    "name": "Xatu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Xatu"
   },
   "179": {
-    "name": "Mareep",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mareep"
   },
   "180": {
-    "name": "Flaaffy",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Flaaffy"
   },
   "181": {
-    "name": "Ampharos",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ampharos"
   },
   "182": {
-    "name": "Bellossom",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bellossom"
   },
   "183": {
-    "name": "Marill",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Marill"
   },
   "184": {
-    "name": "Azumarill",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Azumarill"
   },
   "185": {
-    "name": "Sudowoodo",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sudowoodo"
   },
   "186": {
-    "name": "Politoed",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Politoed"
   },
   "187": {
-    "name": "Hoppip",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hoppip"
   },
   "188": {
-    "name": "Skiploom",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skiploom"
   },
   "189": {
-    "name": "Jumpluff",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Jumpluff"
   },
   "190": {
-    "name": "Aipom",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aipom"
   },
   "191": {
-    "name": "Sunkern",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sunkern"
   },
   "192": {
-    "name": "Sunflora",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sunflora"
   },
   "193": {
-    "name": "Yanma",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Yanma"
   },
   "194": {
-    "name": "Wooper",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wooper"
   },
   "195": {
-    "name": "Quagsire",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quagsire"
   },
   "196": {
-    "name": "Espeon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Espeon"
   },
   "197": {
-    "name": "Umbreon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Umbreon"
   },
   "198": {
-    "name": "Murkrow",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Murkrow"
   },
   "199": {
-    "name": "Slowking",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slowking"
   },
   "200": {
-    "name": "Misdreavus",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Misdreavus"
   },
   "201": {
-    "name": "Unown",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Unown"
   },
   "202": {
-    "name": "Wobbuffet",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wobbuffet"
   },
   "203": {
-    "name": "Girafarig",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Girafarig"
   },
   "204": {
-    "name": "Pineco",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pineco"
   },
   "205": {
-    "name": "Forretress",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Forretress"
   },
   "206": {
-    "name": "Dunsparce",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dunsparce"
   },
   "207": {
-    "name": "Gligar",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gligar"
   },
   "208": {
-    "name": "Steelix",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Steelix"
   },
   "209": {
-    "name": "Snubbull",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Snubbull"
   },
   "210": {
-    "name": "Granbull",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Granbull"
   },
   "211": {
-    "name": "Qwilfish",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Qwilfish"
   },
   "212": {
-    "name": "Scizor",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scizor"
   },
   "213": {
-    "name": "Shuckle",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shuckle"
   },
   "214": {
-    "name": "Heracross",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Heracross"
   },
   "215": {
-    "name": "Sneasel",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sneasel"
   },
   "216": {
-    "name": "Teddiursa",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Teddiursa"
   },
   "217": {
-    "name": "Ursaring",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ursaring"
   },
   "218": {
-    "name": "Slugma",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slugma"
   },
   "219": {
-    "name": "Magcargo",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magcargo"
   },
   "220": {
-    "name": "Swinub",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swinub"
   },
   "221": {
-    "name": "Piloswine",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Piloswine"
   },
   "222": {
-    "name": "Corsola",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Corsola"
   },
   "223": {
-    "name": "Remoraid",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Remoraid"
   },
   "224": {
-    "name": "Octillery",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Octillery"
   },
   "225": {
-    "name": "Delibird",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Delibird"
   },
   "226": {
-    "name": "Mantine",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mantine"
   },
   "227": {
-    "name": "Skarmory",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skarmory"
   },
   "228": {
-    "name": "Houndour",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Houndour"
   },
   "229": {
-    "name": "Houndoom",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Houndoom"
   },
   "230": {
-    "name": "Kingdra",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kingdra"
   },
   "231": {
-    "name": "Phanpy",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Phanpy"
   },
   "232": {
-    "name": "Donphan",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Donphan"
   },
   "233": {
-    "name": "Porygon2",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Porygon2"
   },
   "234": {
-    "name": "Stantler",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Stantler"
   },
   "235": {
-    "name": "Smeargle",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Smeargle"
   },
   "236": {
-    "name": "Tyrogue",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyrogue"
   },
   "237": {
-    "name": "Hitmontop",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hitmontop"
   },
   "238": {
-    "name": "Smoochum",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Smoochum"
   },
   "239": {
-    "name": "Elekid",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Elekid"
   },
   "240": {
-    "name": "Magby",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magby"
   },
   "241": {
-    "name": "Miltank",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Miltank"
   },
   "242": {
-    "name": "Blissey",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Blissey"
   },
   "243": {
-    "name": "Raikou",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Raikou"
   },
   "244": {
-    "name": "Entei",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Entei"
   },
   "245": {
-    "name": "Suicune",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Suicune"
   },
   "246": {
-    "name": "Larvitar",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Larvitar"
   },
   "247": {
-    "name": "Pupitar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pupitar"
   },
   "248": {
-    "name": "Tyranitar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyranitar"
   },
   "249": {
-    "name": "Lugia",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lugia"
   },
   "250": {
-    "name": "Ho-Oh",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ho-Oh"
   },
   "251": {
-    "name": "Celebi",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Celebi"
   },
   "252": {
-    "name": "Treecko",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Treecko"
   },
   "253": {
-    "name": "Grovyle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Grovyle"
   },
   "254": {
-    "name": "Sceptile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Sceptile"
   },
   "255": {
-    "name": "Torchic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torchic"
   },
   "256": {
-    "name": "Combusken",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Combusken"
   },
   "257": {
-    "name": "Blaziken",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Blaziken"
   },
   "258": {
-    "name": "Mudkip",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Mudkip"
   },
   "259": {
-    "name": "Marshtomp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Marshtomp"
   },
   "260": {
-    "name": "Swampert",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Swampert"
   },
   "261": {
-    "name": "Poochyena",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Poochyena"
   },
   "262": {
-    "name": "Mightyena",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Mightyena"
   },
   "263": {
-    "name": "Zigzagoon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Zigzagoon"
   },
   "264": {
-    "name": "Linoone",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Linoone"
   },
   "265": {
-    "name": "Wurmple",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Wurmple"
   },
   "266": {
-    "name": "Silcoon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Silcoon"
   },
   "267": {
-    "name": "Beautifly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Beautifly"
   },
   "268": {
-    "name": "Cascoon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Cascoon"
   },
   "269": {
-    "name": "Dustox",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Dustox"
   },
   "270": {
-    "name": "Lotad",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lotad"
   },
   "271": {
-    "name": "Lombre",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lombre"
   },
   "272": {
-    "name": "Ludicolo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Ludicolo"
   },
   "273": {
-    "name": "Seedot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Seedot"
   },
   "274": {
-    "name": "Nuzleaf",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Nuzleaf"
   },
   "275": {
-    "name": "Shiftry",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Shiftry"
   },
   "276": {
-    "name": "Taillow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Taillow"
   },
   "277": {
-    "name": "Swellow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swellow"
   },
   "278": {
-    "name": "Wingull",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Wingull"
   },
   "279": {
-    "name": "Pelipper",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pelipper"
   },
   "280": {
-    "name": "Ralts",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Ralts"
   },
   "281": {
-    "name": "Kirlia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Kirlia"
   },
   "282": {
-    "name": "Gardevoir",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Gardevoir"
   },
   "283": {
-    "name": "Surskit",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Surskit"
   },
   "284": {
-    "name": "Masquerain",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Masquerain"
   },
   "285": {
-    "name": "Shroomish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Shroomish"
   },
   "286": {
-    "name": "Breloom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Breloom"
   },
   "287": {
-    "name": "Slakoth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Slakoth"
   },
   "288": {
-    "name": "Vigoroth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Vigoroth"
   },
   "289": {
-    "name": "Slaking",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Slaking"
   },
   "290": {
-    "name": "Nincada",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Nincada"
   },
   "291": {
-    "name": "Ninjask",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Ninjask"
   },
   "292": {
-    "name": "Shedinja",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Shedinja"
   },
   "293": {
-    "name": "Whismur",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Whismur"
   },
   "294": {
-    "name": "Loudred",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Loudred"
   },
   "295": {
-    "name": "Exploud",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Exploud"
   },
   "296": {
-    "name": "Makuhita",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Makuhita"
   },
   "297": {
-    "name": "Hariyama",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Hariyama"
   },
   "298": {
-    "name": "Azurill",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Azurill"
   },
   "299": {
-    "name": "Nosepass",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Nosepass"
   },
   "300": {
-    "name": "Skitty",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Skitty"
   },
   "301": {
-    "name": "Delcatty",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Delcatty"
   },
   "302": {
-    "name": "Sableye",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Sableye"
   },
   "303": {
-    "name": "Mawile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mawile"
   },
   "304": {
-    "name": "Aron",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Aron"
   },
   "305": {
-    "name": "Lairon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Lairon"
   },
   "306": {
-    "name": "Aggron",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Aggron"
   },
   "307": {
-    "name": "Meditite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Meditite"
   },
   "308": {
-    "name": "Medicham",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Medicham"
   },
   "309": {
-    "name": "Electrike",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Electrike"
   },
   "310": {
-    "name": "Manectric",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Manectric"
   },
   "311": {
-    "name": "Plusle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Plusle"
   },
   "312": {
-    "name": "Minun",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Minun"
   },
   "313": {
-    "name": "Volbeat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Volbeat"
   },
   "314": {
-    "name": "Illumise",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Illumise"
   },
   "315": {
-    "name": "Roselia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Roselia"
   },
   "316": {
-    "name": "Gulpin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Gulpin"
   },
   "317": {
-    "name": "Swalot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Swalot"
   },
   "318": {
-    "name": "Carvanha",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Carvanha"
   },
   "319": {
-    "name": "Sharpedo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Sharpedo"
   },
   "320": {
-    "name": "Wailmer",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wailmer"
   },
   "321": {
-    "name": "Wailord",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wailord"
   },
   "322": {
-    "name": "Numel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Numel"
   },
   "323": {
-    "name": "Camerupt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Camerupt"
   },
   "324": {
-    "name": "Torkoal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torkoal"
   },
   "325": {
-    "name": "Spoink",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Spoink"
   },
   "326": {
-    "name": "Grumpig",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Grumpig"
   },
   "327": {
-    "name": "Spinda",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Spinda"
   },
   "328": {
-    "name": "Trapinch",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Trapinch"
   },
   "329": {
-    "name": "Vibrava",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Vibrava"
   },
   "330": {
-    "name": "Flygon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Flygon"
   },
   "331": {
-    "name": "Cacnea",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cacnea"
   },
   "332": {
-    "name": "Cacturne",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Cacturne"
   },
   "333": {
-    "name": "Swablu",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swablu"
   },
   "334": {
-    "name": "Altaria",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Altaria"
   },
   "335": {
-    "name": "Zangoose",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Zangoose"
   },
   "336": {
-    "name": "Seviper",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Seviper"
   },
   "337": {
-    "name": "Lunatone",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Lunatone"
   },
   "338": {
-    "name": "Solrock",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Solrock"
   },
   "339": {
-    "name": "Barboach",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Barboach"
   },
   "340": {
-    "name": "Whiscash",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Whiscash"
   },
   "341": {
-    "name": "Corphish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Corphish"
   },
   "342": {
-    "name": "Crawdaunt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Crawdaunt"
   },
   "343": {
-    "name": "Baltoy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Baltoy"
   },
   "344": {
-    "name": "Claydol",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Claydol"
   },
   "345": {
-    "name": "Lileep",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lileep"
   },
   "346": {
-    "name": "Cradily",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cradily"
   },
   "347": {
-    "name": "Anorith",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Anorith"
   },
   "348": {
-    "name": "Armaldo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Armaldo"
   },
   "349": {
-    "name": "Feebas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Feebas"
   },
   "350": {
-    "name": "Milotic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Milotic"
   },
   "351": {
-    "name": "Castform",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Castform"
   },
   "352": {
-    "name": "Kecleon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Kecleon"
   },
   "353": {
-    "name": "Shuppet",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Shuppet"
   },
   "354": {
-    "name": "Banette",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Banette"
   },
   "355": {
-    "name": "Duskull",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Duskull"
   },
   "356": {
-    "name": "Dusclops",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Dusclops"
   },
   "357": {
-    "name": "Tropius",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Tropius"
   },
   "358": {
-    "name": "Chimecho",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Chimecho"
   },
   "359": {
-    "name": "Absol",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Absol"
   },
   "360": {
-    "name": "Wynaut",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Wynaut"
   },
   "361": {
-    "name": "Snorunt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Snorunt"
   },
   "362": {
-    "name": "Glalie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Glalie"
   },
   "363": {
-    "name": "Spheal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Spheal"
   },
   "364": {
-    "name": "Sealeo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Sealeo"
   },
   "365": {
-    "name": "Walrein",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Walrein"
   },
   "366": {
-    "name": "Clamperl",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Clamperl"
   },
   "367": {
-    "name": "Huntail",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Huntail"
   },
   "368": {
-    "name": "Gorebyss",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Gorebyss"
   },
   "369": {
-    "name": "Relicanth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Relicanth"
   },
   "370": {
-    "name": "Luvdisc",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Luvdisc"
   },
   "371": {
-    "name": "Bagon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Bagon"
   },
   "372": {
-    "name": "Shelgon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Shelgon"
   },
   "373": {
-    "name": "Salamence",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Salamence"
   },
   "374": {
-    "name": "Beldum",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Beldum"
   },
   "375": {
-    "name": "Metang",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Metang"
   },
   "376": {
-    "name": "Metagross",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Metagross"
   },
   "377": {
-    "name": "Regirock",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Regirock"
   },
   "378": {
-    "name": "Regice",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Regice"
   },
   "379": {
-    "name": "Registeel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Registeel"
   },
   "380": {
-    "name": "Latias",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Latias"
   },
   "381": {
-    "name": "Latios",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Latios"
   },
   "382": {
-    "name": "Kyogre",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Kyogre"
   },
   "383": {
-    "name": "Groudon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Groudon"
   },
   "384": {
-    "name": "Rayquaza",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rayquaza"
   },
   "385": {
-    "name": "Jirachi",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Jirachi"
   },
   "386": {
-    "name": "Deoxys",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Deoxys"
   },
   "387": {
-    "name": "Turtwig",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Turtwig"
   },
   "388": {
-    "name": "Grotle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Grotle"
   },
   "389": {
-    "name": "Torterra",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Torterra"
   },
   "390": {
-    "name": "Chimchar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Chimchar"
   },
   "391": {
-    "name": "Monferno",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Monferno"
   },
   "392": {
-    "name": "Infernape",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Infernape"
   },
   "393": {
-    "name": "Piplup",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Piplup"
   },
   "394": {
-    "name": "Prinplup",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Prinplup"
   },
   "395": {
-    "name": "Empoleon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Empoleon"
   },
   "396": {
-    "name": "Starly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Starly"
   },
   "397": {
-    "name": "Staravia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Staravia"
   },
   "398": {
-    "name": "Staraptor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Staraptor"
   },
   "399": {
-    "name": "Bidoof",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Bidoof"
   },
   "400": {
-    "name": "Bibarel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Bibarel"
   },
   "401": {
-    "name": "Kricketot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Kricketot"
   },
   "402": {
-    "name": "Kricketune",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Kricketune"
   },
   "403": {
-    "name": "Shinx",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Shinx"
   },
   "404": {
-    "name": "Luxio",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Luxio"
   },
   "405": {
-    "name": "Luxray",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Luxray"
   },
   "406": {
-    "name": "Budew",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Budew"
   },
   "407": {
-    "name": "Roserade",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Roserade"
   },
   "408": {
-    "name": "Cranidos",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Cranidos"
   },
   "409": {
-    "name": "Rampardos",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rampardos"
   },
   "410": {
-    "name": "Shieldon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Shieldon"
   },
   "411": {
-    "name": "Bastiodon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Bastiodon"
   },
   "412": {
-    "name": "Burmy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "413": {
-    "name": "Wormadam",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Burmy"
   },
   "414": {
-    "name": "Mothim",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Mothim"
   },
   "415": {
-    "name": "Combee",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Combee"
   },
   "416": {
-    "name": "Vespiquen",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Vespiquen"
   },
   "417": {
-    "name": "Pachirisu",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Pachirisu"
   },
   "418": {
-    "name": "Buizel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Buizel"
   },
   "419": {
-    "name": "Floatzel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Floatzel"
   },
   "420": {
-    "name": "Cherubi",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cherubi"
   },
   "421": {
-    "name": "Cherrim",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cherrim"
   },
   "422": {
-    "name": "Shellos",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Shellos"
   },
   "423": {
-    "name": "Gastrodon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Gastrodon"
   },
   "424": {
-    "name": "Ambipom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Ambipom"
   },
   "425": {
-    "name": "Drifloon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Drifloon"
   },
   "426": {
-    "name": "Drifblim",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Drifblim"
   },
   "427": {
-    "name": "Buneary",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Buneary"
   },
   "428": {
-    "name": "Lopunny",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Lopunny"
   },
   "429": {
-    "name": "Mismagius",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Mismagius"
   },
   "430": {
-    "name": "Honchkrow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Honchkrow"
   },
   "431": {
-    "name": "Glameow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Glameow"
   },
   "432": {
-    "name": "Purugly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Purugly"
   },
   "433": {
-    "name": "Chingling",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Chingling"
   },
   "434": {
-    "name": "Stunky",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Stunky"
   },
   "435": {
-    "name": "Skuntank",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Skuntank"
   },
   "436": {
-    "name": "Bronzor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bronzor"
   },
   "437": {
-    "name": "Bronzong",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bronzong"
   },
   "438": {
-    "name": "Bonsly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Bonsly"
   },
   "439": {
-    "name": "Mime Jr.",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mime Jr."
   },
   "440": {
-    "name": "Happiny",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Happiny"
   },
   "441": {
-    "name": "Chatot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Chatot"
   },
   "442": {
-    "name": "Spiritomb",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Spiritomb"
   },
   "443": {
-    "name": "Gible",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Gible"
   },
   "444": {
-    "name": "Gabite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Gabite"
   },
   "445": {
-    "name": "Garchomp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Garchomp"
   },
   "446": {
-    "name": "Munchlax",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Munchlax"
   },
   "447": {
-    "name": "Riolu",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Riolu"
   },
   "448": {
-    "name": "Lucario",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Lucario"
   },
   "449": {
-    "name": "Hippopotas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Hippopotas"
   },
   "450": {
-    "name": "Hippowdon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Hippowdon"
   },
   "451": {
-    "name": "Skorupi",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Skorupi"
   },
   "452": {
-    "name": "Drapion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Drapion"
   },
   "453": {
-    "name": "Croagunk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Croagunk"
   },
   "454": {
-    "name": "Toxicroak",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Toxicroak"
   },
   "455": {
-    "name": "Carnivine",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Carnivine"
   },
   "456": {
-    "name": "Finneon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Finneon"
   },
   "457": {
-    "name": "Lumineon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Lumineon"
   },
   "458": {
-    "name": "Mantyke",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Mantyke"
   },
   "459": {
-    "name": "Snover",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Snover"
   },
   "460": {
-    "name": "Abomasnow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Abomasnow"
   },
   "461": {
-    "name": "Weavile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Weavile"
   },
   "462": {
-    "name": "Magnezone",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Magnezone"
   },
   "463": {
-    "name": "Lickilicky",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Lickilicky"
   },
   "464": {
-    "name": "Rhyperior",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rhyperior"
   },
   "465": {
-    "name": "Tangrowth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Tangrowth"
   },
   "466": {
-    "name": "Electivire",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Electivire"
   },
   "467": {
-    "name": "Magmortar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Magmortar"
   },
   "468": {
-    "name": "Togekiss",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Togekiss"
   },
   "469": {
-    "name": "Yanmega",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Yanmega"
   },
   "470": {
-    "name": "Leafeon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Leafeon"
   },
   "471": {
-    "name": "Glaceon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Glaceon"
   },
   "472": {
-    "name": "Gliscor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Gliscor"
   },
   "473": {
-    "name": "Mamoswine",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mamoswine"
   },
   "474": {
-    "name": "Porygon-Z",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Porygon-Z"
   },
   "475": {
-    "name": "Gallade",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Gallade"
   },
   "476": {
-    "name": "Probopass",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Probopass"
   },
   "477": {
-    "name": "Dusknoir",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Dusknoir"
   },
   "478": {
-    "name": "Froslass",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Froslass"
   },
   "479": {
-    "name": "Rotom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Rotom"
   },
   "480": {
-    "name": "Uxie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Uxie"
   },
   "481": {
-    "name": "Mesprit",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Mesprit"
   },
   "482": {
-    "name": "Azelf",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Azelf"
   },
   "483": {
-    "name": "Dialga",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Dialga"
   },
   "484": {
-    "name": "Palkia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Palkia"
   },
   "485": {
-    "name": "Heatran",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Heatran"
   },
   "486": {
-    "name": "Regigigas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "487": {
-    "name": "Giratina",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Regigigas"
   },
   "488": {
-    "name": "Cresselia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cresselia"
   },
   "489": {
-    "name": "Phione",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Phione"
   },
   "490": {
-    "name": "Manaphy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Manaphy"
   },
   "491": {
-    "name": "Darkrai",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "492": {
-    "name": "Shaymin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Darkrai"
   },
   "493": {
-    "name": "Arceus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Arceus"
   },
   "494": {
-    "name": "Victini",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Victini"
   },
   "495": {
-    "name": "Snivy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Snivy"
   },
   "496": {
-    "name": "Servine",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Servine"
   },
   "497": {
-    "name": "Serperior",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Serperior"
   },
   "498": {
-    "name": "Tepig",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Tepig"
   },
   "499": {
-    "name": "Pignite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pignite"
   },
   "500": {
-    "name": "Emboar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Emboar"
   },
   "501": {
-    "name": "Oshawott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Oshawott"
   },
   "502": {
-    "name": "Dewott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Dewott"
   },
   "503": {
-    "name": "Samurott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Samurott"
   },
   "504": {
-    "name": "Patrat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Patrat"
   },
   "505": {
-    "name": "Watchog",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Watchog"
   },
   "506": {
-    "name": "Lillipup",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Lillipup"
   },
   "507": {
-    "name": "Herdier",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Herdier"
   },
   "508": {
-    "name": "Stoutland",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Stoutland"
   },
   "509": {
-    "name": "Purrloin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Purrloin"
   },
   "510": {
-    "name": "Liepard",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Liepard"
   },
   "511": {
-    "name": "Pansage",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Pansage"
   },
   "512": {
-    "name": "Simisage",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Simisage"
   },
   "513": {
-    "name": "Pansear",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Pansear"
   },
   "514": {
-    "name": "Simisear",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Simisear"
   },
   "515": {
-    "name": "Panpour",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Panpour"
   },
   "516": {
-    "name": "Simipour",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Simipour"
   },
   "517": {
-    "name": "Munna",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Munna"
   },
   "518": {
-    "name": "Musharna",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Musharna"
   },
   "519": {
-    "name": "Pidove",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pidove"
   },
   "520": {
-    "name": "Tranquill",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Tranquill"
   },
   "521": {
-    "name": "Unfezant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Unfezant"
   },
   "522": {
-    "name": "Blitzle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Blitzle"
   },
   "523": {
-    "name": "Zebstrika",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Zebstrika"
   },
   "524": {
-    "name": "Roggenrola",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Roggenrola"
   },
   "525": {
-    "name": "Boldore",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Boldore"
   },
   "526": {
-    "name": "Gigalith",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Gigalith"
   },
   "527": {
-    "name": "Woobat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Woobat"
   },
   "528": {
-    "name": "Swoobat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swoobat"
   },
   "529": {
-    "name": "Drilbur",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Drilbur"
   },
   "530": {
-    "name": "Excadrill",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Excadrill"
   },
   "531": {
-    "name": "Audino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Audino"
   },
   "532": {
-    "name": "Timburr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Timburr"
   },
   "533": {
-    "name": "Gurdurr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Gurdurr"
   },
   "534": {
-    "name": "Conkeldurr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Conkeldurr"
   },
   "535": {
-    "name": "Tympole",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Tympole"
   },
   "536": {
-    "name": "Palpitoad",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Palpitoad"
   },
   "537": {
-    "name": "Seismitoad",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Seismitoad"
   },
   "538": {
-    "name": "Throh",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Throh"
   },
   "539": {
-    "name": "Sawk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Sawk"
   },
   "540": {
-    "name": "Sewaddle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Sewaddle"
   },
   "541": {
-    "name": "Swadloon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Swadloon"
   },
   "542": {
-    "name": "Leavanny",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Leavanny"
   },
   "543": {
-    "name": "Venipede",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Venipede"
   },
   "544": {
-    "name": "Whirlipede",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Whirlipede"
   },
   "545": {
-    "name": "Scolipede",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Scolipede"
   },
   "546": {
-    "name": "Cottonee",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Cottonee"
   },
   "547": {
-    "name": "Whimsicott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Whimsicott"
   },
   "548": {
-    "name": "Petilil",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Petilil"
   },
   "549": {
-    "name": "Lilligant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lilligant"
   },
   "550": {
-    "name": "Basculin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Basculin"
   },
   "551": {
-    "name": "Sandile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Sandile"
   },
   "552": {
-    "name": "Krokorok",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Krokorok"
   },
   "553": {
-    "name": "Krookodile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Krookodile"
   },
   "554": {
-    "name": "Darumaka",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Darumaka"
   },
   "555": {
-    "name": "Darmanitan",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Darmanitan"
   },
   "556": {
-    "name": "Maractus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Maractus"
   },
   "557": {
-    "name": "Dwebble",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Dwebble"
   },
   "558": {
-    "name": "Crustle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Crustle"
   },
   "559": {
-    "name": "Scraggy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Scraggy"
   },
   "560": {
-    "name": "Scrafty",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Scrafty"
   },
   "561": {
-    "name": "Sigilyph",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Sigilyph"
   },
   "562": {
-    "name": "Yamask",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Yamask"
   },
   "563": {
-    "name": "Cofagrigus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Cohagrigus"
   },
   "564": {
-    "name": "Tirtouga",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Tirtouga"
   },
   "565": {
-    "name": "Carracosta",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Carracosta"
   },
   "566": {
-    "name": "Archen",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Archen"
   },
   "567": {
-    "name": "Archeops",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Archeops"
   },
   "568": {
-    "name": "Trubbish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Trubbish"
   },
   "569": {
-    "name": "Garbodor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Garbodor"
   },
   "570": {
-    "name": "Zorua",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Zorua"
   },
   "571": {
-    "name": "Zoroark",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Zoroark"
   },
   "572": {
-    "name": "Minccino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Minccino"
   },
   "573": {
-    "name": "Cinccino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Cinccino"
   },
   "574": {
-    "name": "Gothita",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Gothita"
   },
   "575": {
-    "name": "Gothorita",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Gothorita"
   },
   "576": {
-    "name": "Gothitelle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Gothitelle"
   },
   "577": {
-    "name": "Solosis",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Solosis"
   },
   "578": {
-    "name": "Duosion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Duosion"
   },
   "579": {
-    "name": "Reuniclus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Reuniclus"
   },
   "580": {
-    "name": "Ducklett",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Ducklett"
   },
   "581": {
-    "name": "Swanna",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swanna"
   },
   "582": {
-    "name": "Vanillite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Vanillite"
   },
   "583": {
-    "name": "Vanillish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Vanillish"
   },
   "584": {
-    "name": "Vanilluxe",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Vanilluxe"
   },
   "585": {
-    "name": "Deerling",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Deerling"
   },
   "586": {
-    "name": "Sawsbuck",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Sawsbuck"
   },
   "587": {
-    "name": "Emolga",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Emolga"
   },
   "588": {
-    "name": "Karrablast",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Karrablast"
   },
   "589": {
-    "name": "Escavalier",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Escavalier"
   },
   "590": {
-    "name": "Foongus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Foongus"
   },
   "591": {
-    "name": "Amoonguss",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Amoonguss"
   },
   "592": {
-    "name": "Frillish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Frillish"
   },
   "593": {
-    "name": "Jellicent",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Jellicent"
   },
   "594": {
-    "name": "Alomomola",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Alomomola"
   },
   "595": {
-    "name": "Joltik",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Joltik"
   },
   "596": {
-    "name": "Galvantula",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Galvantula"
   },
   "597": {
-    "name": "Ferroseed",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Ferroseed"
   },
   "598": {
-    "name": "Ferrothorn",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Ferrothorn"
   },
   "599": {
-    "name": "Klink",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Klink"
   },
   "600": {
-    "name": "Klang",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Klang"
   },
   "601": {
-    "name": "Klinklang",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Klinklang"
   },
   "602": {
-    "name": "Tynamo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Tynamo"
   },
   "603": {
-    "name": "Eelektrik",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Eelektrik"
   },
   "604": {
-    "name": "Eelektross",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Eelektross"
   },
   "605": {
-    "name": "Elgyem",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Elgyem"
   },
   "606": {
-    "name": "Beheeyem",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Beheeyem"
   },
   "607": {
-    "name": "Litwick",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Litwick"
   },
   "608": {
-    "name": "Lampent",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Lampent"
   },
   "609": {
-    "name": "Chandelure",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Chandelure"
   },
   "610": {
-    "name": "Axew",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Axew"
   },
   "611": {
-    "name": "Fraxure",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Fraxure"
   },
   "612": {
-    "name": "Haxorus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Haxorus"
   },
   "613": {
-    "name": "Cubchoo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Cubchoo"
   },
   "614": {
-    "name": "Beartic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Beartic"
   },
   "615": {
-    "name": "Cryogonal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Cryogonal"
   },
   "616": {
-    "name": "Shelmet",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Shelmet"
   },
   "617": {
-    "name": "Accelgor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Accelgor"
   },
   "618": {
-    "name": "Stunfisk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Stunfisk"
   },
   "619": {
-    "name": "Mienfoo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Mienfoo"
   },
   "620": {
-    "name": "Mienshao",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Mienshao"
   },
   "621": {
-    "name": "Druddigon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Druddigon"
   },
   "622": {
-    "name": "Golett",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Golett"
   },
   "623": {
-    "name": "Golurk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Golurk"
   },
   "624": {
-    "name": "Pawniard",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Pawniard"
   },
   "625": {
-    "name": "Bisharp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Bisharp"
   },
   "626": {
-    "name": "Bouffalant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Bouffalant"
   },
   "627": {
-    "name": "Rufflet",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rufflet"
   },
   "628": {
-    "name": "Braviary",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Braviary"
   },
   "629": {
-    "name": "Vullaby",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Vullaby"
   },
   "630": {
-    "name": "Mandibuzz",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Mandibuzz"
   },
   "631": {
-    "name": "Heatmor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Heatmor"
   },
   "632": {
-    "name": "Durant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Durant"
   },
   "633": {
-    "name": "Deino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Deino"
   },
   "634": {
-    "name": "Zweilous",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Zweilous"
   },
   "635": {
-    "name": "Hydreigon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Hydreigon"
   },
   "636": {
-    "name": "Larvesta",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Larvesta"
   },
   "637": {
-    "name": "Volcarona",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Volcarona"
   },
   "638": {
-    "name": "Cobalion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Cobalion"
   },
   "639": {
-    "name": "Terrakion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Terrakion"
   },
   "640": {
-    "name": "Virizion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "641": {
-    "name": "Tornadus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "642": {
-    "name": "Thundurus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Virizion"
   },
   "643": {
-    "name": "Reshiram",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Reshiram"
   },
   "644": {
-    "name": "Zekrom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "645": {
-    "name": "Landorus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Zekrom"
   },
   "646": {
-    "name": "Kyurem",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Kyurem"
   },
   "647": {
-    "name": "Keldeo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "648": {
-    "name": "Meloetta",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Keldeo"
   },
   "649": {
-    "name": "Genesect",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Genesect"
   },
   "650": {
-    "name": "Chespin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Chespin"
   },
   "651": {
-    "name": "Quilladin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Quilladin"
   },
   "652": {
-    "name": "Chesnaught",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Chesnaught"
   },
   "653": {
-    "name": "Fennekin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Fennekin"
   },
   "654": {
-    "name": "Braixen",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Braixen"
   },
   "655": {
-    "name": "Delphox",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Delphox"
   },
   "656": {
-    "name": "Froakie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Froakie"
   },
   "657": {
-    "name": "Frogadier",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Frogadier"
   },
   "658": {
-    "name": "Greninja",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Greninja"
   },
   "659": {
-    "name": "Bunnelby",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Bunnelby"
   },
   "660": {
-    "name": "Diggersby",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Diggersby"
   },
   "661": {
-    "name": "Fletchling",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Fletchling"
   },
   "662": {
-    "name": "Fletchinder",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Fletchinder"
   },
   "663": {
-    "name": "Talonflame",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Talonflame"
   },
   "664": {
-    "name": "Scatterbug",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Scatterbug"
   },
   "665": {
-    "name": "Spewpa",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Spewpa"
   },
   "666": {
-    "name": "Vivillon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Vivillon"
   },
   "667": {
-    "name": "Litleo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Litleo"
   },
   "668": {
-    "name": "Pyroar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Pyroar"
   },
   "669": {
-    "name": "Flabébé",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Flabébé"
   },
   "670": {
-    "name": "Floette",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Floette"
   },
   "671": {
-    "name": "Florges",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Florges"
   },
   "672": {
-    "name": "Skiddo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Skiddo"
   },
   "673": {
-    "name": "Gogoat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Gogoat"
   },
   "674": {
-    "name": "Pancham",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pancham"
   },
   "675": {
-    "name": "Pangoro",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Pangoro"
   },
   "676": {
-    "name": "Furfrou",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Furfrou"
   },
   "677": {
-    "name": "Espurr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Espurr"
   },
   "678": {
-    "name": "Meowstic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Meowstic"
   },
   "679": {
-    "name": "Honedge",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Honedge"
   },
   "680": {
-    "name": "Doublade",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "681": {
-    "name": "Aegislash",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Doublade"
   },
   "682": {
-    "name": "Spritzee",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Spritzee"
   },
   "683": {
-    "name": "Aromatisse",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Aromatisse"
   },
   "684": {
-    "name": "Swirlix",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Swirlix"
   },
   "685": {
-    "name": "Slurpuff",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Slurpuff"
   },
   "686": {
-    "name": "Inkay",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Inkay"
   },
   "687": {
-    "name": "Malamar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Malamar"
   },
   "688": {
-    "name": "Binacle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Binacle"
   },
   "689": {
-    "name": "Barbaracle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Barbaracle"
   },
   "690": {
-    "name": "Skrelp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Skrelp"
   },
   "691": {
-    "name": "Dragalge",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Dragalge"
   },
   "692": {
-    "name": "Clauncher",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Clauncher"
   },
   "693": {
-    "name": "Clawitzer",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Clawitzer"
   },
   "694": {
-    "name": "Helioptile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Helioptile"
   },
   "695": {
-    "name": "Heliolisk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Heliolisk"
   },
   "696": {
-    "name": "Tyrunt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Tyrunt"
   },
   "697": {
-    "name": "Tyrantrum",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Tyrantrum"
   },
   "698": {
-    "name": "Amaura",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Amaura"
   },
   "699": {
-    "name": "Aurorus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Aurorus"
   },
   "700": {
-    "name": "Sylveon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Sylveon"
   },
   "701": {
-    "name": "Hawlucha",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Hawlucha"
   },
   "702": {
-    "name": "Dedenne",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Dedenne"
   },
   "703": {
-    "name": "Carbink",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Carbink"
   },
   "704": {
-    "name": "Goomy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Goomy"
   },
   "705": {
-    "name": "Sliggoo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Sliggoo"
   },
   "706": {
-    "name": "Goodra",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Goodra"
   },
   "707": {
-    "name": "Klefki",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Klefki"
   },
   "708": {
-    "name": "Phantump",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Phantump"
   },
   "709": {
-    "name": "Trevenant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Trevenant"
   },
   "710": {
-    "name": "Pumpkaboo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Pumpkaboo"
   },
   "711": {
-    "name": "Gourgeist",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Gourgeist"
   },
   "712": {
-    "name": "Bergmite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Bergmite"
   },
   "713": {
-    "name": "Avalugg",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Avalugg"
   },
   "714": {
-    "name": "Noibat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Noibat"
   },
   "715": {
-    "name": "Noivern",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Noivern"
   },
   "716": {
-    "name": "Xerneas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Xerneas"
   },
   "717": {
-    "name": "Yveltal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Yveltal"
   },
   "718": {
-    "name": "Zygarde",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Zygarde"
   },
   "719": {
-    "name": "Diancie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "720": {
-    "name": "Hoopa",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Diancie"
   },
   "721": {
-    "name": "Volcanion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Volcanion"
+  },
+  "722": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rowlet"
+  },
+  "723": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Dartrix"
+  },
+  "724": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Decidueye"
+  },
+  "725": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Litten"
+  },
+  "726": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torracat"
+  },
+  "727": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Incineroar"
+  },
+  "728": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Popplio"
+  },
+  "729": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Brionne"
+  },
+  "730": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Primarina"
+  },
+  "731": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pikipek"
+  },
+  "732": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Trumbeak"
+  },
+  "733": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Toucannon"
+  },
+  "734": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Yungoos"
+  },
+  "735": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Gumshoos"
+  },
+  "736": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Grubbin"
+  },
+  "737": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Charjabug"
+  },
+  "738": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Vikavolt"
+  },
+  "739": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Crabrawler"
+  },
+  "740": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Crabominable"
+  },
+  "741": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Oricorio"
+  },
+  "742": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Cutiefly"
+  },
+  "743": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Ribombee"
+  },
+  "744": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rockruff"
+  },
+  "745": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Lycanroc"
+  },
+  "746": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wishiwashi"
+  },
+  "747": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Mareanie"
+  },
+  "748": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Toxapex"
+  },
+  "749": {
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mudbray"
+  },
+  "750": {
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mudsdale"
+  },
+  "751": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Dewpider"
+  },
+  "752": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Araquanid"
+  },
+  "753": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Fomantis"
+  },
+  "754": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lurantis"
+  },
+  "755": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Morelull"
+  },
+  "756": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Shiinotic"
+  },
+  "757": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Salandit"
+  },
+  "758": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Salazzle"
+  },
+  "759": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Stufful"
+  },
+  "760": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Bewear"
+  },
+  "761": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Bounsweet"
+  },
+  "762": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Steenee"
+  },
+  "763": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Tsareena"
+  },
+  "764": {
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Comfey"
+  },
+  "765": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Oranguru"
+  },
+  "766": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Passimian"
+  },
+  "767": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wimpod"
+  },
+  "768": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Golisopod"
+  },
+  "769": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Sandygast"
+  },
+  "770": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Palossand"
+  },
+  "771": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Pyukumuku"
+  },
+  "772": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Type: Null"
+  },
+  "773": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Silvally"
+  },
+  "774": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Minior (Core)"
+  },
+  "775": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Komala"
+  },
+  "776": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Turtonator"
+  },
+  "777": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Togedemaru"
+  },
+  "778": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mimikyu"
+  },
+  "779": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bruxish"
+  },
+  "780": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Drampa"
+  },
+  "781": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Dhelmise"
+  },
+  "782": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Jangmo-o"
+  },
+  "783": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Hakamo-o"
+  },
+  "784": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Kommo-o"
+  },
+  "785": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Koko"
+  },
+  "786": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Lele"
+  },
+  "787": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Bulu"
+  },
+  "788": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Fini"
+  },
+  "789": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cosmog"
+  },
+  "790": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cosmoem"
+  },
+  "791": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Solgaleo"
+  },
+  "792": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Lunala"
+  },
+  "793": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Nihilego"
+  },
+  "794": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Buzzwole"
+  },
+  "795": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pheromosa"
+  },
+  "796": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Xurkitree"
+  },
+  "797": {
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Celesteela"
+  },
+  "798": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Kartana"
+  },
+  "799": {
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Guzzlord"
+  },
+  "800": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Necrozma"
+  },
+  "801": {
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Magearna"
+  },
+  "802": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Marshadow"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a Python script for generating default Pokemon icons.

## Motivation and Context
Gen 3 is likely to start arriving sometime around Halloween, and at present RM has no (automattic) way of generating the necessary default icons.

This tool allows us to quickly generate more default icons, both immediately (for Gen3) and in the future (for later generations and forms).

## How Has This Been Tested?
Icon generation was run on a Ubuntu 16.04 server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
