### PR TITLE
Add default icons for gen3 sprites

### DIFF
--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -1,8719 +1,9278 @@
 {
   "1": {
+    "name": "Bulbasaur",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Bulbasaur"
+    "spawn_rate": "61"
   },
   "2": {
+    "name": "Ivysaur",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Ivysaur"
+    "spawn_rate": "421"
   },
   "3": {
+    "name": "Venusaur",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venusaur"
+    "spawn_rate": "641"
   },
   "4": {
+    "name": "Charmander",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Charmander"
+    "spawn_rate": "119"
   },
   "5": {
+    "name": "Charmeleon",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Charmeleon"
+    "spawn_rate": "1025"
   },
   "6": {
+    "name": "Charizard",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Charizard"
+    "spawn_rate": "879"
   },
   "7": {
+    "name": "Squirtle",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Squirtle"
+    "spawn_rate": "65"
   },
   "8": {
+    "name": "Wartortle",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wartortle"
+    "spawn_rate": "484"
   },
   "9": {
+    "name": "Blastoise",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Blastoise"
+    "spawn_rate": "843"
   },
   "10": {
+    "name": "Caterpie",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Caterpie"
+    "spawn_rate": "51"
   },
   "11": {
+    "name": "Metapod",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Metapod"
+    "spawn_rate": "433"
   },
   "12": {
+    "name": "Butterfree",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Butterfree"
+    "spawn_rate": "843"
   },
   "13": {
+    "name": "Weedle",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Weedle"
+    "spawn_rate": "21"
   },
   "14": {
+    "name": "Kakuna",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Kakuna"
+    "spawn_rate": "204"
   },
   "15": {
+    "name": "Beedrill",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Beedrill"
+    "spawn_rate": "377"
   },
   "16": {
+    "name": "Pidgey",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidgey"
+    "spawn_rate": "10"
   },
   "17": {
+    "name": "Pidgeotto",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidgeotto"
+    "spawn_rate": "75"
   },
   "18": {
+    "name": "Pidgeot",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidgeot"
+    "spawn_rate": "203"
   },
   "19": {
+    "name": "Rattata",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Rattata"
+    "spawn_rate": "13"
   },
   "20": {
+    "name": "Raticate",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Raticate"
+    "spawn_rate": "159"
   },
   "21": {
+    "name": "Spearow",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Spearow"
+    "spawn_rate": "31"
   },
   "22": {
+    "name": "Fearow",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Fearow"
+    "spawn_rate": "221"
   },
   "23": {
+    "name": "Ekans",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Ekans"
+    "spawn_rate": "75"
   },
   "24": {
+    "name": "Arbok",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Arbok"
+    "spawn_rate": "544"
   },
   "25": {
+    "name": "Pikachu",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Pikachu"
+    "spawn_rate": "92"
   },
   "26": {
+    "name": "Raichu",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Raichu"
+    "spawn_rate": "2051"
   },
   "27": {
+    "name": "Sandshrew",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Sandshrew"
+    "spawn_rate": "163"
   },
   "28": {
+    "name": "Sandslash",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Sandslash"
+    "spawn_rate": "1619"
   },
   "29": {
+    "name": "Nidoran♀",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidoran♀"
+    "spawn_rate": "77"
   },
   "30": {
+    "name": "Nidorina",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidorina"
+    "spawn_rate": "504"
   },
   "31": {
+    "name": "Nidoqueen",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Nidoqueen"
+    "spawn_rate": "1398"
   },
   "32": {
+    "name": "Nidoran♂",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidoran♂"
+    "spawn_rate": "77"
   },
   "33": {
+    "name": "Nidorino",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidorino"
+    "spawn_rate": "586"
   },
   "34": {
+    "name": "Nidoking",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Nidoking"
+    "spawn_rate": "1025"
   },
   "35": {
+    "name": "Clefairy",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Clefairy"
+    "spawn_rate": "85"
   },
   "36": {
+    "name": "Clefable",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Clefable"
+    "spawn_rate": "1309"
   },
   "37": {
+    "name": "Vulpix",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Vulpix"
+    "spawn_rate": "188"
   },
   "38": {
+    "name": "Ninetales",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Ninetales"
+    "spawn_rate": "1538"
   },
   "39": {
+    "name": "Jigglypuff",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Jigglypuff"
+    "spawn_rate": "101"
   },
   "40": {
+    "name": "Wigglytuff",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Wigglytuff"
+    "spawn_rate": "2051"
   },
   "41": {
+    "name": "Zubat",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Zubat"
+    "spawn_rate": "24"
   },
   "42": {
+    "name": "Golbat",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Golbat"
+    "spawn_rate": "209"
   },
   "43": {
+    "name": "Oddish",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Oddish"
+    "spawn_rate": "91"
   },
   "44": {
+    "name": "Gloom",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gloom"
+    "spawn_rate": "592"
   },
   "45": {
+    "name": "Vileplume",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Vileplume"
+    "spawn_rate": "1864"
   },
   "46": {
+    "name": "Paras",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Paras"
+    "spawn_rate": "44"
   },
   "47": {
+    "name": "Parasect",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Parasect"
+    "spawn_rate": "397"
   },
   "48": {
+    "name": "Venonat",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venonat"
+    "spawn_rate": "38"
   },
   "49": {
+    "name": "Venomoth",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venomoth"
+    "spawn_rate": "300"
   },
   "50": {
+    "name": "Diglett",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Diglett"
+    "spawn_rate": "211"
   },
   "51": {
+    "name": "Dugtrio",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Dugtrio"
+    "spawn_rate": "1663"
   },
   "52": {
+    "name": "Meowth",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Meowth"
+    "spawn_rate": "106"
   },
   "53": {
+    "name": "Persian",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Persian"
+    "spawn_rate": "1282"
   },
   "54": {
+    "name": "Psyduck",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Psyduck"
+    "spawn_rate": "108"
   },
   "55": {
+    "name": "Golduck",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Golduck"
+    "spawn_rate": "707"
   },
   "56": {
+    "name": "Mankey",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Mankey"
+    "spawn_rate": "114"
   },
   "57": {
+    "name": "Primeape",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Primeape"
+    "spawn_rate": "1061"
   },
   "58": {
+    "name": "Growlithe",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Growlithe"
+    "spawn_rate": "77"
   },
   "59": {
+    "name": "Arcanine",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Arcanine"
+    "spawn_rate": "932"
   },
   "60": {
+    "name": "Poliwag",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Poliwag"
+    "spawn_rate": "95"
   },
   "61": {
+    "name": "Poliwhirl",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Poliwhirl"
+    "spawn_rate": "481"
   },
   "62": {
+    "name": "Poliwrath",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Poliwrath"
+    "spawn_rate": "1709"
   },
   "63": {
+    "name": "Abra",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Abra"
+    "spawn_rate": "104"
   },
   "64": {
+    "name": "Kadabra",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Kadabra"
+    "spawn_rate": "779"
   },
   "65": {
+    "name": "Alakazam",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Alakazam"
+    "spawn_rate": "2461"
   },
   "66": {
+    "name": "Machop",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Machop"
+    "spawn_rate": "217"
   },
   "67": {
+    "name": "Machoke",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Machoke"
+    "spawn_rate": "1465"
   },
   "68": {
+    "name": "Machamp",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Machamp"
+    "spawn_rate": "3418"
   },
   "69": {
+    "name": "Bellsprout",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Bellsprout"
+    "spawn_rate": "86"
   },
   "70": {
+    "name": "Weepinbell",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Weepinbell"
+    "spawn_rate": "496"
   },
   "71": {
+    "name": "Victreebel",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Victreebel"
+    "spawn_rate": "2051"
   },
   "72": {
+    "name": "Tentacool",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Tentacool"
+    "spawn_rate": "275"
   },
   "73": {
+    "name": "Tentacruel",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Tentacruel"
+    "spawn_rate": "615"
   },
   "74": {
+    "name": "Geodude",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Geodude"
+    "spawn_rate": "121"
   },
   "75": {
+    "name": "Graveler",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Graveler"
+    "spawn_rate": "707"
   },
   "76": {
+    "name": "Golem",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Golem"
+    "spawn_rate": "2797"
   },
   "77": {
+    "name": "Ponyta",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Ponyta"
+    "spawn_rate": "121"
   },
   "78": {
+    "name": "Rapidash",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Rapidash"
+    "spawn_rate": "992"
   },
   "79": {
+    "name": "Slowpoke",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Slowpoke"
+    "spawn_rate": "175"
   },
   "80": {
+    "name": "Slowbro",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Slowbro"
+    "spawn_rate": "947"
   },
   "81": {
+    "name": "Magnemite",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Magnemite"
+    "spawn_rate": "200"
   },
   "82": {
+    "name": "Magneton",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Magneton"
+    "spawn_rate": "2051"
   },
   "83": {
+    "name": "Farfetch'd",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Farfetch'd"
+    "spawn_rate": "61527"
   },
   "84": {
+    "name": "Doduo",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Doduo"
+    "spawn_rate": "77"
   },
   "85": {
+    "name": "Dodrio",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Dodrio"
+    "spawn_rate": "634"
   },
   "86": {
+    "name": "Seel",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Seel"
+    "spawn_rate": "196"
   },
   "87": {
+    "name": "Dewgong",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Dewgong"
+    "spawn_rate": "1578"
   },
   "88": {
+    "name": "Grimer",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Grimer"
+    "spawn_rate": "879"
   },
   "89": {
+    "name": "Muk",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Muk"
+    "spawn_rate": "7691"
   },
   "90": {
+    "name": "Shellder",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Shellder"
+    "spawn_rate": "177"
   },
   "91": {
+    "name": "Cloyster",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Cloyster"
+    "spawn_rate": "1578"
   },
   "92": {
+    "name": "Gastly",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gastly"
+    "spawn_rate": "77"
   },
   "93": {
+    "name": "Haunter",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Haunter"
+    "spawn_rate": "419"
   },
   "94": {
+    "name": "Gengar",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gengar"
+    "spawn_rate": "1758"
   },
   "95": {
+    "name": "Onix",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Onix"
+    "spawn_rate": "269"
   },
   "96": {
+    "name": "Drowzee",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Drowzee"
+    "spawn_rate": "39"
   },
   "97": {
+    "name": "Hypno",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Hypno"
+    "spawn_rate": "322"
   },
   "98": {
+    "name": "Krabby",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Krabby"
+    "spawn_rate": "73"
   },
   "99": {
+    "name": "Kingler",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kingler"
+    "spawn_rate": "530"
   },
   "100": {
+    "name": "Voltorb",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Voltorb"
+    "spawn_rate": "276"
   },
   "101": {
+    "name": "Electrode",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electrode"
+    "spawn_rate": "1985"
   },
   "102": {
+    "name": "Exeggcute",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Exeggcute"
+    "spawn_rate": "123"
   },
   "103": {
+    "name": "Exeggutor",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Exeggutor"
+    "spawn_rate": "1231"
   },
   "104": {
+    "name": "Cubone",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Cubone"
+    "spawn_rate": "163"
   },
   "105": {
+    "name": "Marowak",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Marowak"
+    "spawn_rate": "1431"
   },
   "106": {
+    "name": "Hitmonlee",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hitmonlee"
+    "spawn_rate": "504"
   },
   "107": {
+    "name": "Hitmonchan",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hitmonchan"
+    "spawn_rate": "446"
   },
   "108": {
+    "name": "Lickitung",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lickitung"
+    "spawn_rate": "443"
   },
   "109": {
+    "name": "Koffing",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Koffing"
+    "spawn_rate": "213"
   },
   "110": {
+    "name": "Weezing",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Weezing"
+    "spawn_rate": "1398"
   },
   "111": {
+    "name": "Rhyhorn",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rhyhorn"
+    "spawn_rate": "110"
   },
   "112": {
+    "name": "Rhydon",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rhydon"
+    "spawn_rate": "867"
   },
   "113": {
+    "name": "Chansey",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Chansey"
+    "spawn_rate": "1256"
   },
   "114": {
+    "name": "Tangela",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Tangela"
+    "spawn_rate": "346"
   },
   "115": {
+    "name": "Kangaskhan",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Kangaskhan"
+    "spawn_rate": "2461"
   },
   "116": {
+    "name": "Horsea",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Horsea"
+    "spawn_rate": "104"
   },
   "117": {
+    "name": "Seadra",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Seadra"
+    "spawn_rate": "760"
   },
   "118": {
+    "name": "Goldeen",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Goldeen"
+    "spawn_rate": "103"
   },
   "119": {
+    "name": "Seaking",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Seaking"
+    "spawn_rate": "684"
   },
   "120": {
+    "name": "Staryu",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Staryu"
+    "spawn_rate": "97"
   },
   "121": {
+    "name": "Starmie",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Starmie"
+    "spawn_rate": "1206"
   },
   "122": {
+    "name": "Mr. Mime",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mr. Mime"
+    "spawn_rate": "1431"
   },
   "123": {
+    "name": "Scyther",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Scyther"
+    "spawn_rate": "155"
   },
   "124": {
+    "name": "Jynx",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Jynx"
+    "spawn_rate": "152"
   },
   "125": {
+    "name": "Electabuzz",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electabuzz"
+    "spawn_rate": "261"
   },
   "126": {
+    "name": "Magmar",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Magmar"
+    "spawn_rate": "213"
   },
   "127": {
+    "name": "Pinsir",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Pinsir"
+    "spawn_rate": "99"
   },
   "128": {
+    "name": "Tauros",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Tauros"
+    "spawn_rate": "153"
   },
   "129": {
+    "name": "Magikarp",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Magikarp"
+    "spawn_rate": "79"
   },
   "130": {
+    "name": "Gyarados",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Gyarados"
+    "spawn_rate": "2279"
   },
   "131": {
+    "name": "Lapras",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Lapras"
+    "spawn_rate": "1183"
   },
   "132": {
+    "name": "Ditto",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Ditto"
+    "spawn_rate": "30764"
   },
   "133": {
+    "name": "Eevee",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Eevee"
+    "spawn_rate": "24"
   },
   "134": {
+    "name": "Vaporeon",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Vaporeon"
+    "spawn_rate": "1465"
   },
   "135": {
+    "name": "Jolteon",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Jolteon"
+    "spawn_rate": "1309"
   },
   "136": {
+    "name": "Flareon",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Flareon"
+    "spawn_rate": "1568"
   },
   "137": {
+    "name": "Porygon",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Porygon"
+    "spawn_rate": "867"
   },
   "138": {
+    "name": "Omanyte",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Omanyte"
+    "spawn_rate": "346"
   },
   "139": {
+    "name": "Omastar",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Omastar"
+    "spawn_rate": "6153"
   },
   "140": {
+    "name": "Kabuto",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kabuto"
+    "spawn_rate": "356"
   },
   "141": {
+    "name": "Kabutops",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kabutops"
+    "spawn_rate": "2930"
   },
   "142": {
+    "name": "Aerodactyl",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Aerodactyl"
+    "spawn_rate": "879"
   },
   "143": {
+    "name": "Snorlax",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Snorlax"
+    "spawn_rate": "284"
   },
   "144": {
+    "name": "Articuno",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Articuno"
+    "spawn_rate": "99999"
   },
   "145": {
+    "name": "Zapdos",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Zapdos"
+    "spawn_rate": "99999"
   },
   "146": {
+    "name": "Moltres",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Moltres"
+    "spawn_rate": "99999"
   },
   "147": {
+    "name": "Dratini",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dratini"
+    "spawn_rate": "91"
   },
   "148": {
+    "name": "Dragonair",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dragonair"
+    "spawn_rate": "699"
   },
   "149": {
+    "name": "Dragonite",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Dragonite"
+    "spawn_rate": "580"
   },
   "150": {
+    "name": "Mewtwo",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Mewtwo"
+    "spawn_rate": "99999"
   },
   "151": {
+    "name": "Mew",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Mew"
+    "spawn_rate": "99999"
   },
   "152": {
+    "name": "Chikorita",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Chikorita"
+    "spawn_rate": ""
   },
   "153": {
+    "name": "Bayleef",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Bayleef"
+    "spawn_rate": ""
   },
   "154": {
+    "name": "Meganium",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Meganium"
+    "spawn_rate": ""
   },
   "155": {
+    "name": "Cyndaquil",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Cyndaquil"
+    "spawn_rate": ""
   },
   "156": {
+    "name": "Quilava",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Quilava"
+    "spawn_rate": ""
   },
   "157": {
+    "name": "Typhlosion",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Typhlosion"
+    "spawn_rate": ""
   },
   "158": {
+    "name": "Totodile",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Totodile"
+    "spawn_rate": ""
   },
   "159": {
+    "name": "Croconaw",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Croconaw"
+    "spawn_rate": ""
   },
   "160": {
+    "name": "Feraligatr",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Feraligatr"
+    "spawn_rate": ""
   },
   "161": {
+    "name": "Sentret",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Sentret"
+    "spawn_rate": ""
   },
   "162": {
+    "name": "Furret",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Furret"
+    "spawn_rate": ""
   },
   "163": {
+    "name": "Hoothoot",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Hoothoot"
+    "spawn_rate": ""
   },
   "164": {
+    "name": "Noctowl",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Noctowl"
+    "spawn_rate": ""
   },
   "165": {
+    "name": "Ledyba",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ledyba"
+    "spawn_rate": ""
   },
   "166": {
+    "name": "Ledian",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ledian"
+    "spawn_rate": ""
   },
   "167": {
+    "name": "Spinarak",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Spinarak"
+    "spawn_rate": ""
   },
   "168": {
+    "name": "Ariados",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Ariados"
+    "spawn_rate": ""
   },
   "169": {
+    "name": "Crobat",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Crobat"
+    "spawn_rate": ""
   },
   "170": {
+    "name": "Chinchou",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Chinchou"
+    "spawn_rate": ""
   },
   "171": {
+    "name": "Lanturn",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Lanturn"
+    "spawn_rate": ""
   },
   "172": {
+    "name": "Pichu",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Pichu"
+    "spawn_rate": ""
   },
   "173": {
+    "name": "Cleffa",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Cleffa"
+    "spawn_rate": ""
   },
   "174": {
+    "name": "Igglybuff",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Igglybuff"
+    "spawn_rate": ""
   },
   "175": {
+    "name": "Togepi",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Togepi"
+    "spawn_rate": ""
   },
   "176": {
+    "name": "Togetic",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Togetic"
+    "spawn_rate": ""
   },
   "177": {
+    "name": "Natu",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Natu"
+    "spawn_rate": ""
   },
   "178": {
+    "name": "Xatu",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Xatu"
+    "spawn_rate": ""
   },
   "179": {
+    "name": "Mareep",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Mareep"
+    "spawn_rate": ""
   },
   "180": {
+    "name": "Flaaffy",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Flaaffy"
+    "spawn_rate": ""
   },
   "181": {
+    "name": "Ampharos",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Ampharos"
+    "spawn_rate": ""
   },
   "182": {
+    "name": "Bellossom",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Bellossom"
+    "spawn_rate": ""
   },
   "183": {
+    "name": "Marill",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Marill"
+    "spawn_rate": ""
   },
   "184": {
+    "name": "Azumarill",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Azumarill"
+    "spawn_rate": ""
   },
   "185": {
+    "name": "Sudowoodo",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Sudowoodo"
+    "spawn_rate": ""
   },
   "186": {
+    "name": "Politoed",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Politoed"
+    "spawn_rate": ""
   },
   "187": {
+    "name": "Hoppip",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Hoppip"
+    "spawn_rate": ""
   },
   "188": {
+    "name": "Skiploom",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Skiploom"
+    "spawn_rate": ""
   },
   "189": {
+    "name": "Jumpluff",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Jumpluff"
+    "spawn_rate": ""
   },
   "190": {
+    "name": "Aipom",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Aipom"
+    "spawn_rate": ""
   },
   "191": {
+    "name": "Sunkern",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sunkern"
+    "spawn_rate": ""
   },
   "192": {
+    "name": "Sunflora",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sunflora"
+    "spawn_rate": ""
   },
   "193": {
+    "name": "Yanma",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Yanma"
+    "spawn_rate": ""
   },
   "194": {
+    "name": "Wooper",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Wooper"
+    "spawn_rate": ""
   },
   "195": {
+    "name": "Quagsire",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Quagsire"
+    "spawn_rate": ""
   },
   "196": {
+    "name": "Espeon",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Espeon"
+    "spawn_rate": ""
   },
   "197": {
+    "name": "Umbreon",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Umbreon"
+    "spawn_rate": ""
   },
   "198": {
+    "name": "Murkrow",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Murkrow"
+    "spawn_rate": ""
   },
   "199": {
+    "name": "Slowking",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Slowking"
+    "spawn_rate": ""
   },
   "200": {
+    "name": "Misdreavus",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Misdreavus"
+    "spawn_rate": ""
   },
   "201": {
+    "name": "Unown",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Unown"
+    "spawn_rate": ""
   },
   "202": {
+    "name": "Wobbuffet",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Wobbuffet"
+    "spawn_rate": ""
   },
   "203": {
+    "name": "Girafarig",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Girafarig"
+    "spawn_rate": ""
   },
   "204": {
+    "name": "Pineco",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Pineco"
+    "spawn_rate": ""
   },
   "205": {
+    "name": "Forretress",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Forretress"
+    "spawn_rate": ""
   },
   "206": {
+    "name": "Dunsparce",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Dunsparce"
+    "spawn_rate": ""
   },
   "207": {
+    "name": "Gligar",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Gligar"
+    "spawn_rate": ""
   },
   "208": {
+    "name": "Steelix",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Steelix"
+    "spawn_rate": ""
   },
   "209": {
+    "name": "Snubbull",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Snubbull"
+    "spawn_rate": ""
   },
   "210": {
+    "name": "Granbull",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Granbull"
+    "spawn_rate": ""
   },
   "211": {
+    "name": "Qwilfish",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Qwilfish"
+    "spawn_rate": ""
   },
   "212": {
+    "name": "Scizor",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Scizor"
+    "spawn_rate": ""
   },
   "213": {
+    "name": "Shuckle",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Shuckle"
+    "spawn_rate": ""
   },
   "214": {
+    "name": "Heracross",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Heracross"
+    "spawn_rate": ""
   },
   "215": {
+    "name": "Sneasel",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Sneasel"
+    "spawn_rate": ""
   },
   "216": {
+    "name": "Teddiursa",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Teddiursa"
+    "spawn_rate": ""
   },
   "217": {
+    "name": "Ursaring",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Ursaring"
+    "spawn_rate": ""
   },
   "218": {
+    "name": "Slugma",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Slugma"
+    "spawn_rate": ""
   },
   "219": {
+    "name": "Magcargo",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Magcargo"
+    "spawn_rate": ""
   },
   "220": {
+    "name": "Swinub",
+    "rarity": "Common",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Swinub"
+    "spawn_rate": ""
   },
   "221": {
+    "name": "Piloswine",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Piloswine"
+    "spawn_rate": ""
   },
   "222": {
+    "name": "Corsola",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Corsola"
+    "spawn_rate": ""
   },
   "223": {
+    "name": "Remoraid",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Remoraid"
+    "spawn_rate": ""
   },
   "224": {
+    "name": "Octillery",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Octillery"
+    "spawn_rate": ""
   },
   "225": {
+    "name": "Delibird",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Delibird"
+    "spawn_rate": ""
   },
   "226": {
+    "name": "Mantine",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mantine"
+    "spawn_rate": ""
   },
   "227": {
+    "name": "Skarmory",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Skarmory"
+    "spawn_rate": ""
   },
   "228": {
+    "name": "Houndour",
+    "rarity": "Uncommon",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Houndour"
+    "spawn_rate": ""
   },
   "229": {
+    "name": "Houndoom",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Houndoom"
+    "spawn_rate": ""
   },
   "230": {
+    "name": "Kingdra",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Kingdra"
+    "spawn_rate": ""
   },
   "231": {
+    "name": "Phanpy",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Phanpy"
+    "spawn_rate": ""
   },
   "232": {
+    "name": "Donphan",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Donphan"
+    "spawn_rate": ""
   },
   "233": {
+    "name": "Porygon2",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Porygon2"
+    "spawn_rate": ""
   },
   "234": {
+    "name": "Stantler",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Stantler"
+    "spawn_rate": ""
   },
   "235": {
+    "name": "Smeargle",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Smeargle"
+    "spawn_rate": ""
   },
   "236": {
+    "name": "Tyrogue",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Tyrogue"
+    "spawn_rate": ""
   },
   "237": {
+    "name": "Hitmontop",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hitmontop"
+    "spawn_rate": ""
   },
   "238": {
+    "name": "Smoochum",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Smoochum"
+    "spawn_rate": ""
   },
   "239": {
+    "name": "Elekid",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Elekid"
+    "spawn_rate": ""
   },
   "240": {
+    "name": "Magby",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Magby"
+    "spawn_rate": ""
   },
   "241": {
+    "name": "Miltank",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Miltank"
+    "spawn_rate": ""
   },
   "242": {
+    "name": "Blissey",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Blissey"
+    "spawn_rate": ""
   },
   "243": {
+    "name": "Raikou",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Raikou"
+    "spawn_rate": ""
   },
   "244": {
+    "name": "Entei",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Entei"
+    "spawn_rate": ""
   },
   "245": {
+    "name": "Suicune",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Suicune"
+    "spawn_rate": ""
   },
   "246": {
+    "name": "Larvitar",
+    "rarity": "Very Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Larvitar"
+    "spawn_rate": ""
   },
   "247": {
+    "name": "Pupitar",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Pupitar"
+    "spawn_rate": ""
   },
   "248": {
+    "name": "Tyranitar",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Tyranitar"
+    "spawn_rate": ""
   },
   "249": {
+    "name": "Lugia",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Lugia"
+    "spawn_rate": ""
   },
   "250": {
+    "name": "Ho-Oh",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ho-Oh"
+    "spawn_rate": ""
   },
   "251": {
+    "name": "Celebi",
+    "rarity": "Ultra Rare",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Celebi"
+    "spawn_rate": ""
   },
   "252": {
+    "name": "Treecko",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Treecko"
+    "spawn_rate": ""
   },
   "253": {
+    "name": "Grovyle",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Grovyle"
+    "spawn_rate": ""
   },
   "254": {
+    "name": "Sceptile",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sceptile"
+    "spawn_rate": ""
   },
   "255": {
+    "name": "Torchic",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Torchic"
+    "spawn_rate": ""
   },
   "256": {
+    "name": "Combusken",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Combusken"
+    "spawn_rate": ""
   },
   "257": {
+    "name": "Blaziken",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Blaziken"
+    "spawn_rate": ""
   },
   "258": {
+    "name": "Mudkip",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Mudkip"
+    "spawn_rate": ""
   },
   "259": {
+    "name": "Marshtomp",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Marshtomp"
+    "spawn_rate": ""
   },
   "260": {
+    "name": "Swampert",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Swampert"
+    "spawn_rate": ""
   },
   "261": {
+    "name": "Poochyena",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Poochyena"
+    "spawn_rate": ""
   },
   "262": {
+    "name": "Mightyena",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Mightyena"
+    "spawn_rate": ""
   },
   "263": {
+    "name": "Zigzagoon",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Zigzagoon"
+    "spawn_rate": ""
   },
   "264": {
+    "name": "Linoone",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Linoone"
+    "spawn_rate": ""
   },
   "265": {
+    "name": "Wurmple",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Wurmple"
+    "spawn_rate": ""
   },
   "266": {
+    "name": "Silcoon",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Silcoon"
+    "spawn_rate": ""
   },
   "267": {
+    "name": "Beautifly",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Beautifly"
+    "spawn_rate": ""
   },
   "268": {
+    "name": "Cascoon",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Cascoon"
+    "spawn_rate": ""
   },
   "269": {
+    "name": "Dustox",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Dustox"
+    "spawn_rate": ""
   },
   "270": {
+    "name": "Lotad",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lotad"
+    "spawn_rate": ""
   },
   "271": {
+    "name": "Lombre",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lombre"
+    "spawn_rate": ""
   },
   "272": {
+    "name": "Ludicolo",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Ludicolo"
+    "spawn_rate": ""
   },
   "273": {
+    "name": "Seedot",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Seedot"
+    "spawn_rate": ""
   },
   "274": {
+    "name": "Nuzleaf",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Nuzleaf"
+    "spawn_rate": ""
   },
   "275": {
+    "name": "Shiftry",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Shiftry"
+    "spawn_rate": ""
   },
   "276": {
+    "name": "Taillow",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Taillow"
+    "spawn_rate": ""
   },
   "277": {
+    "name": "Swellow",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swellow"
+    "spawn_rate": ""
   },
   "278": {
+    "name": "Wingull",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Wingull"
+    "spawn_rate": ""
   },
   "279": {
+    "name": "Pelipper",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pelipper"
+    "spawn_rate": ""
   },
   "280": {
+    "name": "Ralts",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Ralts"
+    "spawn_rate": ""
   },
   "281": {
+    "name": "Kirlia",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Kirlia"
+    "spawn_rate": ""
   },
   "282": {
+    "name": "Gardevoir",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Gardevoir"
+    "spawn_rate": ""
   },
   "283": {
+    "name": "Surskit",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Surskit"
+    "spawn_rate": ""
   },
   "284": {
+    "name": "Masquerain",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Masquerain"
+    "spawn_rate": ""
   },
   "285": {
+    "name": "Shroomish",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Shroomish"
+    "spawn_rate": ""
   },
   "286": {
+    "name": "Breloom",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Breloom"
+    "spawn_rate": ""
   },
   "287": {
+    "name": "Slakoth",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Slakoth"
+    "spawn_rate": ""
   },
   "288": {
+    "name": "Vigoroth",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Vigoroth"
+    "spawn_rate": ""
   },
   "289": {
+    "name": "Slaking",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Slaking"
+    "spawn_rate": ""
   },
   "290": {
+    "name": "Nincada",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Nincada"
+    "spawn_rate": ""
   },
   "291": {
+    "name": "Ninjask",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ninjask"
+    "spawn_rate": ""
   },
   "292": {
+    "name": "Shedinja",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Shedinja"
+    "spawn_rate": ""
   },
   "293": {
+    "name": "Whismur",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Whismur"
+    "spawn_rate": ""
   },
   "294": {
+    "name": "Loudred",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Loudred"
+    "spawn_rate": ""
   },
   "295": {
+    "name": "Exploud",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Exploud"
+    "spawn_rate": ""
   },
   "296": {
+    "name": "Makuhita",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Makuhita"
+    "spawn_rate": ""
   },
   "297": {
+    "name": "Hariyama",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hariyama"
+    "spawn_rate": ""
   },
   "298": {
+    "name": "Azurill",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Azurill"
+    "spawn_rate": ""
   },
   "299": {
+    "name": "Nosepass",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Nosepass"
+    "spawn_rate": ""
   },
   "300": {
+    "name": "Skitty",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Skitty"
+    "spawn_rate": ""
   },
   "301": {
+    "name": "Delcatty",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Delcatty"
+    "spawn_rate": ""
   },
   "302": {
+    "name": "Sableye",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Sableye"
+    "spawn_rate": ""
   },
   "303": {
+    "name": "Mawile",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mawile"
+    "spawn_rate": ""
   },
   "304": {
+    "name": "Aron",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Aron"
+    "spawn_rate": ""
   },
   "305": {
+    "name": "Lairon",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Lairon"
+    "spawn_rate": ""
   },
   "306": {
+    "name": "Aggron",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Aggron"
+    "spawn_rate": ""
   },
   "307": {
+    "name": "Meditite",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Meditite"
+    "spawn_rate": ""
   },
   "308": {
+    "name": "Medicham",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Medicham"
+    "spawn_rate": ""
   },
   "309": {
+    "name": "Electrike",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electrike"
+    "spawn_rate": ""
   },
   "310": {
+    "name": "Manectric",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Manectric"
+    "spawn_rate": ""
   },
   "311": {
+    "name": "Plusle",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Plusle"
+    "spawn_rate": ""
   },
   "312": {
+    "name": "Minun",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Minun"
+    "spawn_rate": ""
   },
   "313": {
+    "name": "Volbeat",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Volbeat"
+    "spawn_rate": ""
   },
   "314": {
+    "name": "Illumise",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Illumise"
+    "spawn_rate": ""
   },
   "315": {
+    "name": "Roselia",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Roselia"
+    "spawn_rate": ""
   },
   "316": {
+    "name": "Gulpin",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gulpin"
+    "spawn_rate": ""
   },
   "317": {
+    "name": "Swalot",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Swalot"
+    "spawn_rate": ""
   },
   "318": {
+    "name": "Carvanha",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Carvanha"
+    "spawn_rate": ""
   },
   "319": {
+    "name": "Sharpedo",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Sharpedo"
+    "spawn_rate": ""
   },
   "320": {
+    "name": "Wailmer",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wailmer"
+    "spawn_rate": ""
   },
   "321": {
+    "name": "Wailord",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wailord"
+    "spawn_rate": ""
   },
   "322": {
+    "name": "Numel",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Numel"
+    "spawn_rate": ""
   },
   "323": {
+    "name": "Camerupt",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Camerupt"
+    "spawn_rate": ""
   },
   "324": {
+    "name": "Torkoal",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Torkoal"
+    "spawn_rate": ""
   },
   "325": {
+    "name": "Spoink",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Spoink"
+    "spawn_rate": ""
   },
   "326": {
+    "name": "Grumpig",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Grumpig"
+    "spawn_rate": ""
   },
   "327": {
+    "name": "Spinda",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Spinda"
+    "spawn_rate": ""
   },
   "328": {
+    "name": "Trapinch",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Trapinch"
+    "spawn_rate": ""
   },
   "329": {
+    "name": "Vibrava",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Vibrava"
+    "spawn_rate": ""
   },
   "330": {
+    "name": "Flygon",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Flygon"
+    "spawn_rate": ""
   },
   "331": {
+    "name": "Cacnea",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cacnea"
+    "spawn_rate": ""
   },
   "332": {
+    "name": "Cacturne",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Cacturne"
+    "spawn_rate": ""
   },
   "333": {
+    "name": "Swablu",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swablu"
+    "spawn_rate": ""
   },
   "334": {
+    "name": "Altaria",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Altaria"
+    "spawn_rate": ""
   },
   "335": {
+    "name": "Zangoose",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Zangoose"
+    "spawn_rate": ""
   },
   "336": {
+    "name": "Seviper",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Seviper"
+    "spawn_rate": ""
   },
   "337": {
+    "name": "Lunatone",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Lunatone"
+    "spawn_rate": ""
   },
   "338": {
+    "name": "Solrock",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Solrock"
+    "spawn_rate": ""
   },
   "339": {
+    "name": "Barboach",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Barboach"
+    "spawn_rate": ""
   },
   "340": {
+    "name": "Whiscash",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Whiscash"
+    "spawn_rate": ""
   },
   "341": {
+    "name": "Corphish",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Corphish"
+    "spawn_rate": ""
   },
   "342": {
+    "name": "Crawdaunt",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Crawdaunt"
+    "spawn_rate": ""
   },
   "343": {
+    "name": "Baltoy",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Baltoy"
+    "spawn_rate": ""
   },
   "344": {
+    "name": "Claydol",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Claydol"
+    "spawn_rate": ""
   },
   "345": {
+    "name": "Lileep",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lileep"
+    "spawn_rate": ""
   },
   "346": {
+    "name": "Cradily",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cradily"
+    "spawn_rate": ""
   },
   "347": {
+    "name": "Anorith",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Anorith"
+    "spawn_rate": ""
   },
   "348": {
+    "name": "Armaldo",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Armaldo"
+    "spawn_rate": ""
   },
   "349": {
+    "name": "Feebas",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Feebas"
+    "spawn_rate": ""
   },
   "350": {
+    "name": "Milotic",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Milotic"
+    "spawn_rate": ""
   },
   "351": {
+    "name": "Castform",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Castform"
+    "spawn_rate": ""
   },
   "352": {
+    "name": "Kecleon",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Kecleon"
+    "spawn_rate": ""
   },
   "353": {
+    "name": "Shuppet",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Shuppet"
+    "spawn_rate": ""
   },
   "354": {
+    "name": "Banette",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Banette"
+    "spawn_rate": ""
   },
   "355": {
+    "name": "Duskull",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Duskull"
+    "spawn_rate": ""
   },
   "356": {
+    "name": "Dusclops",
+    "rarity": "Rare",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Dusclops"
+    "spawn_rate": ""
   },
   "357": {
+    "name": "Tropius",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Tropius"
+    "spawn_rate": ""
   },
   "358": {
+    "name": "Chimecho",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Chimecho"
+    "spawn_rate": ""
   },
   "359": {
+    "name": "Absol",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Absol"
+    "spawn_rate": ""
   },
   "360": {
+    "name": "Wynaut",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Wynaut"
+    "spawn_rate": ""
   },
   "361": {
+    "name": "Snorunt",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Snorunt"
+    "spawn_rate": ""
   },
   "362": {
+    "name": "Glalie",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Glalie"
+    "spawn_rate": ""
   },
   "363": {
+    "name": "Spheal",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Spheal"
+    "spawn_rate": ""
   },
   "364": {
+    "name": "Sealeo",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Sealeo"
+    "spawn_rate": ""
   },
   "365": {
+    "name": "Walrein",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Walrein"
+    "spawn_rate": ""
   },
   "366": {
+    "name": "Clamperl",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Clamperl"
+    "spawn_rate": ""
   },
   "367": {
+    "name": "Huntail",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Huntail"
+    "spawn_rate": ""
   },
   "368": {
+    "name": "Gorebyss",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Gorebyss"
+    "spawn_rate": ""
   },
   "369": {
+    "name": "Relicanth",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Relicanth"
+    "spawn_rate": ""
   },
   "370": {
+    "name": "Luvdisc",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Luvdisc"
+    "spawn_rate": ""
   },
   "371": {
+    "name": "Bagon",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Bagon"
+    "spawn_rate": ""
   },
   "372": {
+    "name": "Shelgon",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Shelgon"
+    "spawn_rate": ""
   },
   "373": {
+    "name": "Salamence",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Salamence"
+    "spawn_rate": ""
   },
   "374": {
+    "name": "Beldum",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Beldum"
+    "spawn_rate": ""
   },
   "375": {
+    "name": "Metang",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Metang"
+    "spawn_rate": ""
   },
   "376": {
+    "name": "Metagross",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Metagross"
+    "spawn_rate": ""
   },
   "377": {
+    "name": "Regirock",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Regirock"
+    "spawn_rate": ""
   },
   "378": {
+    "name": "Regice",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Regice"
+    "spawn_rate": ""
   },
   "379": {
+    "name": "Registeel",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Registeel"
+    "spawn_rate": ""
   },
   "380": {
+    "name": "Latias",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Latias"
+    "spawn_rate": ""
   },
   "381": {
+    "name": "Latios",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Latios"
+    "spawn_rate": ""
   },
   "382": {
+    "name": "Kyogre",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kyogre"
+    "spawn_rate": ""
   },
   "383": {
+    "name": "Groudon",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Groudon"
+    "spawn_rate": ""
   },
   "384": {
+    "name": "Rayquaza",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Rayquaza"
+    "spawn_rate": ""
   },
   "385": {
+    "name": "Jirachi",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Jirachi"
+    "spawn_rate": ""
   },
   "386": {
+    "name": "Deoxys",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Deoxys"
+    "spawn_rate": ""
   },
   "387": {
+    "name": "Turtwig",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Turtwig"
+    "spawn_rate": ""
   },
   "388": {
+    "name": "Grotle",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Grotle"
+    "spawn_rate": ""
   },
   "389": {
+    "name": "Torterra",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Torterra"
+    "spawn_rate": ""
   },
   "390": {
+    "name": "Chimchar",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Chimchar"
+    "spawn_rate": ""
   },
   "391": {
+    "name": "Monferno",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Monferno"
+    "spawn_rate": ""
   },
   "392": {
+    "name": "Infernape",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Infernape"
+    "spawn_rate": ""
   },
   "393": {
+    "name": "Piplup",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Piplup"
+    "spawn_rate": ""
   },
   "394": {
+    "name": "Prinplup",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Prinplup"
+    "spawn_rate": ""
   },
   "395": {
+    "name": "Empoleon",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Empoleon"
+    "spawn_rate": ""
   },
   "396": {
+    "name": "Starly",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Starly"
+    "spawn_rate": ""
   },
   "397": {
+    "name": "Staravia",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Staravia"
+    "spawn_rate": ""
   },
   "398": {
+    "name": "Staraptor",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Staraptor"
+    "spawn_rate": ""
   },
   "399": {
+    "name": "Bidoof",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Bidoof"
+    "spawn_rate": ""
   },
   "400": {
+    "name": "Bibarel",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Bibarel"
+    "spawn_rate": ""
   },
   "401": {
+    "name": "Kricketot",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Kricketot"
+    "spawn_rate": ""
   },
   "402": {
+    "name": "Kricketune",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Kricketune"
+    "spawn_rate": ""
   },
   "403": {
+    "name": "Shinx",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Shinx"
+    "spawn_rate": ""
   },
   "404": {
+    "name": "Luxio",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Luxio"
+    "spawn_rate": ""
   },
   "405": {
+    "name": "Luxray",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Luxray"
+    "spawn_rate": ""
   },
   "406": {
+    "name": "Budew",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Budew"
+    "spawn_rate": ""
   },
   "407": {
+    "name": "Roserade",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Roserade"
+    "spawn_rate": ""
   },
   "408": {
+    "name": "Cranidos",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Cranidos"
+    "spawn_rate": ""
   },
   "409": {
+    "name": "Rampardos",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rampardos"
+    "spawn_rate": ""
   },
   "410": {
+    "name": "Shieldon",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Shieldon"
+    "spawn_rate": ""
   },
   "411": {
+    "name": "Bastiodon",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Bastiodon"
+    "spawn_rate": ""
   },
   "412": {
+    "name": "Burmy",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Burmy"
+    "spawn_rate": ""
+  },
+  "413": {
+    "name": "Wormadam",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "414": {
+    "name": "Mothim",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mothim"
+    "spawn_rate": ""
   },
   "415": {
+    "name": "Combee",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Combee"
+    "spawn_rate": ""
   },
   "416": {
+    "name": "Vespiquen",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Vespiquen"
+    "spawn_rate": ""
   },
   "417": {
+    "name": "Pachirisu",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Pachirisu"
+    "spawn_rate": ""
   },
   "418": {
+    "name": "Buizel",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Buizel"
+    "spawn_rate": ""
   },
   "419": {
+    "name": "Floatzel",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Floatzel"
+    "spawn_rate": ""
   },
   "420": {
+    "name": "Cherubi",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cherubi"
+    "spawn_rate": ""
   },
   "421": {
+    "name": "Cherrim",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cherrim"
+    "spawn_rate": ""
   },
   "422": {
+    "name": "Shellos",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Shellos"
+    "spawn_rate": ""
   },
   "423": {
+    "name": "Gastrodon",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Gastrodon"
+    "spawn_rate": ""
   },
   "424": {
+    "name": "Ambipom",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Ambipom"
+    "spawn_rate": ""
   },
   "425": {
+    "name": "Drifloon",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Drifloon"
+    "spawn_rate": ""
   },
   "426": {
+    "name": "Drifblim",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Drifblim"
+    "spawn_rate": ""
   },
   "427": {
+    "name": "Buneary",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Buneary"
+    "spawn_rate": ""
   },
   "428": {
+    "name": "Lopunny",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lopunny"
+    "spawn_rate": ""
   },
   "429": {
+    "name": "Mismagius",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Mismagius"
+    "spawn_rate": ""
   },
   "430": {
+    "name": "Honchkrow",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Honchkrow"
+    "spawn_rate": ""
   },
   "431": {
+    "name": "Glameow",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Glameow"
+    "spawn_rate": ""
   },
   "432": {
+    "name": "Purugly",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Purugly"
+    "spawn_rate": ""
   },
   "433": {
+    "name": "Chingling",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Chingling"
+    "spawn_rate": ""
   },
   "434": {
+    "name": "Stunky",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Stunky"
+    "spawn_rate": ""
   },
   "435": {
+    "name": "Skuntank",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Skuntank"
+    "spawn_rate": ""
   },
   "436": {
+    "name": "Bronzor",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Bronzor"
+    "spawn_rate": ""
   },
   "437": {
+    "name": "Bronzong",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Bronzong"
+    "spawn_rate": ""
   },
   "438": {
+    "name": "Bonsly",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Bonsly"
+    "spawn_rate": ""
   },
   "439": {
+    "name": "Mime Jr.",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mime Jr."
+    "spawn_rate": ""
   },
   "440": {
+    "name": "Happiny",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Happiny"
+    "spawn_rate": ""
   },
   "441": {
+    "name": "Chatot",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Chatot"
+    "spawn_rate": ""
   },
   "442": {
+    "name": "Spiritomb",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Spiritomb"
+    "spawn_rate": ""
   },
   "443": {
+    "name": "Gible",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Gible"
+    "spawn_rate": ""
   },
   "444": {
+    "name": "Gabite",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Gabite"
+    "spawn_rate": ""
   },
   "445": {
+    "name": "Garchomp",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Garchomp"
+    "spawn_rate": ""
   },
   "446": {
+    "name": "Munchlax",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Munchlax"
+    "spawn_rate": ""
   },
   "447": {
+    "name": "Riolu",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Riolu"
+    "spawn_rate": ""
   },
   "448": {
+    "name": "Lucario",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Lucario"
+    "spawn_rate": ""
   },
   "449": {
+    "name": "Hippopotas",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Hippopotas"
+    "spawn_rate": ""
   },
   "450": {
+    "name": "Hippowdon",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Hippowdon"
+    "spawn_rate": ""
   },
   "451": {
+    "name": "Skorupi",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Skorupi"
+    "spawn_rate": ""
   },
   "452": {
+    "name": "Drapion",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Drapion"
+    "spawn_rate": ""
   },
   "453": {
+    "name": "Croagunk",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Croagunk"
+    "spawn_rate": ""
   },
   "454": {
+    "name": "Toxicroak",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Toxicroak"
+    "spawn_rate": ""
   },
   "455": {
+    "name": "Carnivine",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Carnivine"
+    "spawn_rate": ""
   },
   "456": {
+    "name": "Finneon",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Finneon"
+    "spawn_rate": ""
   },
   "457": {
+    "name": "Lumineon",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Lumineon"
+    "spawn_rate": ""
   },
   "458": {
+    "name": "Mantyke",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mantyke"
+    "spawn_rate": ""
   },
   "459": {
+    "name": "Snover",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Snover"
+    "spawn_rate": ""
   },
   "460": {
+    "name": "Abomasnow",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Abomasnow"
+    "spawn_rate": ""
   },
   "461": {
+    "name": "Weavile",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Weavile"
+    "spawn_rate": ""
   },
   "462": {
+    "name": "Magnezone",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Magnezone"
+    "spawn_rate": ""
   },
   "463": {
+    "name": "Lickilicky",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lickilicky"
+    "spawn_rate": ""
   },
   "464": {
+    "name": "Rhyperior",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rhyperior"
+    "spawn_rate": ""
   },
   "465": {
+    "name": "Tangrowth",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Tangrowth"
+    "spawn_rate": ""
   },
   "466": {
+    "name": "Electivire",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electivire"
+    "spawn_rate": ""
   },
   "467": {
+    "name": "Magmortar",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Magmortar"
+    "spawn_rate": ""
   },
   "468": {
+    "name": "Togekiss",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Togekiss"
+    "spawn_rate": ""
   },
   "469": {
+    "name": "Yanmega",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Yanmega"
+    "spawn_rate": ""
   },
   "470": {
+    "name": "Leafeon",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Leafeon"
+    "spawn_rate": ""
   },
   "471": {
+    "name": "Glaceon",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Glaceon"
+    "spawn_rate": ""
   },
   "472": {
+    "name": "Gliscor",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Gliscor"
+    "spawn_rate": ""
   },
   "473": {
+    "name": "Mamoswine",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Mamoswine"
+    "spawn_rate": ""
   },
   "474": {
+    "name": "Porygon-Z",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Porygon-Z"
+    "spawn_rate": ""
   },
   "475": {
+    "name": "Gallade",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Gallade"
+    "spawn_rate": ""
   },
   "476": {
+    "name": "Probopass",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Probopass"
+    "spawn_rate": ""
   },
   "477": {
+    "name": "Dusknoir",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Dusknoir"
+    "spawn_rate": ""
   },
   "478": {
+    "name": "Froslass",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Froslass"
+    "spawn_rate": ""
   },
   "479": {
+    "name": "Rotom",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Rotom"
+    "spawn_rate": ""
   },
   "480": {
+    "name": "Uxie",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Uxie"
+    "spawn_rate": ""
   },
   "481": {
+    "name": "Mesprit",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Mesprit"
+    "spawn_rate": ""
   },
   "482": {
+    "name": "Azelf",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Azelf"
+    "spawn_rate": ""
   },
   "483": {
+    "name": "Dialga",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dialga"
+    "spawn_rate": ""
   },
   "484": {
+    "name": "Palkia",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Palkia"
+    "spawn_rate": ""
   },
   "485": {
+    "name": "Heatran",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Heatran"
+    "spawn_rate": ""
   },
   "486": {
+    "name": "Regigigas",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Regigigas"
+    "spawn_rate": ""
+  },
+  "487": {
+    "name": "Giratina",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "488": {
+    "name": "Cresselia",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Cresselia"
+    "spawn_rate": ""
   },
   "489": {
+    "name": "Phione",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Phione"
+    "spawn_rate": ""
   },
   "490": {
+    "name": "Manaphy",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Manaphy"
+    "spawn_rate": ""
   },
   "491": {
+    "name": "Darkrai",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Darkrai"
+    "spawn_rate": ""
+  },
+  "492": {
+    "name": "Shaymin",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "493": {
+    "name": "Arceus",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Arceus"
+    "spawn_rate": ""
   },
   "494": {
+    "name": "Victini",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Victini"
+    "spawn_rate": ""
   },
   "495": {
+    "name": "Snivy",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Snivy"
+    "spawn_rate": ""
   },
   "496": {
+    "name": "Servine",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Servine"
+    "spawn_rate": ""
   },
   "497": {
+    "name": "Serperior",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Serperior"
+    "spawn_rate": ""
   },
   "498": {
+    "name": "Tepig",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Tepig"
+    "spawn_rate": ""
   },
   "499": {
+    "name": "Pignite",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Pignite"
+    "spawn_rate": ""
   },
   "500": {
+    "name": "Emboar",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Emboar"
+    "spawn_rate": ""
   },
   "501": {
+    "name": "Oshawott",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Oshawott"
+    "spawn_rate": ""
   },
   "502": {
+    "name": "Dewott",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Dewott"
+    "spawn_rate": ""
   },
   "503": {
+    "name": "Samurott",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Samurott"
+    "spawn_rate": ""
   },
   "504": {
+    "name": "Patrat",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Patrat"
+    "spawn_rate": ""
   },
   "505": {
+    "name": "Watchog",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Watchog"
+    "spawn_rate": ""
   },
   "506": {
+    "name": "Lillipup",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lillipup"
+    "spawn_rate": ""
   },
   "507": {
+    "name": "Herdier",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Herdier"
+    "spawn_rate": ""
   },
   "508": {
+    "name": "Stoutland",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Stoutland"
+    "spawn_rate": ""
   },
   "509": {
+    "name": "Purrloin",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Purrloin"
+    "spawn_rate": ""
   },
   "510": {
+    "name": "Liepard",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Liepard"
+    "spawn_rate": ""
   },
   "511": {
+    "name": "Pansage",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Pansage"
+    "spawn_rate": ""
   },
   "512": {
+    "name": "Simisage",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Simisage"
+    "spawn_rate": ""
   },
   "513": {
+    "name": "Pansear",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Pansear"
+    "spawn_rate": ""
   },
   "514": {
+    "name": "Simisear",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Simisear"
+    "spawn_rate": ""
   },
   "515": {
+    "name": "Panpour",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Panpour"
+    "spawn_rate": ""
   },
   "516": {
+    "name": "Simipour",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Simipour"
+    "spawn_rate": ""
   },
   "517": {
+    "name": "Munna",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Munna"
+    "spawn_rate": ""
   },
   "518": {
+    "name": "Musharna",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Musharna"
+    "spawn_rate": ""
   },
   "519": {
+    "name": "Pidove",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidove"
+    "spawn_rate": ""
   },
   "520": {
+    "name": "Tranquill",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Tranquill"
+    "spawn_rate": ""
   },
   "521": {
+    "name": "Unfezant",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Unfezant"
+    "spawn_rate": ""
   },
   "522": {
+    "name": "Blitzle",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Blitzle"
+    "spawn_rate": ""
   },
   "523": {
+    "name": "Zebstrika",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Zebstrika"
+    "spawn_rate": ""
   },
   "524": {
+    "name": "Roggenrola",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Roggenrola"
+    "spawn_rate": ""
   },
   "525": {
+    "name": "Boldore",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Boldore"
+    "spawn_rate": ""
   },
   "526": {
+    "name": "Gigalith",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Gigalith"
+    "spawn_rate": ""
   },
   "527": {
+    "name": "Woobat",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Woobat"
+    "spawn_rate": ""
   },
   "528": {
+    "name": "Swoobat",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swoobat"
+    "spawn_rate": ""
   },
   "529": {
+    "name": "Drilbur",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Drilbur"
+    "spawn_rate": ""
   },
   "530": {
+    "name": "Excadrill",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Excadrill"
+    "spawn_rate": ""
   },
   "531": {
+    "name": "Audino",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Audino"
+    "spawn_rate": ""
   },
   "532": {
+    "name": "Timburr",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Timburr"
+    "spawn_rate": ""
   },
   "533": {
+    "name": "Gurdurr",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Gurdurr"
+    "spawn_rate": ""
   },
   "534": {
+    "name": "Conkeldurr",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Conkeldurr"
+    "spawn_rate": ""
   },
   "535": {
+    "name": "Tympole",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Tympole"
+    "spawn_rate": ""
   },
   "536": {
+    "name": "Palpitoad",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Palpitoad"
+    "spawn_rate": ""
   },
   "537": {
+    "name": "Seismitoad",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Seismitoad"
+    "spawn_rate": ""
   },
   "538": {
+    "name": "Throh",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Throh"
+    "spawn_rate": ""
   },
   "539": {
+    "name": "Sawk",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Sawk"
+    "spawn_rate": ""
   },
   "540": {
+    "name": "Sewaddle",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sewaddle"
+    "spawn_rate": ""
   },
   "541": {
+    "name": "Swadloon",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Swadloon"
+    "spawn_rate": ""
   },
   "542": {
+    "name": "Leavanny",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Leavanny"
+    "spawn_rate": ""
   },
   "543": {
+    "name": "Venipede",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venipede"
+    "spawn_rate": ""
   },
   "544": {
+    "name": "Whirlipede",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Whirlipede"
+    "spawn_rate": ""
   },
   "545": {
+    "name": "Scolipede",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Scolipede"
+    "spawn_rate": ""
   },
   "546": {
+    "name": "Cottonee",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Cottonee"
+    "spawn_rate": ""
   },
   "547": {
+    "name": "Whimsicott",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Whimsicott"
+    "spawn_rate": ""
   },
   "548": {
+    "name": "Petilil",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Petilil"
+    "spawn_rate": ""
   },
   "549": {
+    "name": "Lilligant",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lilligant"
+    "spawn_rate": ""
   },
   "550": {
+    "name": "Basculin",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Basculin"
+    "spawn_rate": ""
   },
   "551": {
+    "name": "Sandile",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Sandile"
+    "spawn_rate": ""
   },
   "552": {
+    "name": "Krokorok",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Krokorok"
+    "spawn_rate": ""
   },
   "553": {
+    "name": "Krookodile",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Krookodile"
+    "spawn_rate": ""
   },
   "554": {
+    "name": "Darumaka",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Darumaka"
+    "spawn_rate": ""
   },
   "555": {
+    "name": "Darmanitan",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Darmanitan"
+    "spawn_rate": ""
   },
   "556": {
+    "name": "Maractus",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Maractus"
+    "spawn_rate": ""
   },
   "557": {
+    "name": "Dwebble",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Dwebble"
+    "spawn_rate": ""
   },
   "558": {
+    "name": "Crustle",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Crustle"
+    "spawn_rate": ""
   },
   "559": {
+    "name": "Scraggy",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Scraggy"
+    "spawn_rate": ""
   },
   "560": {
+    "name": "Scrafty",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Scrafty"
+    "spawn_rate": ""
   },
   "561": {
+    "name": "Sigilyph",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Sigilyph"
+    "spawn_rate": ""
   },
   "562": {
+    "name": "Yamask",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Yamask"
+    "spawn_rate": ""
   },
   "563": {
+    "name": "Cofagrigus",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Cohagrigus"
+    "spawn_rate": ""
   },
   "564": {
+    "name": "Tirtouga",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Tirtouga"
+    "spawn_rate": ""
   },
   "565": {
+    "name": "Carracosta",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Carracosta"
+    "spawn_rate": ""
   },
   "566": {
+    "name": "Archen",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Archen"
+    "spawn_rate": ""
   },
   "567": {
+    "name": "Archeops",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Archeops"
+    "spawn_rate": ""
   },
   "568": {
+    "name": "Trubbish",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Trubbish"
+    "spawn_rate": ""
   },
   "569": {
+    "name": "Garbodor",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Garbodor"
+    "spawn_rate": ""
   },
   "570": {
+    "name": "Zorua",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Zorua"
+    "spawn_rate": ""
   },
   "571": {
+    "name": "Zoroark",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Zoroark"
+    "spawn_rate": ""
   },
   "572": {
+    "name": "Minccino",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Minccino"
+    "spawn_rate": ""
   },
   "573": {
+    "name": "Cinccino",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Cinccino"
+    "spawn_rate": ""
   },
   "574": {
+    "name": "Gothita",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Gothita"
+    "spawn_rate": ""
   },
   "575": {
+    "name": "Gothorita",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Gothorita"
+    "spawn_rate": ""
   },
   "576": {
+    "name": "Gothitelle",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Gothitelle"
+    "spawn_rate": ""
   },
   "577": {
+    "name": "Solosis",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Solosis"
+    "spawn_rate": ""
   },
   "578": {
+    "name": "Duosion",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Duosion"
+    "spawn_rate": ""
   },
   "579": {
+    "name": "Reuniclus",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Reuniclus"
+    "spawn_rate": ""
   },
   "580": {
+    "name": "Ducklett",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ducklett"
+    "spawn_rate": ""
   },
   "581": {
+    "name": "Swanna",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swanna"
+    "spawn_rate": ""
   },
   "582": {
+    "name": "Vanillite",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Vanillite"
+    "spawn_rate": ""
   },
   "583": {
+    "name": "Vanillish",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Vanillish"
+    "spawn_rate": ""
   },
   "584": {
+    "name": "Vanilluxe",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Vanilluxe"
+    "spawn_rate": ""
   },
   "585": {
+    "name": "Deerling",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Deerling"
+    "spawn_rate": ""
   },
   "586": {
+    "name": "Sawsbuck",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sawsbuck"
+    "spawn_rate": ""
   },
   "587": {
+    "name": "Emolga",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Emolga"
+    "spawn_rate": ""
   },
   "588": {
+    "name": "Karrablast",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Karrablast"
+    "spawn_rate": ""
   },
   "589": {
+    "name": "Escavalier",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Escavalier"
+    "spawn_rate": ""
   },
   "590": {
+    "name": "Foongus",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Foongus"
+    "spawn_rate": ""
   },
   "591": {
+    "name": "Amoonguss",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Amoonguss"
+    "spawn_rate": ""
   },
   "592": {
+    "name": "Frillish",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Frillish"
+    "spawn_rate": ""
   },
   "593": {
+    "name": "Jellicent",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Jellicent"
+    "spawn_rate": ""
   },
   "594": {
+    "name": "Alomomola",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Alomomola"
+    "spawn_rate": ""
   },
   "595": {
+    "name": "Joltik",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Joltik"
+    "spawn_rate": ""
   },
   "596": {
+    "name": "Galvantula",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Galvantula"
+    "spawn_rate": ""
   },
   "597": {
+    "name": "Ferroseed",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Ferroseed"
+    "spawn_rate": ""
   },
   "598": {
+    "name": "Ferrothorn",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Ferrothorn"
+    "spawn_rate": ""
   },
   "599": {
+    "name": "Klink",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Klink"
+    "spawn_rate": ""
   },
   "600": {
+    "name": "Klang",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Klang"
+    "spawn_rate": ""
   },
   "601": {
+    "name": "Klinklang",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Klinklang"
+    "spawn_rate": ""
   },
   "602": {
+    "name": "Tynamo",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Tynamo"
+    "spawn_rate": ""
   },
   "603": {
+    "name": "Eelektrik",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Eelektrik"
+    "spawn_rate": ""
   },
   "604": {
+    "name": "Eelektross",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Eelektross"
+    "spawn_rate": ""
   },
   "605": {
+    "name": "Elgyem",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Elgyem"
+    "spawn_rate": ""
   },
   "606": {
+    "name": "Beheeyem",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Beheeyem"
+    "spawn_rate": ""
   },
   "607": {
+    "name": "Litwick",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Litwick"
+    "spawn_rate": ""
   },
   "608": {
+    "name": "Lampent",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Lampent"
+    "spawn_rate": ""
   },
   "609": {
+    "name": "Chandelure",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Chandelure"
+    "spawn_rate": ""
   },
   "610": {
+    "name": "Axew",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Axew"
+    "spawn_rate": ""
   },
   "611": {
+    "name": "Fraxure",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Fraxure"
+    "spawn_rate": ""
   },
   "612": {
+    "name": "Haxorus",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Haxorus"
+    "spawn_rate": ""
   },
   "613": {
+    "name": "Cubchoo",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Cubchoo"
+    "spawn_rate": ""
   },
   "614": {
+    "name": "Beartic",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Beartic"
+    "spawn_rate": ""
   },
   "615": {
+    "name": "Cryogonal",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Cryogonal"
+    "spawn_rate": ""
   },
   "616": {
+    "name": "Shelmet",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Shelmet"
+    "spawn_rate": ""
   },
   "617": {
+    "name": "Accelgor",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Accelgor"
+    "spawn_rate": ""
   },
   "618": {
+    "name": "Stunfisk",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Stunfisk"
+    "spawn_rate": ""
   },
   "619": {
+    "name": "Mienfoo",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Mienfoo"
+    "spawn_rate": ""
   },
   "620": {
+    "name": "Mienshao",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Mienshao"
+    "spawn_rate": ""
   },
   "621": {
+    "name": "Druddigon",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Druddigon"
+    "spawn_rate": ""
   },
   "622": {
+    "name": "Golett",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Golett"
+    "spawn_rate": ""
   },
   "623": {
+    "name": "Golurk",
+    "rarity": "",
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Golurk"
+    "spawn_rate": ""
   },
   "624": {
+    "name": "Pawniard",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Pawniard"
+    "spawn_rate": ""
   },
   "625": {
+    "name": "Bisharp",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Bisharp"
+    "spawn_rate": ""
   },
   "626": {
+    "name": "Bouffalant",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Bouffalant"
+    "spawn_rate": ""
   },
   "627": {
+    "name": "Rufflet",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Rufflet"
+    "spawn_rate": ""
   },
   "628": {
+    "name": "Braviary",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Braviary"
+    "spawn_rate": ""
   },
   "629": {
+    "name": "Vullaby",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Vullaby"
+    "spawn_rate": ""
   },
   "630": {
+    "name": "Mandibuzz",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mandibuzz"
+    "spawn_rate": ""
   },
   "631": {
+    "name": "Heatmor",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Heatmor"
+    "spawn_rate": ""
   },
   "632": {
+    "name": "Durant",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Durant"
+    "spawn_rate": ""
   },
   "633": {
+    "name": "Deino",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Deino"
+    "spawn_rate": ""
   },
   "634": {
+    "name": "Zweilous",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Zweilous"
+    "spawn_rate": ""
   },
   "635": {
+    "name": "Hydreigon",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Hydreigon"
+    "spawn_rate": ""
   },
   "636": {
+    "name": "Larvesta",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Larvesta"
+    "spawn_rate": ""
   },
   "637": {
+    "name": "Volcarona",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Volcarona"
+    "spawn_rate": ""
   },
   "638": {
+    "name": "Cobalion",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Cobalion"
+    "spawn_rate": ""
   },
   "639": {
+    "name": "Terrakion",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Terrakion"
+    "spawn_rate": ""
   },
   "640": {
+    "name": "Virizion",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Virizion"
+    "spawn_rate": ""
+  },
+  "641": {
+    "name": "Tornadus",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
+  },
+  "642": {
+    "name": "Thundurus",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "643": {
+    "name": "Reshiram",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Reshiram"
+    "spawn_rate": ""
   },
   "644": {
+    "name": "Zekrom",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Zekrom"
+    "spawn_rate": ""
+  },
+  "645": {
+    "name": "Landorus",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "646": {
+    "name": "Kyurem",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Kyurem"
+    "spawn_rate": ""
   },
   "647": {
+    "name": "Keldeo",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Keldeo"
+    "spawn_rate": ""
+  },
+  "648": {
+    "name": "Meloetta",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "649": {
+    "name": "Genesect",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Genesect"
+    "spawn_rate": ""
   },
   "650": {
+    "name": "Chespin",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Chespin"
+    "spawn_rate": ""
   },
   "651": {
+    "name": "Quilladin",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Quilladin"
+    "spawn_rate": ""
   },
   "652": {
+    "name": "Chesnaught",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Chesnaught"
+    "spawn_rate": ""
   },
   "653": {
+    "name": "Fennekin",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Fennekin"
+    "spawn_rate": ""
   },
   "654": {
+    "name": "Braixen",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Braixen"
+    "spawn_rate": ""
   },
   "655": {
+    "name": "Delphox",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Delphox"
+    "spawn_rate": ""
   },
   "656": {
+    "name": "Froakie",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Froakie"
+    "spawn_rate": ""
   },
   "657": {
+    "name": "Frogadier",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Frogadier"
+    "spawn_rate": ""
   },
   "658": {
+    "name": "Greninja",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Greninja"
+    "spawn_rate": ""
   },
   "659": {
+    "name": "Bunnelby",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Bunnelby"
+    "spawn_rate": ""
   },
   "660": {
+    "name": "Diggersby",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Diggersby"
+    "spawn_rate": ""
   },
   "661": {
+    "name": "Fletchling",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Fletchling"
+    "spawn_rate": ""
   },
   "662": {
+    "name": "Fletchinder",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Fletchinder"
+    "spawn_rate": ""
   },
   "663": {
+    "name": "Talonflame",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Talonflame"
+    "spawn_rate": ""
   },
   "664": {
+    "name": "Scatterbug",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Scatterbug"
+    "spawn_rate": ""
   },
   "665": {
+    "name": "Spewpa",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Spewpa"
+    "spawn_rate": ""
   },
   "666": {
+    "name": "Vivillon",
+    "rarity": "",
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Vivillon"
+    "spawn_rate": ""
   },
   "667": {
+    "name": "Litleo",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Litleo"
+    "spawn_rate": ""
   },
   "668": {
+    "name": "Pyroar",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Pyroar"
+    "spawn_rate": ""
   },
   "669": {
+    "name": "Flabébé",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Flabébé"
+    "spawn_rate": ""
   },
   "670": {
+    "name": "Floette",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Floette"
+    "spawn_rate": ""
   },
   "671": {
+    "name": "Florges",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Florges"
+    "spawn_rate": ""
   },
   "672": {
+    "name": "Skiddo",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Skiddo"
+    "spawn_rate": ""
   },
   "673": {
+    "name": "Gogoat",
+    "rarity": "",
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Gogoat"
+    "spawn_rate": ""
   },
   "674": {
+    "name": "Pancham",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Pancham"
+    "spawn_rate": ""
   },
   "675": {
+    "name": "Pangoro",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Pangoro"
+    "spawn_rate": ""
   },
   "676": {
+    "name": "Furfrou",
+    "rarity": "",
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Furfrou"
+    "spawn_rate": ""
   },
   "677": {
+    "name": "Espurr",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Espurr"
+    "spawn_rate": ""
   },
   "678": {
+    "name": "Meowstic",
+    "rarity": "",
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Meowstic"
+    "spawn_rate": ""
   },
   "679": {
+    "name": "Honedge",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Honedge"
+    "spawn_rate": ""
   },
   "680": {
+    "name": "Doublade",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Doublade"
+    "spawn_rate": ""
+  },
+  "681": {
+    "name": "Aegislash",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "682": {
+    "name": "Spritzee",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Spritzee"
+    "spawn_rate": ""
   },
   "683": {
+    "name": "Aromatisse",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Aromatisse"
+    "spawn_rate": ""
   },
   "684": {
+    "name": "Swirlix",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Swirlix"
+    "spawn_rate": ""
   },
   "685": {
+    "name": "Slurpuff",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Slurpuff"
+    "spawn_rate": ""
   },
   "686": {
+    "name": "Inkay",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Inkay"
+    "spawn_rate": ""
   },
   "687": {
+    "name": "Malamar",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Malamar"
+    "spawn_rate": ""
   },
   "688": {
+    "name": "Binacle",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Binacle"
+    "spawn_rate": ""
   },
   "689": {
+    "name": "Barbaracle",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Barbaracle"
+    "spawn_rate": ""
   },
   "690": {
+    "name": "Skrelp",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Skrelp"
+    "spawn_rate": ""
   },
   "691": {
+    "name": "Dragalge",
+    "rarity": "",
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dragalge"
+    "spawn_rate": ""
   },
   "692": {
+    "name": "Clauncher",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Clauncher"
+    "spawn_rate": ""
   },
   "693": {
+    "name": "Clawitzer",
+    "rarity": "",
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Clawitzer"
+    "spawn_rate": ""
   },
   "694": {
+    "name": "Helioptile",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Helioptile"
+    "spawn_rate": ""
   },
   "695": {
+    "name": "Heliolisk",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Heliolisk"
+    "spawn_rate": ""
   },
   "696": {
+    "name": "Tyrunt",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Tyrunt"
+    "spawn_rate": ""
   },
   "697": {
+    "name": "Tyrantrum",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Tyrantrum"
+    "spawn_rate": ""
   },
   "698": {
+    "name": "Amaura",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Amaura"
+    "spawn_rate": ""
   },
   "699": {
+    "name": "Aurorus",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Aurorus"
+    "spawn_rate": ""
   },
   "700": {
+    "name": "Sylveon",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Sylveon"
+    "spawn_rate": ""
   },
   "701": {
+    "name": "Hawlucha",
+    "rarity": "",
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Hawlucha"
+    "spawn_rate": ""
   },
   "702": {
+    "name": "Dedenne",
+    "rarity": "",
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Dedenne"
+    "spawn_rate": ""
   },
   "703": {
+    "name": "Carbink",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Carbink"
+    "spawn_rate": ""
   },
   "704": {
+    "name": "Goomy",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Goomy"
+    "spawn_rate": ""
   },
   "705": {
+    "name": "Sliggoo",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Sliggoo"
+    "spawn_rate": ""
   },
   "706": {
+    "name": "Goodra",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Goodra"
+    "spawn_rate": ""
   },
   "707": {
+    "name": "Klefki",
+    "rarity": "",
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Klefki"
+    "spawn_rate": ""
   },
   "708": {
+    "name": "Phantump",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Phantump"
+    "spawn_rate": ""
   },
   "709": {
+    "name": "Trevenant",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Trevenant"
+    "spawn_rate": ""
   },
   "710": {
+    "name": "Pumpkaboo",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Pumpkaboo"
+    "spawn_rate": ""
   },
   "711": {
+    "name": "Gourgeist",
+    "rarity": "",
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Gourgeist"
+    "spawn_rate": ""
   },
   "712": {
+    "name": "Bergmite",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Bergmite"
+    "spawn_rate": ""
   },
   "713": {
+    "name": "Avalugg",
+    "rarity": "",
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Avalugg"
+    "spawn_rate": ""
   },
   "714": {
+    "name": "Noibat",
+    "rarity": "",
     "types": [
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Noibat"
+    "spawn_rate": ""
   },
   "715": {
+    "name": "Noivern",
+    "rarity": "",
     "types": [
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Noivern"
+    "spawn_rate": ""
   },
   "716": {
+    "name": "Xerneas",
+    "rarity": "",
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Xerneas"
+    "spawn_rate": ""
   },
   "717": {
+    "name": "Yveltal",
+    "rarity": "",
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Yveltal"
+    "spawn_rate": ""
   },
   "718": {
+    "name": "Zygarde",
+    "rarity": "",
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Zygarde"
+    "spawn_rate": ""
   },
   "719": {
+    "name": "Diancie",
+    "rarity": "",
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Diancie"
+    "spawn_rate": ""
+  },
+  "720": {
+    "name": "Hoopa",
+    "rarity": "",
+    "types": [
+
+    ],
+    "spawn_rate": ""
   },
   "721": {
+    "name": "Volcanion",
+    "rarity": "",
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Volcanion"
-  },
-  "722": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Rowlet"
-  },
-  "723": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Dartrix"
-  },
-  "724": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      }
-    ],
-    "name": "Decidueye"
-  },
-  "725": {
-    "types": [
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      }
-    ],
-    "name": "Litten"
-  },
-  "726": {
-    "types": [
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      }
-    ],
-    "name": "Torracat"
-  },
-  "727": {
-    "types": [
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      },
-      {
-      "type": "Dark",
-      "color": "#707070"
-      }
-    ],
-    "name": "Incineroar"
-  },
-  "728": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Popplio"
-  },
-  "729": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Brionne"
-  },
-  "730": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Primarina"
-  },
-  "731": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Pikipek"
-  },
-  "732": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Trumbeak"
-  },
-  "733": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Toucannon"
-  },
-  "734": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      }
-    ],
-    "name": "Yungoos"
-  },
-  "735": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      }
-    ],
-    "name": "Gumshoos"
-  },
-  "736": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      }
-    ],
-    "name": "Grubbin"
-  },
-  "737": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Electric",
-      "color": "#f8d030"
-      }
-    ],
-    "name": "Charjabug"
-  },
-  "738": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Electric",
-      "color": "#f8d030"
-      }
-    ],
-    "name": "Vikavolt"
-  },
-  "739": {
-    "types": [
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Crabrawler"
-  },
-  "740": {
-    "types": [
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      },
-      {
-      "type": "Ice",
-      "color": "#98d8d8"
-      }
-    ],
-    "name": "Crabominable"
-  },
-  "741": {
-    "types": [
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Oricorio"
-  },
-  "742": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Cutiefly"
-  },
-  "743": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Ribombee"
-  },
-  "744": {
-    "types": [
-      {
-      "type": "Rock",
-      "color": "#b8a038"
-      }
-    ],
-    "name": "Rockruff"
-  },
-  "745": {
-    "types": [
-      {
-      "type": "Rock",
-      "color": "#b8a038"
-      }
-    ],
-    "name": "Lycanroc"
-  },
-  "746": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Wishiwashi"
-  },
-  "747": {
-    "types": [
-      {
-      "type": "Poison",
-      "color": "#a040a0"
-      },
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Mareanie"
-  },
-  "748": {
-    "types": [
-      {
-      "type": "Poison",
-      "color": "#a040a0"
-      },
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Toxapex"
-  },
-  "749": {
-    "types": [
-      {
-      "type": "Ground",
-      "color": "#e0c068"
-      }
-    ],
-    "name": "Mudbray"
-  },
-  "750": {
-    "types": [
-      {
-      "type": "Ground",
-      "color": "#e0c068"
-      }
-    ],
-    "name": "Mudsdale"
-  },
-  "751": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      },
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      }
-    ],
-    "name": "Dewpider"
-  },
-  "752": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      },
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      }
-    ],
-    "name": "Araquanid"
-  },
-  "753": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      }
-    ],
-    "name": "Fomantis"
-  },
-  "754": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      }
-    ],
-    "name": "Lurantis"
-  },
-  "755": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Morelull"
-  },
-  "756": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Shiinotic"
-  },
-  "757": {
-    "types": [
-      {
-      "type": "Poison",
-      "color": "#a040a0"
-      },
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      }
-    ],
-    "name": "Salandit"
-  },
-  "758": {
-    "types": [
-      {
-      "type": "Poison",
-      "color": "#a040a0"
-      },
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      }
-    ],
-    "name": "Salazzle"
-  },
-  "759": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Stufful"
-  },
-  "760": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Bewear"
-  },
-  "761": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      }
-    ],
-    "name": "Bounsweet"
-  },
-  "762": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      }
-    ],
-    "name": "Steenee"
-  },
-  "763": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      }
-    ],
-    "name": "Tsareena"
-  },
-  "764": {
-    "types": [
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Comfey"
-  },
-  "765": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      }
-    ],
-    "name": "Oranguru"
-  },
-  "766": {
-    "types": [
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Passimian"
-  },
-  "767": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Wimpod"
-  },
-  "768": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Golisopod"
-  },
-  "769": {
-    "types": [
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      },
-      {
-      "type": "Ground",
-      "color": "#e0c068"
-      }
-    ],
-    "name": "Sandygast"
-  },
-  "770": {
-    "types": [
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      },
-      {
-      "type": "Ground",
-      "color": "#e0c068"
-      }
-    ],
-    "name": "Palossand"
-  },
-  "771": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      }
-    ],
-    "name": "Pyukumuku"
-  },
-  "772": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      }
-    ],
-    "name": "Type: Null"
-  },
-  "773": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      }
-    ],
-    "name": "Silvally"
-  },
-  "774": {
-    "types": [
-      {
-      "type": "Rock",
-      "color": "#b8a038"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Minior (Core)"
-  },
-  "775": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      }
-    ],
-    "name": "Komala"
-  },
-  "776": {
-    "types": [
-      {
-      "type": "Fire",
-      "color": "#f08030"
-      },
-      {
-      "type": "Dragon",
-      "color": "#7038f8"
-      }
-    ],
-    "name": "Turtonator"
-  },
-  "777": {
-    "types": [
-      {
-      "type": "Electric",
-      "color": "#f8d030"
-      },
-      {
-      "type": "Steel",
-      "color": "#b8b8d0"
-      }
-    ],
-    "name": "Togedemaru"
-  },
-  "778": {
-    "types": [
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Mimikyu"
-  },
-  "779": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      },
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      }
-    ],
-    "name": "Bruxish"
-  },
-  "780": {
-    "types": [
-      {
-      "type": "Normal",
-      "color": "#8a8a59"
-      },
-      {
-      "type": "Dragon",
-      "color": "#7038f8"
-      }
-    ],
-    "name": "Drampa"
-  },
-  "781": {
-    "types": [
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      },
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      }
-    ],
-    "name": "Dhelmise"
-  },
-  "782": {
-    "types": [
-      {
-      "type": "Dragon",
-      "color": "#7038f8"
-      }
-    ],
-    "name": "Jangmo-o"
-  },
-  "783": {
-    "types": [
-      {
-      "type": "Dragon",
-      "color": "#7038f8"
-      },
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Hakamo-o"
-  },
-  "784": {
-    "types": [
-      {
-      "type": "Dragon",
-      "color": "#7038f8"
-      },
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Kommo-o"
-  },
-  "785": {
-    "types": [
-      {
-      "type": "Electric",
-      "color": "#f8d030"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Tapu Koko"
-  },
-  "786": {
-    "types": [
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Tapu Lele"
-  },
-  "787": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Tapu Bulu"
-  },
-  "788": {
-    "types": [
-      {
-      "type": "Water",
-      "color": "#6890f0"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Tapu Fini"
-  },
-  "789": {
-    "types": [
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      }
-    ],
-    "name": "Cosmog"
-  },
-  "790": {
-    "types": [
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      }
-    ],
-    "name": "Cosmoem"
-  },
-  "791": {
-    "types": [
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      },
-      {
-      "type": "Steel",
-      "color": "#b8b8d0"
-      }
-    ],
-    "name": "Solgaleo"
-  },
-  "792": {
-    "types": [
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      },
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      }
-    ],
-    "name": "Lunala"
-  },
-  "793": {
-    "types": [
-      {
-      "type": "Rock",
-      "color": "#b8a038"
-      },
-      {
-      "type": "Poison",
-      "color": "#a040a0"
-      }
-    ],
-    "name": "Nihilego"
-  },
-  "794": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Buzzwole"
-  },
-  "795": {
-    "types": [
-      {
-      "type": "Bug",
-      "color": "#a8b820"
-      },
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      }
-    ],
-    "name": "Pheromosa"
-  },
-  "796": {
-    "types": [
-      {
-      "type": "Electric",
-      "color": "#f8d030"
-      }
-    ],
-    "name": "Xurkitree"
-  },
-  "797": {
-    "types": [
-      {
-      "type": "Steel",
-      "color": "#b8b8d0"
-      },
-      {
-      "type": "Flying",
-      "color": "#a890f0"
-      }
-    ],
-    "name": "Celesteela"
-  },
-  "798": {
-    "types": [
-      {
-      "type": "Grass",
-      "color": "#78c850"
-      },
-      {
-      "type": "Steel",
-      "color": "#b8b8d0"
-      }
-    ],
-    "name": "Kartana"
-  },
-  "799": {
-    "types": [
-      {
-      "type": "Dark",
-      "color": "#707070"
-      },
-      {
-      "type": "Dragon",
-      "color": "#7038f8"
-      }
-    ],
-    "name": "Guzzlord"
-  },
-  "800": {
-    "types": [
-      {
-      "type": "Psychic",
-      "color": "#f85888"
-      }
-    ],
-    "name": "Necrozma"
-  },
-  "801": {
-    "types": [
-      {
-      "type": "Steel",
-      "color": "#b8b8d0"
-      },
-      {
-      "type": "Fairy",
-      "color": "#e898e8"
-      }
-    ],
-    "name": "Magearna"
-  },
-  "802": {
-    "types": [
-      {
-      "type": "Fighting",
-      "color": "#c03028"
-      },
-      {
-      "type": "Ghost",
-      "color": "#705898"
-      }
-    ],
-    "name": "Marshadow"
+    "spawn_rate": ""
   }
 }

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -5311,7 +5311,14 @@
     "name": "Wormadam",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Bug",
+        "color": "#a8b820"
+      },
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
     ],
     "spawn_rate": ""
   },
@@ -6278,7 +6285,14 @@
     "name": "Giratina",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      },
+      {
+        "type": "Dragon",
+        "color": "#7038f8"
+      }
     ],
     "spawn_rate": ""
   },
@@ -6330,7 +6344,10 @@
     "name": "Shaymin",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Grass",
+        "color": "#78c850"
+      }
     ],
     "spawn_rate": ""
   },
@@ -8230,7 +8247,10 @@
     "name": "Tornadus",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      }
     ],
     "spawn_rate": ""
   },
@@ -8238,7 +8258,14 @@
     "name": "Thundurus",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Electric",
+        "color": "#f8d030"
+      },
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      }
     ],
     "spawn_rate": ""
   },
@@ -8276,7 +8303,14 @@
     "name": "Landorus",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Ground",
+        "color": "#e0c068"
+      },
+      {
+        "type": "Flying",
+        "color": "#a890f0"
+      }
     ],
     "spawn_rate": ""
   },
@@ -8314,7 +8348,14 @@
     "name": "Meloetta",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Normal",
+        "color": "#8a8a59"
+      },
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      }
     ],
     "spawn_rate": ""
   },
@@ -8730,7 +8771,14 @@
     "name": "Aegislash",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Steel",
+        "color": "#b8b8d0"
+      },
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
     ],
     "spawn_rate": ""
   },
@@ -9256,7 +9304,14 @@
     "name": "Hoopa",
     "rarity": "",
     "types": [
-
+      {
+        "type": "Psychic",
+        "color": "#f85888"
+      },
+      {
+        "type": "Ghost",
+        "color": "#705898"
+      }
     ],
     "spawn_rate": ""
   },

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -1,6047 +1,8719 @@
 {
   "1": {
-    "name": "Bulbasaur",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "61"
+    "name": "Bulbasaur"
   },
   "2": {
-    "name": "Ivysaur",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "421"
+    "name": "Ivysaur"
   },
   "3": {
-    "name": "Venusaur",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "641"
+    "name": "Venusaur"
   },
   "4": {
-    "name": "Charmander",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "119"
+    "name": "Charmander"
   },
   "5": {
-    "name": "Charmeleon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1025"
+    "name": "Charmeleon"
   },
   "6": {
-    "name": "Charizard",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Charizard"
   },
   "7": {
-    "name": "Squirtle",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "65"
+    "name": "Squirtle"
   },
   "8": {
-    "name": "Wartortle",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "484"
+    "name": "Wartortle"
   },
   "9": {
-    "name": "Blastoise",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "843"
+    "name": "Blastoise"
   },
   "10": {
-    "name": "Caterpie",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "51"
+    "name": "Caterpie"
   },
   "11": {
-    "name": "Metapod",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "433"
+    "name": "Metapod"
   },
   "12": {
-    "name": "Butterfree",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "843"
+    "name": "Butterfree"
   },
   "13": {
-    "name": "Weedle",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "21"
+    "name": "Weedle"
   },
   "14": {
-    "name": "Kakuna",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "204"
+    "name": "Kakuna"
   },
   "15": {
-    "name": "Beedrill",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "377"
+    "name": "Beedrill"
   },
   "16": {
-    "name": "Pidgey",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "10"
+    "name": "Pidgey"
   },
   "17": {
-    "name": "Pidgeotto",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "75"
+    "name": "Pidgeotto"
   },
   "18": {
-    "name": "Pidgeot",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "203"
+    "name": "Pidgeot"
   },
   "19": {
-    "name": "Rattata",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "13"
+    "name": "Rattata"
   },
   "20": {
-    "name": "Raticate",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "159"
+    "name": "Raticate"
   },
   "21": {
-    "name": "Spearow",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "31"
+    "name": "Spearow"
   },
   "22": {
-    "name": "Fearow",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "221"
+    "name": "Fearow"
   },
   "23": {
-    "name": "Ekans",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "75"
+    "name": "Ekans"
   },
   "24": {
-    "name": "Arbok",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "544"
+    "name": "Arbok"
   },
   "25": {
-    "name": "Pikachu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "92"
+    "name": "Pikachu"
   },
   "26": {
-    "name": "Raichu",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Raichu"
   },
   "27": {
-    "name": "Sandshrew",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "163"
+    "name": "Sandshrew"
   },
   "28": {
-    "name": "Sandslash",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1619"
+    "name": "Sandslash"
   },
   "29": {
-    "name": "Nidoran♀",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Nidoran♀"
   },
   "30": {
-    "name": "Nidorina",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "504"
+    "name": "Nidorina"
   },
   "31": {
-    "name": "Nidoqueen",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1398"
+    "name": "Nidoqueen"
   },
   "32": {
-    "name": "Nidoran♂",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Nidoran♂"
   },
   "33": {
-    "name": "Nidorino",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "586"
+    "name": "Nidorino"
   },
   "34": {
-    "name": "Nidoking",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1025"
+    "name": "Nidoking"
   },
   "35": {
-    "name": "Clefairy",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "85"
+    "name": "Clefairy"
   },
   "36": {
-    "name": "Clefable",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "1309"
+    "name": "Clefable"
   },
   "37": {
-    "name": "Vulpix",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "188"
+    "name": "Vulpix"
   },
   "38": {
-    "name": "Ninetales",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1538"
+    "name": "Ninetales"
   },
   "39": {
-    "name": "Jigglypuff",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "101"
+    "name": "Jigglypuff"
   },
   "40": {
-    "name": "Wigglytuff",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Wigglytuff"
   },
   "41": {
-    "name": "Zubat",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "24"
+    "name": "Zubat"
   },
   "42": {
-    "name": "Golbat",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "209"
+    "name": "Golbat"
   },
   "43": {
-    "name": "Oddish",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "91"
+    "name": "Oddish"
   },
   "44": {
-    "name": "Gloom",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "592"
+    "name": "Gloom"
   },
   "45": {
-    "name": "Vileplume",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1864"
+    "name": "Vileplume"
   },
   "46": {
-    "name": "Paras",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "44"
+    "name": "Paras"
   },
   "47": {
-    "name": "Parasect",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "397"
+    "name": "Parasect"
   },
   "48": {
-    "name": "Venonat",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "38"
+    "name": "Venonat"
   },
   "49": {
-    "name": "Venomoth",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "300"
+    "name": "Venomoth"
   },
   "50": {
-    "name": "Diglett",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "211"
+    "name": "Diglett"
   },
   "51": {
-    "name": "Dugtrio",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1663"
+    "name": "Dugtrio"
   },
   "52": {
-    "name": "Meowth",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "106"
+    "name": "Meowth"
   },
   "53": {
-    "name": "Persian",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "1282"
+    "name": "Persian"
   },
   "54": {
-    "name": "Psyduck",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "108"
+    "name": "Psyduck"
   },
   "55": {
-    "name": "Golduck",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "707"
+    "name": "Golduck"
   },
   "56": {
-    "name": "Mankey",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "114"
+    "name": "Mankey"
   },
   "57": {
-    "name": "Primeape",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1061"
+    "name": "Primeape"
   },
   "58": {
-    "name": "Growlithe",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Growlithe"
   },
   "59": {
-    "name": "Arcanine",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "932"
+    "name": "Arcanine"
   },
   "60": {
-    "name": "Poliwag",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "95"
+    "name": "Poliwag"
   },
   "61": {
-    "name": "Poliwhirl",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "481"
+    "name": "Poliwhirl"
   },
   "62": {
-    "name": "Poliwrath",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1709"
+    "name": "Poliwrath"
   },
   "63": {
-    "name": "Abra",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "104"
+    "name": "Abra"
   },
   "64": {
-    "name": "Kadabra",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "779"
+    "name": "Kadabra"
   },
   "65": {
-    "name": "Alakazam",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "2461"
+    "name": "Alakazam"
   },
   "66": {
-    "name": "Machop",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "217"
+    "name": "Machop"
   },
   "67": {
-    "name": "Machoke",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1465"
+    "name": "Machoke"
   },
   "68": {
-    "name": "Machamp",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "3418"
+    "name": "Machamp"
   },
   "69": {
-    "name": "Bellsprout",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "86"
+    "name": "Bellsprout"
   },
   "70": {
-    "name": "Weepinbell",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "496"
+    "name": "Weepinbell"
   },
   "71": {
-    "name": "Victreebel",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Victreebel"
   },
   "72": {
-    "name": "Tentacool",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "275"
+    "name": "Tentacool"
   },
   "73": {
-    "name": "Tentacruel",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "615"
+    "name": "Tentacruel"
   },
   "74": {
-    "name": "Geodude",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "121"
+    "name": "Geodude"
   },
   "75": {
-    "name": "Graveler",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "707"
+    "name": "Graveler"
   },
   "76": {
-    "name": "Golem",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "2797"
+    "name": "Golem"
   },
   "77": {
-    "name": "Ponyta",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "121"
+    "name": "Ponyta"
   },
   "78": {
-    "name": "Rapidash",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "992"
+    "name": "Rapidash"
   },
   "79": {
-    "name": "Slowpoke",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "175"
+    "name": "Slowpoke"
   },
   "80": {
-    "name": "Slowbro",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "947"
+    "name": "Slowbro"
   },
   "81": {
-    "name": "Magnemite",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": "200"
+    "name": "Magnemite"
   },
   "82": {
-    "name": "Magneton",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Magneton"
   },
   "83": {
-    "name": "Farfetch'd",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "61527"
+    "name": "Farfetch'd"
   },
   "84": {
-    "name": "Doduo",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Doduo"
   },
   "85": {
-    "name": "Dodrio",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "634"
+    "name": "Dodrio"
   },
   "86": {
-    "name": "Seel",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "196"
+    "name": "Seel"
   },
   "87": {
-    "name": "Dewgong",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1578"
+    "name": "Dewgong"
   },
   "88": {
-    "name": "Grimer",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Grimer"
   },
   "89": {
-    "name": "Muk",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "7691"
+    "name": "Muk"
   },
   "90": {
-    "name": "Shellder",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "177"
+    "name": "Shellder"
   },
   "91": {
-    "name": "Cloyster",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1578"
+    "name": "Cloyster"
   },
   "92": {
-    "name": "Gastly",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Gastly"
   },
   "93": {
-    "name": "Haunter",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "419"
+    "name": "Haunter"
   },
   "94": {
-    "name": "Gengar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1758"
+    "name": "Gengar"
   },
   "95": {
-    "name": "Onix",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "269"
+    "name": "Onix"
   },
   "96": {
-    "name": "Drowzee",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "39"
+    "name": "Drowzee"
   },
   "97": {
-    "name": "Hypno",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "322"
+    "name": "Hypno"
   },
   "98": {
-    "name": "Krabby",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "73"
+    "name": "Krabby"
   },
   "99": {
-    "name": "Kingler",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "530"
+    "name": "Kingler"
   },
   "100": {
-    "name": "Voltorb",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "276"
+    "name": "Voltorb"
   },
   "101": {
-    "name": "Electrode",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "1985"
+    "name": "Electrode"
   },
   "102": {
-    "name": "Exeggcute",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "123"
+    "name": "Exeggcute"
   },
   "103": {
-    "name": "Exeggutor",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "1231"
+    "name": "Exeggutor"
   },
   "104": {
-    "name": "Cubone",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "163"
+    "name": "Cubone"
   },
   "105": {
-    "name": "Marowak",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1431"
+    "name": "Marowak"
   },
   "106": {
-    "name": "Hitmonlee",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "504"
+    "name": "Hitmonlee"
   },
   "107": {
-    "name": "Hitmonchan",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "446"
+    "name": "Hitmonchan"
   },
   "108": {
-    "name": "Lickitung",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "443"
+    "name": "Lickitung"
   },
   "109": {
-    "name": "Koffing",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "213"
+    "name": "Koffing"
   },
   "110": {
-    "name": "Weezing",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1398"
+    "name": "Weezing"
   },
   "111": {
-    "name": "Rhyhorn",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": "110"
+    "name": "Rhyhorn"
   },
   "112": {
-    "name": "Rhydon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": "867"
+    "name": "Rhydon"
   },
   "113": {
-    "name": "Chansey",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "1256"
+    "name": "Chansey"
   },
   "114": {
-    "name": "Tangela",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "346"
+    "name": "Tangela"
   },
   "115": {
-    "name": "Kangaskhan",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "2461"
+    "name": "Kangaskhan"
   },
   "116": {
-    "name": "Horsea",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "104"
+    "name": "Horsea"
   },
   "117": {
-    "name": "Seadra",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "760"
+    "name": "Seadra"
   },
   "118": {
-    "name": "Goldeen",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "103"
+    "name": "Goldeen"
   },
   "119": {
-    "name": "Seaking",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "684"
+    "name": "Seaking"
   },
   "120": {
-    "name": "Staryu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "97"
+    "name": "Staryu"
   },
   "121": {
-    "name": "Starmie",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "1206"
+    "name": "Starmie"
   },
   "122": {
-    "name": "Mr. Mime",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "1431"
+    "name": "Mr. Mime"
   },
   "123": {
-    "name": "Scyther",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "155"
+    "name": "Scyther"
   },
   "124": {
-    "name": "Jynx",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "152"
+    "name": "Jynx"
   },
   "125": {
-    "name": "Electabuzz",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "261"
+    "name": "Electabuzz"
   },
   "126": {
-    "name": "Magmar",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "213"
+    "name": "Magmar"
   },
   "127": {
-    "name": "Pinsir",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "99"
+    "name": "Pinsir"
   },
   "128": {
-    "name": "Tauros",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "153"
+    "name": "Tauros"
   },
   "129": {
-    "name": "Magikarp",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "79"
+    "name": "Magikarp"
   },
   "130": {
-    "name": "Gyarados",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "2279"
+    "name": "Gyarados"
   },
   "131": {
-    "name": "Lapras",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1183"
+    "name": "Lapras"
   },
   "132": {
-    "name": "Ditto",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "30764"
+    "name": "Ditto"
   },
   "133": {
-    "name": "Eevee",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "24"
+    "name": "Eevee"
   },
   "134": {
-    "name": "Vaporeon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "1465"
+    "name": "Vaporeon"
   },
   "135": {
-    "name": "Jolteon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "1309"
+    "name": "Jolteon"
   },
   "136": {
-    "name": "Flareon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1568"
+    "name": "Flareon"
   },
   "137": {
-    "name": "Porygon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "867"
+    "name": "Porygon"
   },
   "138": {
-    "name": "Omanyte",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "346"
+    "name": "Omanyte"
   },
   "139": {
-    "name": "Omastar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "6153"
+    "name": "Omastar"
   },
   "140": {
-    "name": "Kabuto",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "356"
+    "name": "Kabuto"
   },
   "141": {
-    "name": "Kabutops",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "2930"
+    "name": "Kabutops"
   },
   "142": {
-    "name": "Aerodactyl",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Aerodactyl"
   },
   "143": {
-    "name": "Snorlax",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "284"
+    "name": "Snorlax"
   },
   "144": {
-    "name": "Articuno",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Articuno"
   },
   "145": {
-    "name": "Zapdos",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Zapdos"
   },
   "146": {
-    "name": "Moltres",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Moltres"
   },
   "147": {
-    "name": "Dratini",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": "91"
+    "name": "Dratini"
   },
   "148": {
-    "name": "Dragonair",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": "699"
+    "name": "Dragonair"
   },
   "149": {
-    "name": "Dragonite",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "580"
+    "name": "Dragonite"
   },
   "150": {
-    "name": "Mewtwo",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Mewtwo"
   },
   "151": {
-    "name": "Mew",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Mew"
   },
   "152": {
-    "name": "Chikorita",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chikorita"
   },
   "153": {
-    "name": "Bayleef",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bayleef"
   },
   "154": {
-    "name": "Meganium",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Meganium"
   },
   "155": {
-    "name": "Cyndaquil",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cyndaquil"
   },
   "156": {
-    "name": "Quilava",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quilava"
   },
   "157": {
-    "name": "Typhlosion",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Typhlosion"
   },
   "158": {
-    "name": "Totodile",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Totodile"
   },
   "159": {
-    "name": "Croconaw",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Croconaw"
   },
   "160": {
-    "name": "Feraligatr",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Feraligatr"
   },
   "161": {
-    "name": "Sentret",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sentret"
   },
   "162": {
-    "name": "Furret",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Furret"
   },
   "163": {
-    "name": "Hoothoot",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hoothoot"
   },
   "164": {
-    "name": "Noctowl",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Noctowl"
   },
   "165": {
-    "name": "Ledyba",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ledyba"
   },
   "166": {
-    "name": "Ledian",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ledian"
   },
   "167": {
-    "name": "Spinarak",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spinarak"
   },
   "168": {
-    "name": "Ariados",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ariados"
   },
   "169": {
-    "name": "Crobat",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Crobat"
   },
   "170": {
-    "name": "Chinchou",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chinchou"
   },
   "171": {
-    "name": "Lanturn",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lanturn"
   },
   "172": {
-    "name": "Pichu",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pichu"
   },
   "173": {
-    "name": "Cleffa",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cleffa"
   },
   "174": {
-    "name": "Igglybuff",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Igglybuff"
   },
   "175": {
-    "name": "Togepi",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togepi"
   },
   "176": {
-    "name": "Togetic",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togetic"
   },
   "177": {
-    "name": "Natu",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Natu"
   },
   "178": {
-    "name": "Xatu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Xatu"
   },
   "179": {
-    "name": "Mareep",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mareep"
   },
   "180": {
-    "name": "Flaaffy",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Flaaffy"
   },
   "181": {
-    "name": "Ampharos",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ampharos"
   },
   "182": {
-    "name": "Bellossom",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bellossom"
   },
   "183": {
-    "name": "Marill",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Marill"
   },
   "184": {
-    "name": "Azumarill",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Azumarill"
   },
   "185": {
-    "name": "Sudowoodo",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sudowoodo"
   },
   "186": {
-    "name": "Politoed",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Politoed"
   },
   "187": {
-    "name": "Hoppip",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hoppip"
   },
   "188": {
-    "name": "Skiploom",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skiploom"
   },
   "189": {
-    "name": "Jumpluff",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Jumpluff"
   },
   "190": {
-    "name": "Aipom",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aipom"
   },
   "191": {
-    "name": "Sunkern",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sunkern"
   },
   "192": {
-    "name": "Sunflora",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sunflora"
   },
   "193": {
-    "name": "Yanma",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Yanma"
   },
   "194": {
-    "name": "Wooper",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wooper"
   },
   "195": {
-    "name": "Quagsire",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quagsire"
   },
   "196": {
-    "name": "Espeon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Espeon"
   },
   "197": {
-    "name": "Umbreon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Umbreon"
   },
   "198": {
-    "name": "Murkrow",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Murkrow"
   },
   "199": {
-    "name": "Slowking",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slowking"
   },
   "200": {
-    "name": "Misdreavus",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Misdreavus"
   },
   "201": {
-    "name": "Unown",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Unown"
   },
   "202": {
-    "name": "Wobbuffet",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wobbuffet"
   },
   "203": {
-    "name": "Girafarig",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Girafarig"
   },
   "204": {
-    "name": "Pineco",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pineco"
   },
   "205": {
-    "name": "Forretress",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Forretress"
   },
   "206": {
-    "name": "Dunsparce",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dunsparce"
   },
   "207": {
-    "name": "Gligar",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gligar"
   },
   "208": {
-    "name": "Steelix",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Steelix"
   },
   "209": {
-    "name": "Snubbull",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Snubbull"
   },
   "210": {
-    "name": "Granbull",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Granbull"
   },
   "211": {
-    "name": "Qwilfish",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Qwilfish"
   },
   "212": {
-    "name": "Scizor",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scizor"
   },
   "213": {
-    "name": "Shuckle",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shuckle"
   },
   "214": {
-    "name": "Heracross",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Heracross"
   },
   "215": {
-    "name": "Sneasel",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sneasel"
   },
   "216": {
-    "name": "Teddiursa",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Teddiursa"
   },
   "217": {
-    "name": "Ursaring",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ursaring"
   },
   "218": {
-    "name": "Slugma",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slugma"
   },
   "219": {
-    "name": "Magcargo",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magcargo"
   },
   "220": {
-    "name": "Swinub",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swinub"
   },
   "221": {
-    "name": "Piloswine",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Piloswine"
   },
   "222": {
-    "name": "Corsola",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Corsola"
   },
   "223": {
-    "name": "Remoraid",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Remoraid"
   },
   "224": {
-    "name": "Octillery",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Octillery"
   },
   "225": {
-    "name": "Delibird",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Delibird"
   },
   "226": {
-    "name": "Mantine",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mantine"
   },
   "227": {
-    "name": "Skarmory",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skarmory"
   },
   "228": {
-    "name": "Houndour",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Houndour"
   },
   "229": {
-    "name": "Houndoom",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Houndoom"
   },
   "230": {
-    "name": "Kingdra",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kingdra"
   },
   "231": {
-    "name": "Phanpy",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Phanpy"
   },
   "232": {
-    "name": "Donphan",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Donphan"
   },
   "233": {
-    "name": "Porygon2",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Porygon2"
   },
   "234": {
-    "name": "Stantler",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Stantler"
   },
   "235": {
-    "name": "Smeargle",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Smeargle"
   },
   "236": {
-    "name": "Tyrogue",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyrogue"
   },
   "237": {
-    "name": "Hitmontop",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hitmontop"
   },
   "238": {
-    "name": "Smoochum",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Smoochum"
   },
   "239": {
-    "name": "Elekid",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Elekid"
   },
   "240": {
-    "name": "Magby",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magby"
   },
   "241": {
-    "name": "Miltank",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Miltank"
   },
   "242": {
-    "name": "Blissey",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Blissey"
   },
   "243": {
-    "name": "Raikou",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Raikou"
   },
   "244": {
-    "name": "Entei",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Entei"
   },
   "245": {
-    "name": "Suicune",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Suicune"
   },
   "246": {
-    "name": "Larvitar",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Larvitar"
   },
   "247": {
-    "name": "Pupitar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pupitar"
   },
   "248": {
-    "name": "Tyranitar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyranitar"
   },
   "249": {
-    "name": "Lugia",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lugia"
   },
   "250": {
-    "name": "Ho-Oh",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ho-Oh"
   },
   "251": {
-    "name": "Celebi",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Celebi"
   },
   "252": {
-    "name": "Treecko",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Treecko"
   },
   "253": {
-    "name": "Grovyle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Grovyle"
   },
   "254": {
-    "name": "Sceptile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Sceptile"
   },
   "255": {
-    "name": "Torchic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torchic"
   },
   "256": {
-    "name": "Combusken",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Combusken"
   },
   "257": {
-    "name": "Blaziken",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Blaziken"
   },
   "258": {
-    "name": "Mudkip",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Mudkip"
   },
   "259": {
-    "name": "Marshtomp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Marshtomp"
   },
   "260": {
-    "name": "Swampert",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Swampert"
   },
   "261": {
-    "name": "Poochyena",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Poochyena"
   },
   "262": {
-    "name": "Mightyena",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Mightyena"
   },
   "263": {
-    "name": "Zigzagoon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Zigzagoon"
   },
   "264": {
-    "name": "Linoone",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Linoone"
   },
   "265": {
-    "name": "Wurmple",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Wurmple"
   },
   "266": {
-    "name": "Silcoon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Silcoon"
   },
   "267": {
-    "name": "Beautifly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Beautifly"
   },
   "268": {
-    "name": "Cascoon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Cascoon"
   },
   "269": {
-    "name": "Dustox",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Dustox"
   },
   "270": {
-    "name": "Lotad",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lotad"
   },
   "271": {
-    "name": "Lombre",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lombre"
   },
   "272": {
-    "name": "Ludicolo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Ludicolo"
   },
   "273": {
-    "name": "Seedot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Seedot"
   },
   "274": {
-    "name": "Nuzleaf",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Nuzleaf"
   },
   "275": {
-    "name": "Shiftry",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Shiftry"
   },
   "276": {
-    "name": "Taillow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Taillow"
   },
   "277": {
-    "name": "Swellow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swellow"
   },
   "278": {
-    "name": "Wingull",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Wingull"
   },
   "279": {
-    "name": "Pelipper",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pelipper"
   },
   "280": {
-    "name": "Ralts",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Ralts"
   },
   "281": {
-    "name": "Kirlia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Kirlia"
   },
   "282": {
-    "name": "Gardevoir",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Gardevoir"
   },
   "283": {
-    "name": "Surskit",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Surskit"
   },
   "284": {
-    "name": "Masquerain",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Masquerain"
   },
   "285": {
-    "name": "Shroomish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Shroomish"
   },
   "286": {
-    "name": "Breloom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Breloom"
   },
   "287": {
-    "name": "Slakoth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Slakoth"
   },
   "288": {
-    "name": "Vigoroth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Vigoroth"
   },
   "289": {
-    "name": "Slaking",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Slaking"
   },
   "290": {
-    "name": "Nincada",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Nincada"
   },
   "291": {
-    "name": "Ninjask",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Ninjask"
   },
   "292": {
-    "name": "Shedinja",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Shedinja"
   },
   "293": {
-    "name": "Whismur",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Whismur"
   },
   "294": {
-    "name": "Loudred",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Loudred"
   },
   "295": {
-    "name": "Exploud",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Exploud"
   },
   "296": {
-    "name": "Makuhita",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Makuhita"
   },
   "297": {
-    "name": "Hariyama",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Hariyama"
   },
   "298": {
-    "name": "Azurill",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Azurill"
   },
   "299": {
-    "name": "Nosepass",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Nosepass"
   },
   "300": {
-    "name": "Skitty",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Skitty"
   },
   "301": {
-    "name": "Delcatty",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Delcatty"
   },
   "302": {
-    "name": "Sableye",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Sableye"
   },
   "303": {
-    "name": "Mawile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mawile"
   },
   "304": {
-    "name": "Aron",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Aron"
   },
   "305": {
-    "name": "Lairon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Lairon"
   },
   "306": {
-    "name": "Aggron",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Aggron"
   },
   "307": {
-    "name": "Meditite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Meditite"
   },
   "308": {
-    "name": "Medicham",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Medicham"
   },
   "309": {
-    "name": "Electrike",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Electrike"
   },
   "310": {
-    "name": "Manectric",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Manectric"
   },
   "311": {
-    "name": "Plusle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Plusle"
   },
   "312": {
-    "name": "Minun",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Minun"
   },
   "313": {
-    "name": "Volbeat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Volbeat"
   },
   "314": {
-    "name": "Illumise",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Illumise"
   },
   "315": {
-    "name": "Roselia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Roselia"
   },
   "316": {
-    "name": "Gulpin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Gulpin"
   },
   "317": {
-    "name": "Swalot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Swalot"
   },
   "318": {
-    "name": "Carvanha",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Carvanha"
   },
   "319": {
-    "name": "Sharpedo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Sharpedo"
   },
   "320": {
-    "name": "Wailmer",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wailmer"
   },
   "321": {
-    "name": "Wailord",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wailord"
   },
   "322": {
-    "name": "Numel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Numel"
   },
   "323": {
-    "name": "Camerupt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Camerupt"
   },
   "324": {
-    "name": "Torkoal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torkoal"
   },
   "325": {
-    "name": "Spoink",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Spoink"
   },
   "326": {
-    "name": "Grumpig",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Grumpig"
   },
   "327": {
-    "name": "Spinda",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Spinda"
   },
   "328": {
-    "name": "Trapinch",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Trapinch"
   },
   "329": {
-    "name": "Vibrava",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Vibrava"
   },
   "330": {
-    "name": "Flygon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Flygon"
   },
   "331": {
-    "name": "Cacnea",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cacnea"
   },
   "332": {
-    "name": "Cacturne",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Cacturne"
   },
   "333": {
-    "name": "Swablu",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swablu"
   },
   "334": {
-    "name": "Altaria",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Altaria"
   },
   "335": {
-    "name": "Zangoose",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Zangoose"
   },
   "336": {
-    "name": "Seviper",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Seviper"
   },
   "337": {
-    "name": "Lunatone",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Lunatone"
   },
   "338": {
-    "name": "Solrock",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Solrock"
   },
   "339": {
-    "name": "Barboach",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Barboach"
   },
   "340": {
-    "name": "Whiscash",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Whiscash"
   },
   "341": {
-    "name": "Corphish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Corphish"
   },
   "342": {
-    "name": "Crawdaunt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Crawdaunt"
   },
   "343": {
-    "name": "Baltoy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Baltoy"
   },
   "344": {
-    "name": "Claydol",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Claydol"
   },
   "345": {
-    "name": "Lileep",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lileep"
   },
   "346": {
-    "name": "Cradily",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cradily"
   },
   "347": {
-    "name": "Anorith",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Anorith"
   },
   "348": {
-    "name": "Armaldo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Armaldo"
   },
   "349": {
-    "name": "Feebas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Feebas"
   },
   "350": {
-    "name": "Milotic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Milotic"
   },
   "351": {
-    "name": "Castform",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Castform"
   },
   "352": {
-    "name": "Kecleon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Kecleon"
   },
   "353": {
-    "name": "Shuppet",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Shuppet"
   },
   "354": {
-    "name": "Banette",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Banette"
   },
   "355": {
-    "name": "Duskull",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Duskull"
   },
   "356": {
-    "name": "Dusclops",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Dusclops"
   },
   "357": {
-    "name": "Tropius",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Tropius"
   },
   "358": {
-    "name": "Chimecho",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Chimecho"
   },
   "359": {
-    "name": "Absol",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Absol"
   },
   "360": {
-    "name": "Wynaut",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Wynaut"
   },
   "361": {
-    "name": "Snorunt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Snorunt"
   },
   "362": {
-    "name": "Glalie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Glalie"
   },
   "363": {
-    "name": "Spheal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Spheal"
   },
   "364": {
-    "name": "Sealeo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Sealeo"
   },
   "365": {
-    "name": "Walrein",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Walrein"
   },
   "366": {
-    "name": "Clamperl",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Clamperl"
   },
   "367": {
-    "name": "Huntail",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Huntail"
   },
   "368": {
-    "name": "Gorebyss",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Gorebyss"
   },
   "369": {
-    "name": "Relicanth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Relicanth"
   },
   "370": {
-    "name": "Luvdisc",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Luvdisc"
   },
   "371": {
-    "name": "Bagon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Bagon"
   },
   "372": {
-    "name": "Shelgon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Shelgon"
   },
   "373": {
-    "name": "Salamence",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Salamence"
   },
   "374": {
-    "name": "Beldum",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Beldum"
   },
   "375": {
-    "name": "Metang",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Metang"
   },
   "376": {
-    "name": "Metagross",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Metagross"
   },
   "377": {
-    "name": "Regirock",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Regirock"
   },
   "378": {
-    "name": "Regice",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Regice"
   },
   "379": {
-    "name": "Registeel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Registeel"
   },
   "380": {
-    "name": "Latias",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Latias"
   },
   "381": {
-    "name": "Latios",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Latios"
   },
   "382": {
-    "name": "Kyogre",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Kyogre"
   },
   "383": {
-    "name": "Groudon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Groudon"
   },
   "384": {
-    "name": "Rayquaza",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rayquaza"
   },
   "385": {
-    "name": "Jirachi",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Jirachi"
   },
   "386": {
-    "name": "Deoxys",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Deoxys"
   },
   "387": {
-    "name": "Turtwig",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Turtwig"
   },
   "388": {
-    "name": "Grotle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Grotle"
   },
   "389": {
-    "name": "Torterra",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Torterra"
   },
   "390": {
-    "name": "Chimchar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Chimchar"
   },
   "391": {
-    "name": "Monferno",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Monferno"
   },
   "392": {
-    "name": "Infernape",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Infernape"
   },
   "393": {
-    "name": "Piplup",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Piplup"
   },
   "394": {
-    "name": "Prinplup",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Prinplup"
   },
   "395": {
-    "name": "Empoleon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Empoleon"
   },
   "396": {
-    "name": "Starly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Starly"
   },
   "397": {
-    "name": "Staravia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Staravia"
   },
   "398": {
-    "name": "Staraptor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Staraptor"
   },
   "399": {
-    "name": "Bidoof",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Bidoof"
   },
   "400": {
-    "name": "Bibarel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Bibarel"
   },
   "401": {
-    "name": "Kricketot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Kricketot"
   },
   "402": {
-    "name": "Kricketune",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Kricketune"
   },
   "403": {
-    "name": "Shinx",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Shinx"
   },
   "404": {
-    "name": "Luxio",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Luxio"
   },
   "405": {
-    "name": "Luxray",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Luxray"
   },
   "406": {
-    "name": "Budew",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Budew"
   },
   "407": {
-    "name": "Roserade",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Roserade"
   },
   "408": {
-    "name": "Cranidos",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Cranidos"
   },
   "409": {
-    "name": "Rampardos",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rampardos"
   },
   "410": {
-    "name": "Shieldon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Shieldon"
   },
   "411": {
-    "name": "Bastiodon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Bastiodon"
   },
   "412": {
-    "name": "Burmy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "413": {
-    "name": "Wormadam",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Burmy"
   },
   "414": {
-    "name": "Mothim",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Mothim"
   },
   "415": {
-    "name": "Combee",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Combee"
   },
   "416": {
-    "name": "Vespiquen",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Vespiquen"
   },
   "417": {
-    "name": "Pachirisu",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Pachirisu"
   },
   "418": {
-    "name": "Buizel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Buizel"
   },
   "419": {
-    "name": "Floatzel",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Floatzel"
   },
   "420": {
-    "name": "Cherubi",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cherubi"
   },
   "421": {
-    "name": "Cherrim",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Cherrim"
   },
   "422": {
-    "name": "Shellos",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Shellos"
   },
   "423": {
-    "name": "Gastrodon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Gastrodon"
   },
   "424": {
-    "name": "Ambipom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Ambipom"
   },
   "425": {
-    "name": "Drifloon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Drifloon"
   },
   "426": {
-    "name": "Drifblim",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Drifblim"
   },
   "427": {
-    "name": "Buneary",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Buneary"
   },
   "428": {
-    "name": "Lopunny",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Lopunny"
   },
   "429": {
-    "name": "Mismagius",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Mismagius"
   },
   "430": {
-    "name": "Honchkrow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Honchkrow"
   },
   "431": {
-    "name": "Glameow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Glameow"
   },
   "432": {
-    "name": "Purugly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Purugly"
   },
   "433": {
-    "name": "Chingling",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Chingling"
   },
   "434": {
-    "name": "Stunky",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Stunky"
   },
   "435": {
-    "name": "Skuntank",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Skuntank"
   },
   "436": {
-    "name": "Bronzor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bronzor"
   },
   "437": {
-    "name": "Bronzong",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bronzong"
   },
   "438": {
-    "name": "Bonsly",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Bonsly"
   },
   "439": {
-    "name": "Mime Jr.",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mime Jr."
   },
   "440": {
-    "name": "Happiny",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Happiny"
   },
   "441": {
-    "name": "Chatot",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Chatot"
   },
   "442": {
-    "name": "Spiritomb",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Spiritomb"
   },
   "443": {
-    "name": "Gible",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Gible"
   },
   "444": {
-    "name": "Gabite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Gabite"
   },
   "445": {
-    "name": "Garchomp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Garchomp"
   },
   "446": {
-    "name": "Munchlax",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Munchlax"
   },
   "447": {
-    "name": "Riolu",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Riolu"
   },
   "448": {
-    "name": "Lucario",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Lucario"
   },
   "449": {
-    "name": "Hippopotas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Hippopotas"
   },
   "450": {
-    "name": "Hippowdon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Hippowdon"
   },
   "451": {
-    "name": "Skorupi",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Skorupi"
   },
   "452": {
-    "name": "Drapion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Drapion"
   },
   "453": {
-    "name": "Croagunk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Croagunk"
   },
   "454": {
-    "name": "Toxicroak",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Toxicroak"
   },
   "455": {
-    "name": "Carnivine",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Carnivine"
   },
   "456": {
-    "name": "Finneon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Finneon"
   },
   "457": {
-    "name": "Lumineon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Lumineon"
   },
   "458": {
-    "name": "Mantyke",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Mantyke"
   },
   "459": {
-    "name": "Snover",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Snover"
   },
   "460": {
-    "name": "Abomasnow",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Abomasnow"
   },
   "461": {
-    "name": "Weavile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Weavile"
   },
   "462": {
-    "name": "Magnezone",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Magnezone"
   },
   "463": {
-    "name": "Lickilicky",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Lickilicky"
   },
   "464": {
-    "name": "Rhyperior",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rhyperior"
   },
   "465": {
-    "name": "Tangrowth",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Tangrowth"
   },
   "466": {
-    "name": "Electivire",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Electivire"
   },
   "467": {
-    "name": "Magmortar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Magmortar"
   },
   "468": {
-    "name": "Togekiss",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Togekiss"
   },
   "469": {
-    "name": "Yanmega",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Yanmega"
   },
   "470": {
-    "name": "Leafeon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Leafeon"
   },
   "471": {
-    "name": "Glaceon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Glaceon"
   },
   "472": {
-    "name": "Gliscor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Gliscor"
   },
   "473": {
-    "name": "Mamoswine",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mamoswine"
   },
   "474": {
-    "name": "Porygon-Z",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Porygon-Z"
   },
   "475": {
-    "name": "Gallade",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Gallade"
   },
   "476": {
-    "name": "Probopass",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Probopass"
   },
   "477": {
-    "name": "Dusknoir",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Dusknoir"
   },
   "478": {
-    "name": "Froslass",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Froslass"
   },
   "479": {
-    "name": "Rotom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Rotom"
   },
   "480": {
-    "name": "Uxie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Uxie"
   },
   "481": {
-    "name": "Mesprit",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Mesprit"
   },
   "482": {
-    "name": "Azelf",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Azelf"
   },
   "483": {
-    "name": "Dialga",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Dialga"
   },
   "484": {
-    "name": "Palkia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Palkia"
   },
   "485": {
-    "name": "Heatran",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Heatran"
   },
   "486": {
-    "name": "Regigigas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "487": {
-    "name": "Giratina",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Regigigas"
   },
   "488": {
-    "name": "Cresselia",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cresselia"
   },
   "489": {
-    "name": "Phione",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Phione"
   },
   "490": {
-    "name": "Manaphy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Manaphy"
   },
   "491": {
-    "name": "Darkrai",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "492": {
-    "name": "Shaymin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Darkrai"
   },
   "493": {
-    "name": "Arceus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Arceus"
   },
   "494": {
-    "name": "Victini",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Victini"
   },
   "495": {
-    "name": "Snivy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Snivy"
   },
   "496": {
-    "name": "Servine",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Servine"
   },
   "497": {
-    "name": "Serperior",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Serperior"
   },
   "498": {
-    "name": "Tepig",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Tepig"
   },
   "499": {
-    "name": "Pignite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pignite"
   },
   "500": {
-    "name": "Emboar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Emboar"
   },
   "501": {
-    "name": "Oshawott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Oshawott"
   },
   "502": {
-    "name": "Dewott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Dewott"
   },
   "503": {
-    "name": "Samurott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Samurott"
   },
   "504": {
-    "name": "Patrat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Patrat"
   },
   "505": {
-    "name": "Watchog",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Watchog"
   },
   "506": {
-    "name": "Lillipup",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Lillipup"
   },
   "507": {
-    "name": "Herdier",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Herdier"
   },
   "508": {
-    "name": "Stoutland",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Stoutland"
   },
   "509": {
-    "name": "Purrloin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Purrloin"
   },
   "510": {
-    "name": "Liepard",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Liepard"
   },
   "511": {
-    "name": "Pansage",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Pansage"
   },
   "512": {
-    "name": "Simisage",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Simisage"
   },
   "513": {
-    "name": "Pansear",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Pansear"
   },
   "514": {
-    "name": "Simisear",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Simisear"
   },
   "515": {
-    "name": "Panpour",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Panpour"
   },
   "516": {
-    "name": "Simipour",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Simipour"
   },
   "517": {
-    "name": "Munna",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Munna"
   },
   "518": {
-    "name": "Musharna",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Musharna"
   },
   "519": {
-    "name": "Pidove",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pidove"
   },
   "520": {
-    "name": "Tranquill",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Tranquill"
   },
   "521": {
-    "name": "Unfezant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Unfezant"
   },
   "522": {
-    "name": "Blitzle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Blitzle"
   },
   "523": {
-    "name": "Zebstrika",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Zebstrika"
   },
   "524": {
-    "name": "Roggenrola",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Roggenrola"
   },
   "525": {
-    "name": "Boldore",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Boldore"
   },
   "526": {
-    "name": "Gigalith",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Gigalith"
   },
   "527": {
-    "name": "Woobat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Woobat"
   },
   "528": {
-    "name": "Swoobat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swoobat"
   },
   "529": {
-    "name": "Drilbur",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Drilbur"
   },
   "530": {
-    "name": "Excadrill",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Excadrill"
   },
   "531": {
-    "name": "Audino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Audino"
   },
   "532": {
-    "name": "Timburr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Timburr"
   },
   "533": {
-    "name": "Gurdurr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Gurdurr"
   },
   "534": {
-    "name": "Conkeldurr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Conkeldurr"
   },
   "535": {
-    "name": "Tympole",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Tympole"
   },
   "536": {
-    "name": "Palpitoad",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Palpitoad"
   },
   "537": {
-    "name": "Seismitoad",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Seismitoad"
   },
   "538": {
-    "name": "Throh",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Throh"
   },
   "539": {
-    "name": "Sawk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Sawk"
   },
   "540": {
-    "name": "Sewaddle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Sewaddle"
   },
   "541": {
-    "name": "Swadloon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Swadloon"
   },
   "542": {
-    "name": "Leavanny",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Leavanny"
   },
   "543": {
-    "name": "Venipede",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Venipede"
   },
   "544": {
-    "name": "Whirlipede",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Whirlipede"
   },
   "545": {
-    "name": "Scolipede",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Scolipede"
   },
   "546": {
-    "name": "Cottonee",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Cottonee"
   },
   "547": {
-    "name": "Whimsicott",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Whimsicott"
   },
   "548": {
-    "name": "Petilil",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Petilil"
   },
   "549": {
-    "name": "Lilligant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lilligant"
   },
   "550": {
-    "name": "Basculin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Basculin"
   },
   "551": {
-    "name": "Sandile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Sandile"
   },
   "552": {
-    "name": "Krokorok",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Krokorok"
   },
   "553": {
-    "name": "Krookodile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Krookodile"
   },
   "554": {
-    "name": "Darumaka",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Darumaka"
   },
   "555": {
-    "name": "Darmanitan",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Darmanitan"
   },
   "556": {
-    "name": "Maractus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Maractus"
   },
   "557": {
-    "name": "Dwebble",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Dwebble"
   },
   "558": {
-    "name": "Crustle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Crustle"
   },
   "559": {
-    "name": "Scraggy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Scraggy"
   },
   "560": {
-    "name": "Scrafty",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Scrafty"
   },
   "561": {
-    "name": "Sigilyph",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Sigilyph"
   },
   "562": {
-    "name": "Yamask",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Yamask"
   },
   "563": {
-    "name": "Cofagrigus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Cohagrigus"
   },
   "564": {
-    "name": "Tirtouga",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Tirtouga"
   },
   "565": {
-    "name": "Carracosta",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Carracosta"
   },
   "566": {
-    "name": "Archen",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Archen"
   },
   "567": {
-    "name": "Archeops",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Archeops"
   },
   "568": {
-    "name": "Trubbish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Trubbish"
   },
   "569": {
-    "name": "Garbodor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Garbodor"
   },
   "570": {
-    "name": "Zorua",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Zorua"
   },
   "571": {
-    "name": "Zoroark",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Zoroark"
   },
   "572": {
-    "name": "Minccino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Minccino"
   },
   "573": {
-    "name": "Cinccino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Cinccino"
   },
   "574": {
-    "name": "Gothita",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Gothita"
   },
   "575": {
-    "name": "Gothorita",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Gothorita"
   },
   "576": {
-    "name": "Gothitelle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Gothitelle"
   },
   "577": {
-    "name": "Solosis",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Solosis"
   },
   "578": {
-    "name": "Duosion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Duosion"
   },
   "579": {
-    "name": "Reuniclus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Reuniclus"
   },
   "580": {
-    "name": "Ducklett",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Ducklett"
   },
   "581": {
-    "name": "Swanna",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Swanna"
   },
   "582": {
-    "name": "Vanillite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Vanillite"
   },
   "583": {
-    "name": "Vanillish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Vanillish"
   },
   "584": {
-    "name": "Vanilluxe",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Vanilluxe"
   },
   "585": {
-    "name": "Deerling",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Deerling"
   },
   "586": {
-    "name": "Sawsbuck",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Sawsbuck"
   },
   "587": {
-    "name": "Emolga",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Emolga"
   },
   "588": {
-    "name": "Karrablast",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Karrablast"
   },
   "589": {
-    "name": "Escavalier",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Escavalier"
   },
   "590": {
-    "name": "Foongus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Foongus"
   },
   "591": {
-    "name": "Amoonguss",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Amoonguss"
   },
   "592": {
-    "name": "Frillish",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Frillish"
   },
   "593": {
-    "name": "Jellicent",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Jellicent"
   },
   "594": {
-    "name": "Alomomola",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Alomomola"
   },
   "595": {
-    "name": "Joltik",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Joltik"
   },
   "596": {
-    "name": "Galvantula",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Galvantula"
   },
   "597": {
-    "name": "Ferroseed",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Ferroseed"
   },
   "598": {
-    "name": "Ferrothorn",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Ferrothorn"
   },
   "599": {
-    "name": "Klink",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Klink"
   },
   "600": {
-    "name": "Klang",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Klang"
   },
   "601": {
-    "name": "Klinklang",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Klinklang"
   },
   "602": {
-    "name": "Tynamo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Tynamo"
   },
   "603": {
-    "name": "Eelektrik",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Eelektrik"
   },
   "604": {
-    "name": "Eelektross",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Eelektross"
   },
   "605": {
-    "name": "Elgyem",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Elgyem"
   },
   "606": {
-    "name": "Beheeyem",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Beheeyem"
   },
   "607": {
-    "name": "Litwick",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Litwick"
   },
   "608": {
-    "name": "Lampent",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Lampent"
   },
   "609": {
-    "name": "Chandelure",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Chandelure"
   },
   "610": {
-    "name": "Axew",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Axew"
   },
   "611": {
-    "name": "Fraxure",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Fraxure"
   },
   "612": {
-    "name": "Haxorus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Haxorus"
   },
   "613": {
-    "name": "Cubchoo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Cubchoo"
   },
   "614": {
-    "name": "Beartic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Beartic"
   },
   "615": {
-    "name": "Cryogonal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Cryogonal"
   },
   "616": {
-    "name": "Shelmet",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Shelmet"
   },
   "617": {
-    "name": "Accelgor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Accelgor"
   },
   "618": {
-    "name": "Stunfisk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Stunfisk"
   },
   "619": {
-    "name": "Mienfoo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Mienfoo"
   },
   "620": {
-    "name": "Mienshao",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Mienshao"
   },
   "621": {
-    "name": "Druddigon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Druddigon"
   },
   "622": {
-    "name": "Golett",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Golett"
   },
   "623": {
-    "name": "Golurk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Golurk"
   },
   "624": {
-    "name": "Pawniard",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Pawniard"
   },
   "625": {
-    "name": "Bisharp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Bisharp"
   },
   "626": {
-    "name": "Bouffalant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Bouffalant"
   },
   "627": {
-    "name": "Rufflet",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rufflet"
   },
   "628": {
-    "name": "Braviary",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Braviary"
   },
   "629": {
-    "name": "Vullaby",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Vullaby"
   },
   "630": {
-    "name": "Mandibuzz",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Mandibuzz"
   },
   "631": {
-    "name": "Heatmor",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Heatmor"
   },
   "632": {
-    "name": "Durant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Durant"
   },
   "633": {
-    "name": "Deino",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Deino"
   },
   "634": {
-    "name": "Zweilous",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Zweilous"
   },
   "635": {
-    "name": "Hydreigon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Hydreigon"
   },
   "636": {
-    "name": "Larvesta",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Larvesta"
   },
   "637": {
-    "name": "Volcarona",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Volcarona"
   },
   "638": {
-    "name": "Cobalion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Cobalion"
   },
   "639": {
-    "name": "Terrakion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Terrakion"
   },
   "640": {
-    "name": "Virizion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "641": {
-    "name": "Tornadus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "642": {
-    "name": "Thundurus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Virizion"
   },
   "643": {
-    "name": "Reshiram",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Reshiram"
   },
   "644": {
-    "name": "Zekrom",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "645": {
-    "name": "Landorus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Zekrom"
   },
   "646": {
-    "name": "Kyurem",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Kyurem"
   },
   "647": {
-    "name": "Keldeo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "648": {
-    "name": "Meloetta",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Keldeo"
   },
   "649": {
-    "name": "Genesect",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Genesect"
   },
   "650": {
-    "name": "Chespin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Chespin"
   },
   "651": {
-    "name": "Quilladin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Quilladin"
   },
   "652": {
-    "name": "Chesnaught",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Chesnaught"
   },
   "653": {
-    "name": "Fennekin",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Fennekin"
   },
   "654": {
-    "name": "Braixen",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Braixen"
   },
   "655": {
-    "name": "Delphox",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Delphox"
   },
   "656": {
-    "name": "Froakie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Froakie"
   },
   "657": {
-    "name": "Frogadier",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Frogadier"
   },
   "658": {
-    "name": "Greninja",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Greninja"
   },
   "659": {
-    "name": "Bunnelby",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Bunnelby"
   },
   "660": {
-    "name": "Diggersby",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Diggersby"
   },
   "661": {
-    "name": "Fletchling",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Fletchling"
   },
   "662": {
-    "name": "Fletchinder",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Fletchinder"
   },
   "663": {
-    "name": "Talonflame",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Talonflame"
   },
   "664": {
-    "name": "Scatterbug",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Scatterbug"
   },
   "665": {
-    "name": "Spewpa",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Spewpa"
   },
   "666": {
-    "name": "Vivillon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Vivillon"
   },
   "667": {
-    "name": "Litleo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Litleo"
   },
   "668": {
-    "name": "Pyroar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Pyroar"
   },
   "669": {
-    "name": "Flabébé",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Flabébé"
   },
   "670": {
-    "name": "Floette",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Floette"
   },
   "671": {
-    "name": "Florges",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Florges"
   },
   "672": {
-    "name": "Skiddo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Skiddo"
   },
   "673": {
-    "name": "Gogoat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Gogoat"
   },
   "674": {
-    "name": "Pancham",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pancham"
   },
   "675": {
-    "name": "Pangoro",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Pangoro"
   },
   "676": {
-    "name": "Furfrou",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Furfrou"
   },
   "677": {
-    "name": "Espurr",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Espurr"
   },
   "678": {
-    "name": "Meowstic",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Meowstic"
   },
   "679": {
-    "name": "Honedge",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Honedge"
   },
   "680": {
-    "name": "Doublade",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "681": {
-    "name": "Aegislash",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Doublade"
   },
   "682": {
-    "name": "Spritzee",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Spritzee"
   },
   "683": {
-    "name": "Aromatisse",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Aromatisse"
   },
   "684": {
-    "name": "Swirlix",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Swirlix"
   },
   "685": {
-    "name": "Slurpuff",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Slurpuff"
   },
   "686": {
-    "name": "Inkay",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Inkay"
   },
   "687": {
-    "name": "Malamar",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Malamar"
   },
   "688": {
-    "name": "Binacle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Binacle"
   },
   "689": {
-    "name": "Barbaracle",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Barbaracle"
   },
   "690": {
-    "name": "Skrelp",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Skrelp"
   },
   "691": {
-    "name": "Dragalge",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Dragalge"
   },
   "692": {
-    "name": "Clauncher",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Clauncher"
   },
   "693": {
-    "name": "Clawitzer",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Clawitzer"
   },
   "694": {
-    "name": "Helioptile",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Helioptile"
   },
   "695": {
-    "name": "Heliolisk",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Heliolisk"
   },
   "696": {
-    "name": "Tyrunt",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Tyrunt"
   },
   "697": {
-    "name": "Tyrantrum",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Tyrantrum"
   },
   "698": {
-    "name": "Amaura",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Amaura"
   },
   "699": {
-    "name": "Aurorus",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Aurorus"
   },
   "700": {
-    "name": "Sylveon",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Sylveon"
   },
   "701": {
-    "name": "Hawlucha",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Hawlucha"
   },
   "702": {
-    "name": "Dedenne",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Dedenne"
   },
   "703": {
-    "name": "Carbink",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Carbink"
   },
   "704": {
-    "name": "Goomy",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Goomy"
   },
   "705": {
-    "name": "Sliggoo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Sliggoo"
   },
   "706": {
-    "name": "Goodra",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Goodra"
   },
   "707": {
-    "name": "Klefki",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Klefki"
   },
   "708": {
-    "name": "Phantump",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Phantump"
   },
   "709": {
-    "name": "Trevenant",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Trevenant"
   },
   "710": {
-    "name": "Pumpkaboo",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Pumpkaboo"
   },
   "711": {
-    "name": "Gourgeist",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Gourgeist"
   },
   "712": {
-    "name": "Bergmite",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Bergmite"
   },
   "713": {
-    "name": "Avalugg",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Avalugg"
   },
   "714": {
-    "name": "Noibat",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Noibat"
   },
   "715": {
-    "name": "Noivern",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Noivern"
   },
   "716": {
-    "name": "Xerneas",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Xerneas"
   },
   "717": {
-    "name": "Yveltal",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Yveltal"
   },
   "718": {
-    "name": "Zygarde",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Zygarde"
   },
   "719": {
-    "name": "Diancie",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
-  },
-  "720": {
-    "name": "Hoopa",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Diancie"
   },
   "721": {
-    "name": "Volcanion",
-    "rarity": "",
-    "types": [],
-    "spawn_rate": ""
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Volcanion"
+  },
+  "722": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rowlet"
+  },
+  "723": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Dartrix"
+  },
+  "724": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Decidueye"
+  },
+  "725": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Litten"
+  },
+  "726": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torracat"
+  },
+  "727": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Incineroar"
+  },
+  "728": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Popplio"
+  },
+  "729": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Brionne"
+  },
+  "730": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Primarina"
+  },
+  "731": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pikipek"
+  },
+  "732": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Trumbeak"
+  },
+  "733": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Toucannon"
+  },
+  "734": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Yungoos"
+  },
+  "735": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Gumshoos"
+  },
+  "736": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Grubbin"
+  },
+  "737": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Charjabug"
+  },
+  "738": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Vikavolt"
+  },
+  "739": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Crabrawler"
+  },
+  "740": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Crabominable"
+  },
+  "741": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Oricorio"
+  },
+  "742": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Cutiefly"
+  },
+  "743": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Ribombee"
+  },
+  "744": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rockruff"
+  },
+  "745": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Lycanroc"
+  },
+  "746": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wishiwashi"
+  },
+  "747": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Mareanie"
+  },
+  "748": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Toxapex"
+  },
+  "749": {
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mudbray"
+  },
+  "750": {
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mudsdale"
+  },
+  "751": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Dewpider"
+  },
+  "752": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Araquanid"
+  },
+  "753": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Fomantis"
+  },
+  "754": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lurantis"
+  },
+  "755": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Morelull"
+  },
+  "756": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Shiinotic"
+  },
+  "757": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Salandit"
+  },
+  "758": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Salazzle"
+  },
+  "759": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Stufful"
+  },
+  "760": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Bewear"
+  },
+  "761": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Bounsweet"
+  },
+  "762": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Steenee"
+  },
+  "763": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Tsareena"
+  },
+  "764": {
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Comfey"
+  },
+  "765": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Oranguru"
+  },
+  "766": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Passimian"
+  },
+  "767": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wimpod"
+  },
+  "768": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Golisopod"
+  },
+  "769": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Sandygast"
+  },
+  "770": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Palossand"
+  },
+  "771": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Pyukumuku"
+  },
+  "772": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Type: Null"
+  },
+  "773": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Silvally"
+  },
+  "774": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Minior (Core)"
+  },
+  "775": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Komala"
+  },
+  "776": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Turtonator"
+  },
+  "777": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Togedemaru"
+  },
+  "778": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mimikyu"
+  },
+  "779": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bruxish"
+  },
+  "780": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Drampa"
+  },
+  "781": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Dhelmise"
+  },
+  "782": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Jangmo-o"
+  },
+  "783": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Hakamo-o"
+  },
+  "784": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Kommo-o"
+  },
+  "785": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Koko"
+  },
+  "786": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Lele"
+  },
+  "787": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Bulu"
+  },
+  "788": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Fini"
+  },
+  "789": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cosmog"
+  },
+  "790": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cosmoem"
+  },
+  "791": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Solgaleo"
+  },
+  "792": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Lunala"
+  },
+  "793": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Nihilego"
+  },
+  "794": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Buzzwole"
+  },
+  "795": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pheromosa"
+  },
+  "796": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Xurkitree"
+  },
+  "797": {
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Celesteela"
+  },
+  "798": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Kartana"
+  },
+  "799": {
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Guzzlord"
+  },
+  "800": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Necrozma"
+  },
+  "801": {
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Magearna"
+  },
+  "802": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Marshadow"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds default icons for the next wave of pokemon.

## Motivation and Context
Gen3 has an upcoming partial release, which we need sprites and data for.

Thanks to @BrownSlaughter for producing the updated pokemon data file.

## Screenshots (if appropriate):
![icons-large-sprite](https://user-images.githubusercontent.com/23409825/31794569-a72c3a70-b51a-11e7-906c-3eb834cceb6c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
