### PR TITLE
Avoid converting coordinates to int

### DIFF
--- a/pogom/apiRequests.py
+++ b/pogom/apiRequests.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from pgoapi.utilities import f2i, get_cell_ids
+from pgoapi.utilities import get_cell_ids
 from pgoapi.hash_server import BadHashRequestException, HashingOfflineException
 
 log = logging.getLogger(__name__)
@@ -239,8 +239,8 @@ def get_map_objects(api, account, location):
     timestamps = [0, ]*len(cell_ids)
     req = api.create_request()
     req.get_map_objects(
-        latitude=f2i(location[0]),
-        longitude=f2i(location[1]),
+        latitude=location[0],
+        longitude=location[1],
         since_timestamp_ms=timestamps,
         cell_id=cell_ids)
     return send_generic_request(req, account)
@@ -251,8 +251,8 @@ def gym_get_info(api, account, position, gym):
     req = api.create_request()
     req.gym_get_info(
         gym_id=gym['gym_id'],
-        player_lat_degrees=f2i(position[0]),
-        player_lng_degrees=f2i(position[1]),
+        player_lat_degrees=position[0],
+        player_lng_degrees=position[1],
         gym_lat_degrees=gym['latitude'],
         gym_lng_degrees=gym['longitude'])
     return send_generic_request(req, account)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Coordinates in the api are float and all other apis are sending regular floats with the coords but we kept sending then converted to ints.
Anyway it seems those fields are not taken into account by the server as it uses the location in the envelope,

## Motivation and Context
Avoid easy flags

## How Has This Been Tested?
Runing for 1 day in may production server.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
