### PR TITLE
added more gen3 moves

### DIFF
--- a/static/data/moves.json
+++ b/static/data/moves.json
@@ -1750,5 +1750,77 @@
         "duration": 1500,
         "energy": 15,
         "dps": 10
+    },
+    "282": {
+        "name": "Take Down",
+        "type": "Normal",
+        "damage": 8,
+        "duration": 1200,
+        "energy": 10,
+        "dps": 6.7
+    },
+    "283": {
+        "name": "Waterfall",
+        "type": "Water",
+        "damage": 16,
+        "duration": 1200,
+        "energy": 8,
+        "dps": 13.33
+    },
+    "284": {
+        "name": "Surf",
+        "type": "Water",
+        "damage": 65,
+        "duration": 1700,
+        "energy": 50,
+        "dps": 29.5
+    },
+    "285": {
+        "name": "Draco Meteor",
+        "type": "Dragon",
+        "damage": 150,
+        "duration": 3600,
+        "energy": 100,
+        "dps": 36.6
+    },
+    "286": {
+        "name": "Doom Desire",
+        "type": "Steel",
+        "damage": 80,
+        "duration": 1700,
+        "energy": 50,
+        "dps": 36.4
+    },
+    "287": {
+        "name": "Yawn",
+        "type": "Normal",
+        "damage": 0,
+        "duration": 1700,
+        "energy": 15,
+        "dps": 0
+    },
+    "288": {
+        "name": "Psycho Boost",
+        "type": "Psychic",
+        "damage": 70,
+        "duration": 4000,
+        "energy": 50,
+        "dps": 15.6
+    },
+    "289": {
+        "name": "Origin Pulse",
+        "type": "Water",
+        "damage": 130,
+        "duration": 1700,
+        "energy": 100,
+        "dps": 59.1
+    },
+    "290": {
+        "name": "Precipice Blades",
+        "type": "Ground",
+        "damage": 130,
+        "duration": 1700,
+        "energy": 100,
+        "dps": 59.1
     }
 }


### PR DESCRIPTION
Some moves were not present in moves json file. This prevent gym sidebar to load if a Pokémon with one of the missing moves is deployed at the gym. All stats pulled from [https://pokemon.gameinfo.io/en/moves](url).

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Local instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.