### PR TITLE
Database Cleanup (#2281 rework)

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -22,14 +22,17 @@
                     GMAPS_KEY [--skip-empty] [-C] [-cd] [-np] [-ng] [-nr]
                     [-nk] [-ss] [-ssct SS_CLUSTER_TIME] [-speed] [-spin]
                     [-ams ACCOUNT_MAX_SPINS] [-kph KPH] [-hkph HLVL_KPH]
-                    [-ldur LURE_DURATION] [-pd PURGE_DATA] [-px PROXY] [-pxsc]
+                    [-ldur LURE_DURATION] [-px PROXY] [-pxsc]
                     [-pxt PROXY_TEST_TIMEOUT] [-pxre PROXY_TEST_RETRIES]
                     [-pxbf PROXY_TEST_BACKOFF_FACTOR]
                     [-pxc PROXY_TEST_CONCURRENCY] [-pxd PROXY_DISPLAY]
                     [-pxf PROXY_FILE] [-pxr PROXY_REFRESH]
                     [-pxo PROXY_ROTATION] --db-name DB_NAME --db-user DB_USER
                     --db-pass DB_PASS [--db-host DB_HOST] [--db-port DB_PORT]
-                    [--db-threads DB_THREADS] [-wh WEBHOOKS] [-gi] [-DC]
+                    [--db-threads DB_THREADS] [-DC] [-DCw DB_CLEANUP_WORKER]
+                    [-DCp DB_CLEANUP_POKEMON] [-DCg DB_CLEANUP_GYM]
+                    [-DCs DB_CLEANUP_SPAWNPOINT] [-DCf DB_CLEANUP_FORTS]
+                    [-wh WEBHOOKS] [-gi]
                     [--wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure,captcha}]
                     [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
                     [-whr WH_RETRIES] [-whct WH_CONNECT_TIMEOUT]
@@ -38,11 +41,11 @@
                     [--ssl-certificate SSL_CERTIFICATE]
                     [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]]
                     [-slt STATS_LOG_TIMER] [-sn STATUS_NAME]
-                    [-spp STATUS_PAGE_PASSWORD] [-hk HASH_KEY] [-novc]
-                    [-vci VERSION_CHECK_INTERVAL] [-odt ON_DEMAND_TIMEOUT]
-                    [--disable-blacklist] [-tp TRUSTED_PROXIES]
-                    [--api-version API_VERSION] [--no-file-logs]
-                    [--log-path LOG_PATH] [--dump] [-exg]
+                    [-spp STATUS_PAGE_PASSWORD] [-spf STATUS_PAGE_FILTER]
+                    [-hk HASH_KEY] [-novc] [-vci VERSION_CHECK_INTERVAL]
+                    [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
+                    [-tp TRUSTED_PROXIES] [--api-version API_VERSION]
+                    [--no-file-logs] [--log-path LOG_PATH] [--dump] [-exg]
                     [-v | --verbosity VERBOSE] [-Rh RARITY_HOURS]
                     [-Rf RARITY_UPDATE_FREQUENCY]
 
@@ -275,10 +278,6 @@ environment variables which override config file values which override defaults.
                             Change duration for lures set on pokestops. This is
                             useful for events that extend lure duration. [env var:
                             POGOMAP_LURE_DURATION]
-      -pd PURGE_DATA, --purge-data PURGE_DATA
-                            Clear Pokemon from database this many hours after they
-                            disappear (0 to disable). [env var:
-                            POGOMAP_PURGE_DATA]
       -px PROXY, --proxy PROXY
                             Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
                             POGOMAP_PROXY]
@@ -318,7 +317,6 @@ environment variables which override config file values which override defaults.
                             var: POGOMAP_WEBHOOK]
       -gi, --gym-info       Get all details about gyms (causes an additional API
                             hit for every gym). [env var: POGOMAP_GYM_INFO]
-      -DC, --enable-clean   Enable DB cleaner. [env var: POGOMAP_ENABLE_CLEAN]
       --wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure,captcha}
                             Defines the type of messages to send to webhooks. [env
                             var: POGOMAP_WH_TYPES]
@@ -368,6 +366,9 @@ environment variables which override config file values which override defaults.
       -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
                             Set the status page password. [env var:
                             POGOMAP_STATUS_PAGE_PASSWORD]
+      -spf STATUS_PAGE_FILTER, --status-page-filter STATUS_PAGE_FILTER
+                            Filter worker status inactive for X minutes. [env var:
+                            POGOMAP_STATUS_PAGE_FILTER]
       -hk HASH_KEY, --hash-key HASH_KEY
                             Key for hash server [env var: POGOMAP_HASH_KEY]
       -novc, --no-version-check
@@ -414,6 +415,29 @@ environment variables which override config file values which override defaults.
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
                             behind. [env var: POGOMAP_DB_THREADS]
+
+    Database Cleanup:
+      -DC, --db-cleanup     Enable regular database cleanup thread. [env var:
+                            POGOMAP_DB_CLEANUP]
+      -DCw DB_CLEANUP_WORKER, --db-cleanup-worker DB_CLEANUP_WORKER
+                            Clear worker status from database after X minutes of
+                            inactivity (0 to disable). [env var:
+                            POGOMAP_DB_CLEANUP_WORKER]
+      -DCp DB_CLEANUP_POKEMON, --db-cleanup-pokemon DB_CLEANUP_POKEMON
+                            Clear pokemon from database X hours after they
+                            disappeared (0 to disable). [env var:
+                            POGOMAP_DB_CLEANUP_POKEMON]
+      -DCg DB_CLEANUP_GYM, --db-cleanup-gym DB_CLEANUP_GYM
+                            Clear gym details from database X hours after last gym
+                            scan (0 to disable). [env var: POGOMAP_DB_CLEANUP_GYM]
+      -DCs DB_CLEANUP_SPAWNPOINT, --db-cleanup-spawnpoint DB_CLEANUP_SPAWNPOINT
+                            Clear spawnpoint from database X hours after last
+                            valid scan (0 to disable). [env var:
+                            POGOMAP_DB_CLEANUP_SPAWNPOINT]
+      -DCf DB_CLEANUP_FORTS, --db-cleanup-forts DB_CLEANUP_FORTS
+                            Clear gyms and pokestops from database X days after
+                            last valid scan (0 to disable). [env var:
+                            POGOMAP_DB_CLEANUP_FORTS]
 
     Dynamic Rarity:
       -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -18,8 +18,8 @@
                     [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
                     [-me MAX_EMPTY] [-bsr BAD_SCAN_RETRY]
                     [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
-                    [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-sc] [-nfl] -k
-                    GMAPS_KEY [--skip-empty] [-C] [-cd] [-np] [-ng] [-nr]
+                    [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-sc] [-nfl]
+                    -k GMAPS_KEY [--skip-empty] [-C] [-cd] [-np] [-ng] [-nr]
                     [-nk] [-ss] [-ssct SS_CLUSTER_TIME] [-speed] [-spin]
                     [-ams ACCOUNT_MAX_SPINS] [-kph KPH] [-hkph HLVL_KPH]
                     [-ldur LURE_DURATION] [-px PROXY] [-pxsc]
@@ -391,7 +391,7 @@ environment variables which override config file values which override defaults.
       --dump                Dump censored debug info about the environment and
                             auto-upload to hastebin.com. [env var: POGOMAP_DUMP]
       -exg, --ex-gyms       Fetch OSM parks within geofence and flag gyms that are
-                            candidates for ex raids. Only required once per area.
+                            candidates for EX raids. Only required once per area.
                             [env var: POGOMAP_EX_GYMS]
       -v                    Show debug messages from RocketMap and pgoapi. Can be
                             repeated up to 3 times.

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -40,14 +40,14 @@
                     [-whlfu WH_LFU_SIZE] [-whfi WH_FRAME_INTERVAL]
                     [--ssl-certificate SSL_CERTIFICATE]
                     [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]]
-                    [-slt STATS_LOG_TIMER] [-sn STATUS_NAME]
-                    [-spp STATUS_PAGE_PASSWORD] [-spf STATUS_PAGE_FILTER]
-                    [-hk HASH_KEY] [-novc] [-vci VERSION_CHECK_INTERVAL]
+                    [-slt STATS_LOG_TIMER] [-sn STATUS_NAME] [-hk HASH_KEY]
+                    [-novc] [-vci VERSION_CHECK_INTERVAL]
                     [-odt ON_DEMAND_TIMEOUT] [--disable-blacklist]
                     [-tp TRUSTED_PROXIES] [--api-version API_VERSION]
                     [--no-file-logs] [--log-path LOG_PATH] [--dump] [-exg]
                     [-v | --verbosity VERBOSE] [-Rh RARITY_HOURS]
-                    [-Rf RARITY_UPDATE_FREQUENCY]
+                    [-Rf RARITY_UPDATE_FREQUENCY] [-SPp STATUS_PAGE_PASSWORD]
+                    [-SPf STATUS_PAGE_FILTER]
 
 Args that start with '--' (eg. -a) can also be set in a config file
 (config/config.ini or specified via -cf or -scf). The recognized syntax
@@ -268,12 +268,12 @@ environment variables which override config file values which override defaults.
       -ams ACCOUNT_MAX_SPINS, --account-max-spins ACCOUNT_MAX_SPINS
                             Maximum number of Pokestop spins per hour. [env var:
                             POGOMAP_ACCOUNT_MAX_SPINS]
-      -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement. 0
-                            to disable. Default: 35. [env var: POGOMAP_KPH]
+      -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
+                            Default: 35, 0 to disable. [env var: POGOMAP_KPH]
       -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
                             Set a maximum speed in km/hour for scanner movement,
-                            for high-level (L30) accounts. 0 to disable. Default:
-                            25. [env var: POGOMAP_HLVL_KPH]
+                            for high-level (L30) accounts. Default: 25, 0 to
+                            disable. [env var: POGOMAP_HLVL_KPH]
       -ldur LURE_DURATION, --lure-duration LURE_DURATION
                             Change duration for lures set on pokestops. This is
                             useful for events that extend lure duration. [env var:
@@ -363,12 +363,6 @@ environment variables which override config file values which override defaults.
       -sn STATUS_NAME, --status-name STATUS_NAME
                             Enable status page database update using STATUS_NAME
                             as main worker name. [env var: POGOMAP_STATUS_NAME]
-      -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
-                            Set the status page password. [env var:
-                            POGOMAP_STATUS_PAGE_PASSWORD]
-      -spf STATUS_PAGE_FILTER, --status-page-filter STATUS_PAGE_FILTER
-                            Filter worker status inactive for X minutes. [env var:
-                            POGOMAP_STATUS_PAGE_FILTER]
       -hk HASH_KEY, --hash-key HASH_KEY
                             Key for hash server [env var: POGOMAP_HASH_KEY]
       -novc, --no-version-check
@@ -405,46 +399,56 @@ environment variables which override config file values which override defaults.
                             var: POGOMAP_VERBOSITY]
 
     Database:
-      --db-name DB_NAME     Name of the database to be used. [env var:
-                            POGOMAP_DB_NAME]
+      --db-name DB_NAME     Name of the database to be used.
+                            [env var: POGOMAP_DB_NAME]
       --db-user DB_USER     Username for the database. [env var: POGOMAP_DB_USER]
       --db-pass DB_PASS     Password for the database. [env var: POGOMAP_DB_PASS]
-      --db-host DB_HOST     IP or hostname for the database. [env var:
-                            POGOMAP_DB_HOST]
+      --db-host DB_HOST     IP or hostname for the database.
+                            [env var: POGOMAP_DB_HOST]
       --db-port DB_PORT     Port for the database. [env var: POGOMAP_DB_PORT]
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
                             behind. [env var: POGOMAP_DB_THREADS]
 
     Database Cleanup:
-      -DC, --db-cleanup     Enable regular database cleanup thread. [env var:
-                            POGOMAP_DB_CLEANUP]
+      -DC, --db-cleanup     Enable regular database cleanup thread.
+                            [env var: POGOMAP_DB_CLEANUP]
       -DCw DB_CLEANUP_WORKER, --db-cleanup-worker DB_CLEANUP_WORKER
                             Clear worker status from database after X minutes of
-                            inactivity (0 to disable). [env var:
-                            POGOMAP_DB_CLEANUP_WORKER]
+                            inactivity. Default: 30, 0 to disable.
+                            [env var: POGOMAP_DB_CLEANUP_WORKER]
       -DCp DB_CLEANUP_POKEMON, --db-cleanup-pokemon DB_CLEANUP_POKEMON
                             Clear pokemon from database X hours after they
-                            disappeared (0 to disable). [env var:
-                            POGOMAP_DB_CLEANUP_POKEMON]
+                            disappeared. Default: 0, 0 to disable.
+                            [env var: POGOMAP_DB_CLEANUP_POKEMON]
       -DCg DB_CLEANUP_GYM, --db-cleanup-gym DB_CLEANUP_GYM
                             Clear gym details from database X hours after last gym
-                            scan (0 to disable). [env var: POGOMAP_DB_CLEANUP_GYM]
+                            scan. Default: 8, 0 to disable.
+                            [env var: POGOMAP_DB_CLEANUP_GYM]
       -DCs DB_CLEANUP_SPAWNPOINT, --db-cleanup-spawnpoint DB_CLEANUP_SPAWNPOINT
                             Clear spawnpoint from database X hours after last
-                            valid scan (0 to disable). [env var:
-                            POGOMAP_DB_CLEANUP_SPAWNPOINT]
+                            valid scan. Default: 720, 0 to disable.
+                            [env var: POGOMAP_DB_CLEANUP_SPAWNPOINT]
       -DCf DB_CLEANUP_FORTS, --db-cleanup-forts DB_CLEANUP_FORTS
                             Clear gyms and pokestops from database X days after
-                            last valid scan (0 to disable). [env var:
-                            POGOMAP_DB_CLEANUP_FORTS]
+                            last valid scan. Default: 0, 0 to disable.
+                            [env var: POGOMAP_DB_CLEANUP_FORTS]
 
     Dynamic Rarity:
       -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
                             Number of hours of Pokemon data to use to calculate
-                            dynamic rarity. Decimals allowed. Default: 48. 0 to
+                            dynamic rarity. Decimals allowed. Default: 48, 0 to
                             use all data. [env var: POGOMAP_RARITY_HOURS]
       -Rf RARITY_UPDATE_FREQUENCY, --rarity-update-frequency RARITY_UPDATE_FREQUENCY
                             How often (in minutes) the dynamic rarity should be
-                            updated. Decimals allowed. Default: 0. 0 to disable.
+                            updated. Decimals allowed. Default: 0, 0 to disable.
                             [env var: POGOMAP_RARITY_UPDATE_FREQUENCY]
+
+    Status Page:
+      -SPp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
+                            Set the status page password.
+                            [env var: POGOMAP_STATUS_PAGE_PASSWORD]
+      -SPf STATUS_PAGE_FILTER, --status-page-filter STATUS_PAGE_FILTER
+                            Filter worker status that are inactive for X minutes.
+                            Default: 30, 0 to disable.
+                            [env var: POGOMAP_STATUS_PAGE_FILTER]

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -425,8 +425,14 @@ class Pogom(Flask):
                 d['error'] = 'Access denied'
             elif (request.args.get('password', None) ==
                   args.status_page_password):
-                d['main_workers'] = MainWorker.get_all()
-                d['workers'] = WorkerStatus.get_all()
+                max_status_age = args.status_page_filter
+                if max_status_age > 0:
+                    d['main_workers'] = MainWorker.get_recent(max_status_age)
+                    d['workers'] = WorkerStatus.get_recent(max_status_age)
+                else:
+                    d['main_workers'] = MainWorker.get_all()
+                    d['workers'] = WorkerStatus.get_all()
+
         return jsonify(d)
 
     def loc(self):
@@ -551,8 +557,13 @@ class Pogom(Flask):
 
         if request.form.get('password', None) == args.status_page_password:
             d['login'] = 'ok'
-            d['main_workers'] = MainWorker.get_all()
-            d['workers'] = WorkerStatus.get_all()
+            max_status_age = args.status_page_filter
+            if max_status_age > 0:
+                d['main_workers'] = MainWorker.get_recent(max_status_age)
+                d['workers'] = WorkerStatus.get_recent(max_status_age)
+            else:
+                d['main_workers'] = MainWorker.get_all()
+                d['workers'] = WorkerStatus.get_all()
             d['hashkeys'] = HashKeys.get_obfuscated_keys()
         else:
             d['login'] = 'failed'

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2719,7 +2719,7 @@ def clean_db_loop(args):
                 query = (HashKeys
                          .delete()
                          .where(HashKeys.expires <
-                                (datetime.now() - timedelta(days=1))))
+                                (datetime.utcnow() - timedelta(days=1))))
                 query.execute()
 
                 # If desired, clear old Pokemon spawns.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2677,14 +2677,35 @@ def clean_db_loop(args):
                 query = (GymDetails
                          .delete()
                          .where(GymDetails.last_scanned <
-                                (datetime.now() - timedelta(days=1))))
+                                (datetime.utcnow() - timedelta(days=7))))
                 query.execute()
 
                 # Remove old gym locations.
                 query = (Gym
                          .delete()
                          .where(Gym.last_scanned <
-                                (datetime.now() - timedelta(days=1))))
+                                (datetime.utcnow() - timedelta(days=7))))
+                query.execute()
+
+                # Remove old raid Details.
+                query = (Raid
+                         .delete()
+                         .where(Raid.end <
+                                (datetime.utcnow() - timedelta(days=7))))
+                query.execute()
+
+                # Remove old gym members.
+                query = (GymMember
+                         .delete()
+                         .where(GymMember.last_scanned <
+                                (datetime.utcnow() - timedelta(days=7))))
+                query.execute()
+
+                # Remove old gym Pokemon.
+                query = (GymPokemon
+                         .delete()
+                         .where(GymPokemon.last_seen <
+                                (datetime.utcnow() - timedelta(days=7))))
                 query.execute()
 
                 # Remove old (unusable) captcha tokens

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2673,6 +2673,20 @@ def clean_db_loop(args):
                         Pokestop.lure_expiration < datetime.utcnow()))
                 query.execute()
 
+                # Remove old gym Details.
+                query = (GymDetails
+                         .delete()
+                         .where(GymDetails.last_scanned <
+                                (datetime.now() - timedelta(days=1))))
+                query.execute()
+
+                # Remove old gym locations.
+                query = (Gym
+                         .delete()
+                         .where(Gym.last_scanned <
+                                (datetime.now() - timedelta(days=1))))
+                query.execute()
+
                 # Remove old (unusable) captcha tokens
                 query = (Token
                          .delete()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2718,8 +2718,10 @@ def clean_db_loop(args):
                 # Remove expired HashKeys
                 query = (HashKeys
                          .delete()
-                         .where(HashKeys.expires <
-                                (datetime.utcnow() - timedelta(days=1))))
+                         .where((HashKeys.expires <
+                                (datetime.utcnow() - timedelta(days=1))) |
+                                (HashKeys.last_updated <
+                                (datetime.utcnow() - timedelta(days=7)))))
                 query.execute()
 
                 # If desired, clear old Pokemon spawns.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1223,15 +1223,18 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
 
 
 def upsertKeys(keys, key_scheduler, db_updates_queue):
-    # Prepare hashing keys to be sent to the db. But only
-    # sent latest updates of the 'peak' value per key.
+    # Prepare hashing keys to be sent to the database.
+    # Keep highest peak value stored.
     hashkeys = {}
-    for key in keys:
-        key_instance = key_scheduler.keys[key]
-        hashkeys[key] = key_instance
+    stored_peaks = HashKeys.get_stored_peaks()
+    for key, instance in key_scheduler.keys.iteritems():
+        hashkeys[key] = instance
         hashkeys[key]['key'] = key
-        hashkeys[key]['peak'] = max(key_instance['peak'],
-                                    HashKeys.getStoredPeak(key))
+
+        if key in stored_peaks:
+            max_peak = max(instance['peak'], stored_peaks[key])
+            hashkeys[key]['peak'] = max_peak
+
     db_updates_queue.put((HashKeys, hashkeys))
 
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -331,10 +331,6 @@ def get_args():
                         help=('Change duration for lures set on pokestops. ' +
                               'This is useful for events that extend lure ' +
                               'duration.'), type=int, default=30)
-    parser.add_argument('-pd', '--purge-data',
-                        help=('Clear Pokemon from database this many hours ' +
-                              'after they disappear (0 to disable).'),
-                        type=int, default=0)
     parser.add_argument('-px', '--proxy',
                         help='Proxy url (e.g. socks5://127.0.0.1:9050)',
                         action='append')
@@ -401,8 +397,21 @@ def get_args():
                         help=('Get all details about gyms (causes an ' +
                               'additional API hit for every gym).'),
                         action='store_true', default=False)
-    parser.add_argument('-DC', '--enable-clean', help='Enable DB cleaner.',
+    parser.add_argument('-dbc', '--db-cleanup',
+                        help='Enable database regular cleanup thread.',
                         action='store_true', default=False)
+    parser.add_argument('-dbcp', '--db-cleanup-pokemon',
+                        help=('Clear Pokemon from database X hours ' +
+                              'after they disappear (0 to disable).'),
+                        type=int, default=0)
+    parser.add_argument('-dbcg', '--db-cleanup-gym',
+                        help=('Clear Gym details from database X ' +
+                              'hours after being scanned (0 to disable).'),
+                        type=int, default=3)
+    parser.add_argument('-dbcs', '--db-cleanup-spawnpoint',
+                        help=('Clear Spawnpoint from database without a ' +
+                              'valid scan for X hours (0 to disable).'),
+                        type=int, default=720)
     parser.add_argument(
         '--wh-types',
         help=('Defines the type of messages to send to webhooks.'),

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -477,11 +477,6 @@ def get_args():
     parser.add_argument('-sn', '--status-name', default=str(os.getpid()),
                         help=('Enable status page database update using ' +
                               'STATUS_NAME as main worker name.'))
-    parser.add_argument('-spp', '--status-page-password', default=None,
-                        help='Set the status page password.')
-    parser.add_argument('-spf', '--status-page-filter',
-                        help='Filter worker status inactive for X minutes.',
-                        type=int, default=30)
     parser.add_argument('-hk', '--hash-key', default=None, action='append',
                         help='Key for hash server')
     parser.add_argument('-novc', '--no-version-check', action='store_true',
@@ -533,15 +528,22 @@ def get_args():
                          type=int, dest='verbose')
     rarity = parser.add_argument_group('Dynamic Rarity')
     rarity.add_argument('-Rh', '--rarity-hours',
-                        help=('Number of hours of Pokemon data to use' +
-                              ' to calculate dynamic rarity. Decimals' +
-                              ' allowed. Default: 48. 0 to use all data.'),
+                        help=('Number of hours of Pokemon data to use ' +
+                              'to calculate dynamic rarity. Decimals ' +
+                              'allowed. Default: 48. 0 to use all data.'),
                         type=float, default=48)
     rarity.add_argument('-Rf', '--rarity-update-frequency',
-                        help=('How often (in minutes) the dynamic rarity' +
-                              ' should be updated. Decimals allowed.' +
-                              ' Default: 0. 0 to disable.'),
+                        help=('How often (in minutes) the dynamic rarity ' +
+                              'should be updated. Decimals allowed. ' +
+                              'Default: 0. 0 to disable.'),
                         type=float, default=0)
+    statusp = parser.add_argument_group('Status Page')
+    statusp.add_argument('-SPp', '--status-page-password', default=None,
+                         help='Set the status page password.')
+    statusp.add_argument('-SPf', '--status-page-filter',
+                         help=('Filter worker status that are inactive for ' +
+                               'X minutes. Default: 30. 0 to disable.'),
+                         type=int, default=30)
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -386,6 +386,22 @@ def get_args():
               'queue falls behind.'),
         type=int,
         default=1)
+    group = parser.add_argument_group('Database Cleanup')
+    group.add_argument('-dbc', '--db-cleanup',
+                       help='Enable database regular cleanup thread.',
+                       action='store_true', default=False)
+    group.add_argument('-dbcp', '--db-cleanup-pokemon',
+                       help=('Clear Pokemon from database X hours ' +
+                             'after they disappear (0 to disable).'),
+                       type=int, default=0)
+    group.add_argument('-dbcg', '--db-cleanup-gym',
+                       help=('Clear Gym details from database X ' +
+                             'hours after being scanned (0 to disable).'),
+                       type=int, default=3)
+    group.add_argument('-dbcs', '--db-cleanup-spawnpoint',
+                       help=('Clear Spawnpoint from database without a ' +
+                             'valid scan for X hours (0 to disable).'),
+                       type=int, default=720)
     parser.add_argument(
         '-wh',
         '--webhook',
@@ -397,21 +413,6 @@ def get_args():
                         help=('Get all details about gyms (causes an ' +
                               'additional API hit for every gym).'),
                         action='store_true', default=False)
-    parser.add_argument('-dbc', '--db-cleanup',
-                        help='Enable database regular cleanup thread.',
-                        action='store_true', default=False)
-    parser.add_argument('-dbcp', '--db-cleanup-pokemon',
-                        help=('Clear Pokemon from database X hours ' +
-                              'after they disappear (0 to disable).'),
-                        type=int, default=0)
-    parser.add_argument('-dbcg', '--db-cleanup-gym',
-                        help=('Clear Gym details from database X ' +
-                              'hours after being scanned (0 to disable).'),
-                        type=int, default=3)
-    parser.add_argument('-dbcs', '--db-cleanup-spawnpoint',
-                        help=('Clear Spawnpoint from database without a ' +
-                              'valid scan for X hours (0 to disable).'),
-                        type=int, default=720)
     parser.add_argument(
         '--wh-types',
         help=('Defines the type of messages to send to webhooks.'),

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -387,21 +387,29 @@ def get_args():
         type=int,
         default=1)
     group = parser.add_argument_group('Database Cleanup')
-    group.add_argument('-dbc', '--db-cleanup',
-                       help='Enable database regular cleanup thread.',
+    group.add_argument('-DC', '--db-cleanup',
+                       help='Enable regular database cleanup thread.',
                        action='store_true', default=False)
-    group.add_argument('-dbcp', '--db-cleanup-pokemon',
-                       help=('Clear Pokemon from database X hours ' +
-                             'after they disappear (0 to disable).'),
+    group.add_argument('-DCw', '--db-cleanup-worker',
+                       help=('Clear worker status from database after X ' +
+                             'minutes of inactivity (0 to disable).'),
+                       type=int, default=30)
+    group.add_argument('-DCp', '--db-cleanup-pokemon',
+                       help=('Clear pokemon from database X hours ' +
+                             'after they disappeared (0 to disable).'),
                        type=int, default=0)
-    group.add_argument('-dbcg', '--db-cleanup-gym',
-                       help=('Clear Gym details from database X ' +
-                             'hours after being scanned (0 to disable).'),
-                       type=int, default=3)
-    group.add_argument('-dbcs', '--db-cleanup-spawnpoint',
-                       help=('Clear Spawnpoint from database without a ' +
-                             'valid scan for X hours (0 to disable).'),
+    group.add_argument('-DCg', '--db-cleanup-gym',
+                       help=('Clear gym details from database X hours ' +
+                             'after last gym scan (0 to disable).'),
+                       type=int, default=8)
+    group.add_argument('-DCs', '--db-cleanup-spawnpoint',
+                       help=('Clear spawnpoint from database X hours ' +
+                             'after last valid scan (0 to disable).'),
                        type=int, default=720)
+    group.add_argument('-DCf', '--db-cleanup-forts',
+                       help=('Clear gyms and pokestops from database X days ' +
+                             'after last valid scan (0 to disable).'),
+                       type=int, default=0)
     parser.add_argument(
         '-wh',
         '--webhook',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -320,12 +320,12 @@ def get_args():
                         type=int, default=20)
     parser.add_argument('-kph', '--kph',
                         help=('Set a maximum speed in km/hour for scanner ' +
-                              'movement. 0 to disable. Default: 35.'),
+                              'movement. Default: 35, 0 to disable.'),
                         type=int, default=35)
     parser.add_argument('-hkph', '--hlvl-kph',
                         help=('Set a maximum speed in km/hour for scanner ' +
                               'movement, for high-level (L30) accounts. ' +
-                              '0 to disable. Default: 25.'),
+                              'Default: 25, 0 to disable.'),
                         type=int, default=25)
     parser.add_argument('-ldur', '--lure-duration',
                         help=('Change duration for lures set on pokestops. ' +
@@ -392,23 +392,28 @@ def get_args():
                        action='store_true', default=False)
     group.add_argument('-DCw', '--db-cleanup-worker',
                        help=('Clear worker status from database after X ' +
-                             'minutes of inactivity (0 to disable).'),
+                             'minutes of inactivity. ' +
+                             'Default: 30, 0 to disable.'),
                        type=int, default=30)
     group.add_argument('-DCp', '--db-cleanup-pokemon',
                        help=('Clear pokemon from database X hours ' +
-                             'after they disappeared (0 to disable).'),
+                             'after they disappeared. ' +
+                             'Default: 0, 0 to disable.'),
                        type=int, default=0)
     group.add_argument('-DCg', '--db-cleanup-gym',
                        help=('Clear gym details from database X hours ' +
-                             'after last gym scan (0 to disable).'),
+                             'after last gym scan. ' +
+                             'Default: 8, 0 to disable.'),
                        type=int, default=8)
     group.add_argument('-DCs', '--db-cleanup-spawnpoint',
                        help=('Clear spawnpoint from database X hours ' +
-                             'after last valid scan (0 to disable).'),
+                             'after last valid scan. ' +
+                             'Default: 720, 0 to disable.'),
                        type=int, default=720)
     group.add_argument('-DCf', '--db-cleanup-forts',
                        help=('Clear gyms and pokestops from database X days ' +
-                             'after last valid scan (0 to disable).'),
+                             'after last valid scan. ' +
+                             'Default: 0, 0 to disable.'),
                        type=int, default=0)
     parser.add_argument(
         '-wh',
@@ -530,19 +535,19 @@ def get_args():
     rarity.add_argument('-Rh', '--rarity-hours',
                         help=('Number of hours of Pokemon data to use ' +
                               'to calculate dynamic rarity. Decimals ' +
-                              'allowed. Default: 48. 0 to use all data.'),
+                              'allowed. Default: 48, 0 to use all data.'),
                         type=float, default=48)
     rarity.add_argument('-Rf', '--rarity-update-frequency',
                         help=('How often (in minutes) the dynamic rarity ' +
                               'should be updated. Decimals allowed. ' +
-                              'Default: 0. 0 to disable.'),
+                              'Default: 0, 0 to disable.'),
                         type=float, default=0)
     statusp = parser.add_argument_group('Status Page')
     statusp.add_argument('-SPp', '--status-page-password', default=None,
                          help='Set the status page password.')
     statusp.add_argument('-SPf', '--status-page-filter',
                          help=('Filter worker status that are inactive for ' +
-                               'X minutes. Default: 30. 0 to disable.'),
+                               'X minutes. Default: 30, 0 to disable.'),
                          type=int, default=30)
     parser.set_defaults(DEBUG=False)
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -479,6 +479,9 @@ def get_args():
                               'STATUS_NAME as main worker name.'))
     parser.add_argument('-spp', '--status-page-password', default=None,
                         help='Set the status page password.')
+    parser.add_argument('-spf', '--status-page-filter',
+                        help='Filter worker status inactive for X minutes.',
+                        type=int, default=30)
     parser.add_argument('-hk', '--hash-key', default=None, action='append',
                         help='Key for hash server')
     parser.add_argument('-novc', '--no-version-check', action='store_true',

--- a/runserver.py
+++ b/runserver.py
@@ -372,7 +372,7 @@ def main():
         t.start()
 
     # Database cleaner; really only need one ever.
-    if args.enable_clean:
+    if args.db_cleanup:
         t = Thread(target=clean_db_loop, name='db-cleaner', args=(args,))
         t.daemon = True
         t.start()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Keeping the database size under control is an issue because some tables never get cleanup.
## Description
<!--- Describe your changes in detail -->
Pulled the changes from #2281, rebased it and added a SpawnPoint cleanup routine.
Since SpawnPoint are a bit tricky and are connected to other three tables (ScanSpawnPoint, SpawnPointDetectionData and ScannedLocation) I tried to cascade the cleanup so that all relevant information is kept and only incorrect data is deleted.

**Update**
Removed spawnpoint integrity checks, because they were slow and computationally expensive.
Simplified the spawnpoint cleanup routine so that it removes old SpawnPoint that haven't got a valid scan in a while. SpawnpointDetectionData is also purged of old entries. All related tables are updated so that the data maintains integrity.

**-DC, --db-cleanup**: previously `-DC, --enable-clean`, changed to have consistency between the parameters involved in the database cleanup routine.
- **-DCw, --db-cleanup-worker**: controls how long will inactive worker status remain in the database.
  - Default value is 30 minutes, can be disabled with 0.
- **-DCp, --db-cleanup-pokemon**: previously `-pd, --purge-data`, has the same meaning as before - controls the age of Pokemon spawns that remain in the database.
  - Default value is 0 *disabled*. Recommended 720 hours (30 days).
- **-DCg, --db-cleanup-gym**: lets you control the maximum age of Gym Details, Gym Members and Gym Pokemon that stay on the database.
  - Default is 8 hours. It's up to you to define how long data becomes outdated. Can be disabled.
- **-DCs, --db-cleanup-spawnpoint**: controls the maximum age of Pokemon Spawnpoints **without valid scans** and also controls how long SpawnpointDetectionData can remain in the database.
  - Default value is 720 hours (30 days).
- **-DCf, --db-cleanup-fort**: controls how long can Gyms and Pokestops remain in database without being scanned.
  - Default value is 0 *disabled*.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Big databases clog up servers and can have a detrimental impact on the performance of the scanners.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
MySQL tests went fine... Didn't even need to disable foreign key checks.

```
[db-cleaner][models][   DEBUG] Regular database cleanup started.
[db-cleaner][models][   DEBUG] Completed regular cleanup in 0.004396 seconds.
[db-cleaner][models][   DEBUG] Beginning cleanup of old worker status.
[db-cleaner][models][   DEBUG] Completed cleanup of old worker status in 0.001754 seconds.
[db-cleaner][models][   DEBUG] Beginning cleanup of old pokemon spawns.
[db-cleaner][models][   DEBUG] Deleted 0 old Pokemon entries.
[db-cleaner][models][   DEBUG] Completed cleanup of old pokemon spawns in 0.001303 seconds.
[db-cleaner][models][   DEBUG] Beginning cleanup of old gym data.
[db-cleaner][models][   DEBUG] Deleted 0 old GymDetails entries.
[db-cleaner][models][   DEBUG] Deleted 0 old Raid entries.
[db-cleaner][models][   DEBUG] Deleted 0 old GymMember entries.
[db-cleaner][models][   DEBUG] Deleted 0 old GymPokemon entries.
[db-cleaner][models][   DEBUG] Completed cleanup of old gym data in 0.003231 seconds.
[db-cleaner][models][   DEBUG] Beginning cleanup of old spawnpoint data.
[db-cleaner][models][   DEBUG] Found 0 old SpawnPoint entries.
[db-cleaner][models][   DEBUG] Deleted 0 old SpawnpointDetectionData entries.
[db-cleaner][models][   DEBUG] Found 0 ScannedLocation entries from old spawnpoints.
[db-cleaner][models][   DEBUG] Deleted 0 ScanSpawnPoint entries from old spawnpoints.
[db-cleaner][models][   DEBUG] Deleted 0 old SpawnPoint entries.
[db-cleaner][models][   DEBUG] Deleted 0 ScanSpawnPoint entries from old scan locations.
[db-cleaner][models][   DEBUG] Deleted 0 ScannedLocation entries from old spawnpoints.
[db-cleaner][models][   DEBUG] Completed cleanup of old spawnpoint data in 0.008164 seconds.
[db-cleaner][models][   DEBUG] Beginning cleanup of old forts.
[db-cleaner][models][   DEBUG] Deleted 0 old Gym entries.
[db-cleaner][models][   DEBUG] Deleted 0 old Pokestop entries.
[db-cleaner][models][   DEBUG] Completed cleanup of old forts in 0.002356 seconds.
[db-cleaner][models][    INFO] Full database cleanup completed.
````

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
