### PR TITLE
Update custom.js.example to disable marker clustering even when js load order make the library load before custom.js

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -1,8 +1,8 @@
 $(function () {
     'use strict'
 
-    //marker cluster might have loaded before custom.js
-    const isMarkerClusterLoaded = !!markerCluster;
+    // Marker cluster might have loaded before custom.js
+    const isMarkerClusterLoaded = typeof window.markerCluster !== 'undefined' && !!window.markerCluster
 
     /* Settings. */
 
@@ -84,9 +84,9 @@ $(function () {
     if (disableClusters) {
         Store.set('maxClusterZoomLevel', -1)
 
-        if(isMarkerClusterLoaded) {
-			markerCluster.setMaxZoom(-1)
-		}
+        if (isMarkerClusterLoaded) {
+            window.markerCluster.setMaxZoom(-1)
+        }
     }
 
     // Google Analytics.

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -1,7 +1,7 @@
 $(function () {
     'use strict'
 
-    // Marker cluster might have loaded before custom.js
+    // Marker cluster might have loaded before custom.js.
     const isMarkerClusterLoaded = typeof window.markerCluster !== 'undefined' && !!window.markerCluster
 
     /* Settings. */

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -1,6 +1,8 @@
 $(function () {
     'use strict'
 
+    //marker cluster might have loaded before custom.js
+    const isMarkerClusterLoaded = !!markerCluster;
 
     /* Settings. */
 
@@ -81,6 +83,10 @@ $(function () {
 
     if (disableClusters) {
         Store.set('maxClusterZoomLevel', -1)
+
+        if(isMarkerClusterLoaded) {
+			markerCluster.setMaxZoom(-1)
+		}
     }
 
     // Google Analytics.

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -40,7 +40,7 @@ var reincludedPokemon = []
 var reids = []
 
 var map
-var markerCluster
+var markerCluster = window.markerCluster = {}
 var rawDataIsLoading = false
 var locationMarker
 const rangeMarkers = ['pokemon', 'pokestop', 'gym']


### PR DESCRIPTION
Updates the custom.js example so that if the client happens to be loading for the first time and also at the same time happens to load the marker cluster library before custom.js it will still disable the clusttering without needing a page reload.

## Description
Changed markerCluster definition to be more explicit since we reference it in a different file/context

Checks if markerCluster is defined when custom.js loads and disables clustering directly on the markerCluster object if it is available + needed

If there is other obvious places/things that should utilize the same "hack", it probably should be in this PR as well

## Motivation and Context
Some of my users are paranoid and runs RM in incognito mode, but would always complain that marker clustering was enabled until they reloaded the page.

## How Has This Been Tested?
Opened my local map in incognito mode and saw that there was in fact no pokemon clustering

## Screenshots (if appropriate):
(your mind sees a beautiful image of a lot of pokemon in a map where there would be grouping indicators before - you sigh in awe at the awesomeness of technology)
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
