### PR TITLE
Improved Notification Setting Controls

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -934,6 +934,14 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
+    'hideNotNotified': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    'showPopups': {
+        default: true,
+        type: StoreTypes.Boolean
+    },
     'playSound': {
         default: false,
         type: StoreTypes.Boolean

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -435,6 +435,9 @@ function initSidebar() {
     $('#scanned-switch').prop('checked', Store.get('showScanned'))
     $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
     $('#ranges-switch').prop('checked', Store.get('showRanges'))
+    $('#hideunnotified-switch').prop('checked', Store.get('hideNotNotified'))
+    $('#popups-switch').prop('checked', Store.get('showPopups'))
+    $('#bounce-switch').prop('checked', Store.get('isBounceDisabled'))
     $('#sound-switch').prop('checked', Store.get('playSound'))
     $('#pokemoncries').toggle(Store.get('playSound'))
     $('#cries-switch').prop('checked', Store.get('playCries'))
@@ -1575,17 +1578,18 @@ function processPokemon(item) {
 
     if (!(item['encounter_id'] in mapData.pokemons) &&
          !isExcludedPoke && isPokeAlive) {
-        // Add marker to map and item to dict.
-        if (!item.hidden) {
+
+    // Add marker to map and item to dict.
+        const isNotifyPkmn = isNotifyPoke(item)
+        if (!item.hidden && (!Store.get('hideNotNotified') || isNotifyPkmn)) {
             const isBounceDisabled = Store.get('isBounceDisabled')
             const scaleByRarity = Store.get('scaleByRarity')
-            const isNotifyPkmn = isNotifyPoke(item)
 
             if (item.marker) {
                 updatePokemonMarker(item.marker, map, scaleByRarity, isNotifyPkmn)
             } else {
                 newMarker = setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity, isNotifyPkmn)
-                customizePokemonMarker(newMarker, item)
+                customizePokemonMarker(newMarker, item, !Store.get('showPopups'))
                 item.marker = newMarker
             }
 
@@ -2386,11 +2390,11 @@ $(function () {
     $switchActiveRaidGymsOnly.on('change', function () {
         Store.set('showActiveRaidsOnly', this.checked)
         lastgyms = false
+   
         updateMap()
     })
 
     $switchRaidMinLevel = $('#raid-min-level-only-switch')
-
     $switchRaidMinLevel.select2({
         placeholder: 'Minimum raid level',
         minimumResultsForSearch: Infinity
@@ -2818,6 +2822,21 @@ $(function () {
         } else {
             criesWrapper.hide(options)
         }
+    })
+
+    $('#bounce-switch').change(function () {
+        Store.set('isBounceDisabled', this.checked)
+        location.reload();
+    })
+
+    $('#hideunnotified-switch').change(function () {
+        Store.set('hideNotNotified', this.checked)
+        location.reload();
+    })
+
+    $('#popups-switch').change(function () {
+        Store.set('showPopups', this.checked)
+        location.reload();
     })
 
     $('#cries-switch').change(function () {

--- a/templates/map.html
+++ b/templates/map.html
@@ -355,6 +355,36 @@
             </div>
               {% endif %}
             <div class="form-control switch-container">
+              <h3>Hide unnotified pokemon</h3>
+              <div class="onoffswitch">
+                <input id="hideunnotified-switch" type="checkbox" name="hideunnotified-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="hideunnotified-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Show browser popups</h3>
+              <div class="onoffswitch">
+                <input id="popups-switch" type="checkbox" name="popups-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="popups-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Disable bouncing</h3>
+              <div class="onoffswitch">
+                <input id="bounce-switch" type="checkbox" name="bounce-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="bounce-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
               <h3>Notify with sound</h3>
               <div class="onoffswitch">
                 <input id="sound-switch" type="checkbox" name="sound-switch" class="onoffswitch-checkbox" checked>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds 3 new interrelated settings requested by my users.  I realize some believe that there are 'already too many settings' but I believe these are actually useful and all users are not the same and as such these don't need to be hard-coded.  # 1 especially is a new feature versus the others being control of existing internal settings.

**1.  Hide pokemon which are not being notified (default: off)**
Once implemented, I unexpectedly saw the high value of this.  It hides all pokemon which are not being notified due to IV, Rarity, or Pokemon type.   It gives you a nice clean map with only the items you are interested in seeing (the notified pokemon)

**2. Disable browser popups.  (default: off)** 
Currently if you have notifications enabled you will get the popup notifications unless you go in and block them in the browser.  It can be very annoying if you set a notification incorrectly and get endless popups.  I have received many complaints from mobile users who want to see the pokemon on the map (bouncing) but not get popups.  This can be combined with # 1 above for example for a nice clean map with no popups

**3. Disable bouncing.  (default: off)** 
There is currently no way for the user to control the bouncing of notified pokemon.  A bouncing pokemon jumps out at you but it can also be difficult to click on it when it is moving.  This allows you to turn that off.  When combined with # 1 it allows you to show only notified pokemon and there is no real need for the bouncing


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Described above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it on a development map to work out the kinks.
I then moved it to my production map without issue and reports have been good.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15407947/32987582-7da8e75e-ccb5-11e7-8e8d-1273928626a3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
