### PR TITLE
Only start at user location when no lat and lon not set

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2561,7 +2561,7 @@ $(function () {
         return $state
     }
 
-    if (Store.get('startAtUserLocation')) {
+    if (Store.get('startAtUserLocation') && getParameterByName("lat") == null && getParameterByName("lon") == null) {
         centerMapOnLocation()
     }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2561,7 +2561,7 @@ $(function () {
         return $state
     }
 
-    if (Store.get('startAtUserLocation') && getParameterByName("lat") == null && getParameterByName("lon") == null) {
+    if (Store.get('startAtUserLocation') && getParameterByName('lat') == null && getParameterByName('lon') == null) {
         centerMapOnLocation()
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Only start at user location when no location specified via url.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If location is set in the url the map it should stay there and not start at the users location.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local map

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
