### PR TITLE
Add user interface option to Notify by Pokemon Level

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -869,6 +869,9 @@ var StoreOptions = {
     'excludedRarity': {
         default: 0, // 0: none, 1: <=Common, 2: <=Uncommon, 3: <=Rare, 4: <=Very Rare, 5: <=Ultra Rare
         type: StoreTypes.Number
+    'remember_text_level_notify': {
+        default: '',
+        type: StoreTypes.Number
     },
     'showRaids': {
         default: false,

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -862,13 +862,14 @@ var StoreOptions = {
         default: [], // Common, Uncommon, Rare, Very Rare, Ultra Rare
         type: StoreTypes.JSON
     },
+    'excludedRarity': {
+        default: 0, // 0: none, 1: <=Common, 2: <=Uncommon, 3: <=Rare, 4: <=Very Rare, 5: <=Ultra Rare
+        type: StoreTypes.Number
+    },
     'remember_text_perfection_notify': {
         default: '',
         type: StoreTypes.Number
     },
-    'excludedRarity': {
-        default: 0, // 0: none, 1: <=Common, 2: <=Uncommon, 3: <=Rare, 4: <=Very Rare, 5: <=Ultra Rare
-        type: StoreTypes.Number
     'remember_text_level_notify': {
         default: '',
         type: StoreTypes.Number

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -862,16 +862,16 @@ var StoreOptions = {
         default: [], // Common, Uncommon, Rare, Very Rare, Ultra Rare
         type: StoreTypes.JSON
     },
-    'excludedRarity': {
-        default: 0, // 0: none, 1: <=Common, 2: <=Uncommon, 3: <=Rare, 4: <=Very Rare, 5: <=Ultra Rare
-        type: StoreTypes.Number
-    },
     'remember_text_perfection_notify': {
         default: '',
         type: StoreTypes.Number
     },
     'remember_text_level_notify': {
         default: 0,
+        type: StoreTypes.Number
+    },
+    'excludedRarity': {
+        default: 0, // 0: none, 1: <=Common, 2: <=Uncommon, 3: <=Rare, 4: <=Very Rare, 5: <=Ultra Rare
         type: StoreTypes.Number
     },
     'showRaids': {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -871,7 +871,7 @@ var StoreOptions = {
         type: StoreTypes.Number
     },
     'remember_text_level_notify': {
-        default: '',
+        default: 0,
         type: StoreTypes.Number
     },
     'showRaids': {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1055,8 +1055,8 @@ function isNotifyPerfectionPoke(poke) {
         const perfection = getIv(poke['individual_attack'], poke['individual_defense'], poke['individual_stamina'])
         const level = getPokemonLevel(poke['cp_multiplier'])
 
-        const hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
-        const hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
+        hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
+        hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
 
         const shouldNotifyForIV = (hasHighIV && notifiedMinLevel <= 0)
         const shouldNotifyForLevel = (hasHighLevel && (hasHighIV || notifiedMinPerfection <= 0))

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -6,6 +6,7 @@ var $selectExclude
 var $selectPokemonNotify
 var $selectRarityNotify
 var $textPerfectionNotify
+var $textLevelNotify
 var $selectStyle
 var $selectIconSize
 var $switchOpenGymsOnly
@@ -37,6 +38,7 @@ var excludedRarity
 var notifiedPokemon = []
 var notifiedRarity = []
 var notifiedMinPerfection = null
+var notifiedMinLevel = null
 
 var buffer = []
 var reincludedPokemon = []
@@ -1046,17 +1048,24 @@ function playPokemonSound(pokemonID, cryFileTypes) {
 
 function isNotifyPerfectionPoke(poke) {
     var hasHighIV = false
+    var hasHighLevel = false
+    var hasHighAttributes = false
 
-    if (poke['individual_attack'] != null) {
+    if (poke['individual_attack'] != null && poke['cp_multiplier'] !== null) {
         const perfection = getIv(poke['individual_attack'], poke['individual_defense'], poke['individual_stamina'])
+        const level = getPokemonLevel(poke['cp_multiplier'])
+
         hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
+        hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
+
+        hasHighAttributes = (hasHighIV && !(notifiedMinLevel > 0)) || (hasHighLevel && !(notifiedMinPerfection > 0)) || hasHighLevel && hasHighIV
     }
 
-    return hasHighIV
+    return hasHighAttributes
 }
 
 function isNotifyPoke(poke) {
-    const isOnNotifyList = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
+    const    = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
     const isNotifyPerfectionPkmn = isNotifyPerfectionPoke(poke)
     const showStats = Store.get('showPokemonStats')
 
@@ -2687,6 +2696,7 @@ $(function () {
     $selectPokemonNotify = $('#notify-pokemon')
     $selectRarityNotify = $('#notify-rarity')
     $textPerfectionNotify = $('#notify-perfection')
+    $textLevelNotify = $('#notify-level')
     var numberOfPokemon = 493
 
     // Load pokemon names and populate lists
@@ -2768,6 +2778,17 @@ $(function () {
             $textPerfectionNotify.val(notifiedMinPerfection)
             Store.set('remember_text_perfection_notify', notifiedMinPerfection)
         })
+        $textLevelNotify.on('change', function (e) {
+            notifiedMinLevel = parseInt($textLevelNotify.val(), 10)
+            if (isNaN(notifiedMinLevel) || notifiedMinLevel <= 0) {
+                notifiedMinLevel = ''
+            }
+            if (notifiedMinLevel > 40) {
+                notifiedMinLevel = 40
+            }
+            $textLevelNotify.val(notifiedMinLevel)
+            Store.set('remember_text_level_notify', notifiedMinLevel)
+        })
 
         // recall saved lists
         $selectExclude.val(Store.get('remember_select_exclude')).trigger('change')
@@ -2775,6 +2796,7 @@ $(function () {
         $selectPokemonNotify.val(Store.get('remember_select_notify')).trigger('change')
         $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
         $textPerfectionNotify.val(Store.get('remember_text_perfection_notify')).trigger('change')
+        $textLevelNotify.val(Store.get('remember_text_level_notify')).trigger('change')
 
         if (isTouchDevice() && isMobileDevice()) {
             $('.select2-search input').prop('readonly', true)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1065,7 +1065,7 @@ function isNotifyPerfectionPoke(poke) {
 }
 
 function isNotifyPoke(poke) {
-    const    = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
+    const isOnNotifyList = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
     const isNotifyPerfectionPkmn = isNotifyPerfectionPoke(poke)
     const showStats = Store.get('showPokemonStats')
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1047,21 +1047,25 @@ function playPokemonSound(pokemonID, cryFileTypes) {
 }
 
 function isNotifyPerfectionPoke(poke) {
-    var hasHighIV = false
-    var hasHighLevel = false
     var hasHighAttributes = false
+    var hasHighIV = false
 
-    if (poke['individual_attack'] != null && poke['cp_multiplier'] !== null) {
+    // Notify for IV.
+    if (poke['individual_attack'] != null) {
         const perfection = getIv(poke['individual_attack'], poke['individual_defense'], poke['individual_stamina'])
-        const level = getPokemonLevel(poke['cp_multiplier'])
-
         hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
-        hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
-
         const shouldNotifyForIV = (hasHighIV && notifiedMinLevel <= 0)
+
+        hasHighAttributes = shouldNotifyForIV
+    }
+
+    // Or notify for level. If IV filter is enabled, this is an AND relation.
+    if (poke['cp_multiplier'] !== null) {
+        const level = getPokemonLevel(poke['cp_multiplier'])
+        const hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
         const shouldNotifyForLevel = (hasHighLevel && (hasHighIV || notifiedMinPerfection <= 0))
 
-        hasHighAttributes = shouldNotifyForIV || shouldNotifyForLevel
+        hasHighAttributes = hasHighAttributes || shouldNotifyForLevel
     }
 
     return hasHighAttributes

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1055,10 +1055,13 @@ function isNotifyPerfectionPoke(poke) {
         const perfection = getIv(poke['individual_attack'], poke['individual_defense'], poke['individual_stamina'])
         const level = getPokemonLevel(poke['cp_multiplier'])
 
-        hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
-        hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
+        const hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
+        const hasHighLevel = notifiedMinLevel > 0 && level >= notifiedMinLevel
 
-        hasHighAttributes = (hasHighIV && !(notifiedMinLevel > 0)) || (hasHighLevel && !(notifiedMinPerfection > 0)) || hasHighLevel && hasHighIV
+        const shouldNotifyForIV = (hasHighIV && notifiedMinLevel <= 0)
+        const shouldNotifyForLevel = (hasHighLevel && (hasHighIV || notifiedMinPerfection <= 0))
+
+        hasHighAttributes = shouldNotifyForIV || shouldNotifyForLevel
     }
 
     return hasHighAttributes
@@ -2783,8 +2786,8 @@ $(function () {
             if (isNaN(notifiedMinLevel) || notifiedMinLevel <= 0) {
                 notifiedMinLevel = ''
             }
-            if (notifiedMinLevel > 40) {
-                notifiedMinLevel = 40
+            if (notifiedMinLevel > 35) {
+                notifiedMinLevel = 35
             }
             $textLevelNotify.val(notifiedMinLevel)
             Store.set('remember_text_level_notify', notifiedMinLevel)

--- a/templates/map.html
+++ b/templates/map.html
@@ -378,6 +378,12 @@
                 </label>
               </div>
             </div>
+            <div class="form-control">
+              <label for="notify-level">
+                <h3>Notify of Level</h3>
+                <input id="notify-level" type="text" name="notify-level" placeholder="Minimum level"/>
+              </label>
+            </div>
               {% endif %}
             <div class="form-control switch-container">
               <h3>Notify with sound</h3>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a user interface option to notify by pokemon level.  This is virtually the same coding as the notify by pokemon perfection.

If the user enters a pokemon level between 1 and 40, the map will notify them if a pokemon meeting that level is found.  If both a level and perfection notification are configured, a pokemon will only be notified if it meets both criteria.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was request in the PR channel and I have had multiple users request this feature.  It is especially interesting now with weather-boosting causing pokemon with level 35 to be found in the wild

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the code on my Rocketmap server user interface under Ubuntu 16.04.
I tweaked it until it worked as desired.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15407947/34072662-11c67c98-e251-11e7-9a28-f0374b97b0e4.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
