### PR TITLE
Reduce to 5m jitter + disable by default.

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -112,8 +112,8 @@
                             Query the Elevation API for each step, rather than
                             only once, and store results in the database. [env
                             var: POGOMAP_USE_ALTITUDE_CACHE]
-      -nj, --no-jitter      Don't apply random -9m to +9m jitter to location. [env
-                            var: POGOMAP_NO_JITTER]
+      -nj, --no-jitter      Apply random -5m to +5m jitter to location. [env
+                            var: POGOMAP_JITTER]
       -al, --access-logs    Write web logs to access.log. [env var:
                             POGOMAP_ACCESS_LOGS]
       -st STEP_LIMIT, --step-limit STEP_LIMIT

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -112,7 +112,7 @@
                             Query the Elevation API for each step, rather than
                             only once, and store results in the database. [env
                             var: POGOMAP_USE_ALTITUDE_CACHE]
-      -nj, --no-jitter      Apply random -5m to +5m jitter to location. [env
+      -j, --jitter          Apply random -5m to +5m jitter to location. [env
                             var: POGOMAP_JITTER]
       -al, --access-logs    Write web logs to access.log. [env var:
                             POGOMAP_ACCESS_LOGS]

--- a/pogom/captcha.py
+++ b/pogom/captcha.py
@@ -124,7 +124,7 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
 
     proxy_url = False
     if args.proxy:
-        # Try to fetch a new proxy
+        # Try to fetch a new proxy.
         proxy_num, proxy_url = get_new_proxy(args)
 
         if proxy_url:
@@ -133,8 +133,8 @@ def captcha_solver_thread(args, account_queue, account_captchas, hash_key,
 
     location = account['last_location']
 
-    if not args.no_jitter:
-        # Jitter location before uncaptcha attempt
+    if args.jitter:
+        # Jitter location before uncaptcha attempt.
         location = jitter_location(location)
 
     api.set_position(*location)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -916,9 +916,9 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                 scan_location = ScannedLocation.get_by_loc(scan_coords)
 
                 # Jitter the coords if configured.
-                if not args.no_jitter:
+                if args.jitter:
                     scan_coords = jitter_location(scan_coords)
-                    log.debug('Jittered to: %f/%f/%f', scan_coords[0],
+                    log.debug('Jittered to: %f/%f/%f.', scan_coords[0],
                               scan_coords[1], scan_coords[2])
 
                 # Too soon?
@@ -1007,8 +1007,7 @@ def search_worker_thread(args, account_queue, account_sets, account_failures,
                         # Make another request for the same location
                         # since the previous one was captcha'd.
                         scan_date = datetime.utcnow()
-                        response_dict = gmo(
-                            api, account, scan_coords, args.no_jitter)
+                        response_dict = gmo(api, account, scan_coords)
                     elif captcha is not None:
                         account_queue.task_done()
                         time.sleep(3)

--- a/pogom/transform.py
+++ b/pogom/transform.py
@@ -94,9 +94,9 @@ def fast_get_new_coords(origin, distance, bearing):
 
 
 # Apply a location jitter.
-def jitter_location(location=None, maxMeters=10):
+def jitter_location(location=None, max_meters=5):
     origin = geopy.Point(location[0], location[1])
     bearing = random.randint(0, 360)
-    distance = math.sqrt(random.random()) * (float(maxMeters))
+    distance = math.sqrt(random.random()) * (float(max_meters))
     destination = fast_get_new_coords(origin, distance, bearing)
     return (destination[0], destination[1], location[2])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -116,8 +116,8 @@ def get_args():
                               ' the database.'),
                         action='store_true', default=False)
     parser.add_argument('-j', '--jitter',
-                        help=("Apply random -5m to +5m jitter to " +
-                              "location."),
+                        help=('Apply random -5m to +5m jitter to ' +
+                              'location.'),
                         action='store_true', default=False)
     parser.add_argument('-al', '--access-logs',
                         help=("Write web logs to access.log."),

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -115,8 +115,8 @@ def get_args():
                               ' rather than only once, and store results in' +
                               ' the database.'),
                         action='store_true', default=False)
-    parser.add_argument('-nj', '--no-jitter',
-                        help=("Don't apply random -9m to +9m jitter to " +
+    parser.add_argument('-j', '--jitter',
+                        help=("Apply random -5m to +5m jitter to " +
                               "location."),
                         action='store_true', default=False)
     parser.add_argument('-al', '--access-logs',


### PR DESCRIPTION
## Description
* Disabled jitter by default.
* Reduced jitter range to -5m, +5m.
* Removed positional argument to `gmo()` call that was too much.
* Renamed maxMeter to max_meter.

## Motivation and Context
* As discussed on Discord, we'll disable it for now. Consistency of scans first, test 5m jitter over a longer period, review afterwards.
* Avoid getting too far from the original scan location/range, causing empty scans.
* `gmo()` doesn't have a "jitter" argument.
* Better fits code style.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
