### PR TITLE
Update to fix CONSTRAINT_4 error for spawnpoint table

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1555,8 +1555,8 @@ class SpawnpointDetectionData(BaseModel):
         # Only ssss spawns from here below.
 
         sp['links'] = '+++-'
-        
-        # Cover all bases, make sure we're using values < 3600.		
+
+        # Cover all bases, make sure we're using values < 3600.
         # Warning: python uses modulo as the least residue, not as
         # remainder, so we don't apply it to the result.
         residue_unseen = sp['earliest_unseen'] % 3600
@@ -1644,7 +1644,7 @@ class SpawnpointDetectionData(BaseModel):
     def unseen(sp, now_secs):
 
         # Return if we already have a tth.
-        # Cover all bases, make sure we're using values < 3600.		
+        # Cover all bases, make sure we're using values < 3600.
         # Warning: python uses modulo as the least residue, not as
         # remainder, so we don't apply it to the result.
         residue_unseen = sp['earliest_unseen'] % 3600
@@ -1915,7 +1915,7 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                     (p.last_modified_timestamp_ms +
                      p.time_till_hidden_ms) / 1000.0))
 
-                # Cover all bases, make sure we're using values < 3600.		
+                # Cover all bases, make sure we're using values < 3600.
                 # Warning: python uses modulo as the least residue, not as
                 # remainder, so we don't apply it to the result.
                 residue_unseen = sp['earliest_unseen'] % 3600

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1180,7 +1180,7 @@ class SpawnPoint(LatLongModel):
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
         constraints = [Check('earliest_unseen >= 0'),
-                       Check('earliest_unseen < 3600'),
+                       Check('earliest_unseen <= 3600'),
                        Check('latest_seen >= 0'), Check('latest_seen <= 3600')]
 
     # Returns the spawnpoint dict from ID, or a new dict if not found.
@@ -1269,7 +1269,11 @@ class SpawnPoint(LatLongModel):
     def tth_found(sp):
         # Fully indentified if no '?' in links and
         # latest_seen == earliest_unseen.
-        return sp['latest_seen'] == sp['earliest_unseen']
+        # Warning: python uses modulo as the least residue, not as
+        # remainder, so we don't apply it to the result.
+        latest_seen = (sp['latest_seen'] % 3600)
+        earliest_unseen = (sp['earliest_unseen'] % 3600)
+        return latest_seen - earliest_unseen == 0
 
     # Return [start, end] in seconds after the hour for the spawn, despawn
     # time of a spawnpoint.
@@ -1530,9 +1534,13 @@ class SpawnpointDetectionData(BaseModel):
         sp['links'] = sp['kind'].replace('s', '?')
 
         if sp['kind'] != 'ssss':
-
+            # Cover all bases, make sure we're using values < 3600.
+            # Warning: python uses modulo as the least residue, not as
+            # remainder, so we don't apply it to the result.
+            residue_unseen = sp['earliest_unseen'] % 3600
+            residue_seen = sp['latest_seen'] % 3600
             if (not sp['earliest_unseen'] or
-                    sp['earliest_unseen'] != sp['latest_seen'] or
+                    residue_unseen != residue_seen or
                     not tth_found):
 
                 # New latest_seen will be just before max_gap.
@@ -1547,7 +1555,14 @@ class SpawnpointDetectionData(BaseModel):
         # Only ssss spawns from here below.
 
         sp['links'] = '+++-'
-        if sp['earliest_unseen'] == sp['latest_seen']:
+        
+        # Cover all bases, make sure we're using values < 3600.		
+        # Warning: python uses modulo as the least residue, not as
+        # remainder, so we don't apply it to the result.
+        residue_unseen = sp['earliest_unseen'] % 3600
+        residue_seen = sp['latest_seen'] % 3600
+
+        if residue_unseen == residue_seen:
             return
 
         # Make a sight_list of dicts:
@@ -1629,7 +1644,13 @@ class SpawnpointDetectionData(BaseModel):
     def unseen(sp, now_secs):
 
         # Return if we already have a tth.
-        if sp['latest_seen'] == sp['earliest_unseen']:
+        # Cover all bases, make sure we're using values < 3600.		
+        # Warning: python uses modulo as the least residue, not as
+        # remainder, so we don't apply it to the result.
+        residue_unseen = sp['earliest_unseen'] % 3600
+        residue_seen = sp['latest_seen'] % 3600
+
+        if residue_seen == residue_unseen:
             return False
 
         # If now_secs is later than the latest seen return.
@@ -1893,7 +1914,14 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                 d_t_secs = date_secs(datetime.utcfromtimestamp(
                     (p.last_modified_timestamp_ms +
                      p.time_till_hidden_ms) / 1000.0))
-                if (sp['latest_seen'] != sp['earliest_unseen'] or
+
+                # Cover all bases, make sure we're using values < 3600.		
+                # Warning: python uses modulo as the least residue, not as
+                # remainder, so we don't apply it to the result.
+                residue_unseen = sp['earliest_unseen'] % 3600
+                residue_seen = sp['latest_seen'] % 3600
+
+                if (residue_seen != residue_unseen or
                         not sp['last_scanned']):
                     log.info('TTH found for spawnpoint %s.', sp['id'])
                     sighting['tth_secs'] = d_t_secs
@@ -2239,9 +2267,13 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
         if (not SpawnPoint.tth_found(sp) and scan_location['done'] and
                 (now_secs - sp['latest_seen'] -
                  args.spawn_delay) % 3600 < 60):
+            # Warning: python uses modulo as the least residue, not as
+            # remainder, so we don't apply it to the result. Just a
+            # safety measure until we can guarantee there's never a negative
+            # result.
             log.warning('Spawnpoint %s was unable to locate a TTH, with '
                         'only %ss after Pokemon last seen.', sp['id'],
-                        (now_secs - sp['latest_seen']) % 3600)
+                        (now_secs % 3600 - sp['latest_seen'] % 3600))
             log.info('Restarting current 15 minute search for TTH.')
             if sp['id'] not in sp_id_list:
                 SpawnpointDetectionData.classify(sp, scan_location, now_secs)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3099,13 +3099,15 @@ def database_migrate(db, old_ver):
         db.execute_sql('ALTER TABLE `spawnpoint` '
                        'DROP CONSTRAINT CONSTRAINT_2;')
         db.execute_sql('ALTER TABLE `spawnpoint` '
-                       'ADD CONSTRAINT CONSTRAINT_2 CHECK (`earliest_unseen` <= 3600);')
+                       'ADD CONSTRAINT CONSTRAINT_2 ' +
+                       'CHECK (`earliest_unseen` <= 3600);')
 
         # Drop and add CONSTRAINT_4 with the <= fix.
         db.execute_sql('ALTER TABLE `spawnpoint` '
                        'DROP CONSTRAINT CONSTRAINT_4;')
         db.execute_sql('ALTER TABLE `spawnpoint` '
-                       'ADD CONSTRAINT CONSTRAINT_4 CHECK (`latest_seen` <= 3600);')
+                       'ADD CONSTRAINT CONSTRAINT_4 CHECK ' +
+                       '(`latest_seen` <= 3600);')
 
     # Always log that we're done.
     log.info('Schema upgrade complete.')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1181,7 +1181,7 @@ class SpawnPoint(LatLongModel):
         indexes = ((('latitude', 'longitude'), False),)
         constraints = [Check('earliest_unseen >= 0'),
                        Check('earliest_unseen < 3600'),
-                       Check('latest_seen >= 0'), Check('latest_seen < 3600')]
+                       Check('latest_seen >= 0'), Check('latest_seen <= 3600')]
 
     # Returns the spawnpoint dict from ID, or a new dict if not found.
     @staticmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
RM tries to write DB records with a 'latest_seen=3600' instead of 3599 like the constraint allows for. Changing the Check statement to '=<3600' allows for these records to be written instead of throwing "InternalError(4025, u'CONSTRAINT CONSTRAINT_4 failed for rocketmapdbadmin.spawnpoint')".

Note that this code change will not update existing DBs and will only apply the new constraint to maps that run the -cd flag. 

An FAQ can be added if anyone wants to run the mysql commands to update their DB. The following commands should allow anyone to do it:

```command
mysql -u rocketmapuser -p
```
```mysql
USE 'rocketmapdb';
ALTER TABLE spawnpoint DROP CONSTRAINT CONSTRAINT_4;
ALTER TABLE spawnpoint ADD CONSTRAINT CONSTRAINT_4 CHECK (`latest_seen` <= 3600);
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This error kept occurring on my map and many others. Most have seen this as a resource issue and the only solution was to decrease step size and run a -cd. Search the discord channels, there are 6 pages of results but no real solutions. If this is implemented, people will be able to run their large steps without having to restart a DB if they run into a constraint issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using Ubuntu 17.04 with the GUI desktop installed. Running a speedscan with an -st 200 geofenced to 36723 steps with 600 workers and 10 DB threads. 

**I have not tested the python code change, only the DB constraint commands.**

I have been running this -st 200 with 50K spawnpoints started to get error 4025 when I hit about 75%. I pulled up HeidiSQL to see what was being written. Since I have spawnpoints with 'latest_seen=3599' and saw that RM wanted to write one with 'latest_seen=3600', I changed the constraint on the spawnpoints table with the above commands. Since then, I have not received the error and completed the initial scan. There are about 150 spawnpoints that have 'latest_seen=3600'. 

As my TTH search got smaller, so did the total 'latest_seen=3600' DB records. I was down to 26 after a night so this change should not cause any issues with searching.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
