### PR TITLE
Add connect timeout for webhooks.

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -35,7 +35,8 @@
                     [--enable-clean]
                     [--wh-types {pokemon,gym,raid,egg,tth,gym-info,pokestop,lure,captcha}]
                     [--wh-threads WH_THREADS] [-whc WH_CONCURRENCY]
-                    [-whr WH_RETRIES] [-wht WH_TIMEOUT]
+                    [-whr WH_RETRIES] [-whct WH_CONNECT_TIMEOUT]
+                    [-whrt WH_READ_TIMEOUT]
                     [-whbf WH_BACKOFF_FACTOR] [-whlfu WH_LFU_SIZE]
                     [-whfi WH_FRAME_INTERVAL]
                     [--ssl-certificate SSL_CERTIFICATE]
@@ -342,9 +343,12 @@
       -whr WH_RETRIES, --wh-retries WH_RETRIES
                             Number of times to retry sending webhook data on
                             failure. [env var: POGOMAP_WH_RETRIES]
-      -wht WH_TIMEOUT, --wh-timeout WH_TIMEOUT
-                            Timeout (in seconds) for webhook requests. [env var:
-                            POGOMAP_WH_TIMEOUT]
+      -whct WH_CONNECT_TIMEOUT, --wh-connect-timeout WH_CONNECT_TIMEOUT
+                            Connect timeout (in seconds) for webhook requests.
+                            [env var: POGOMAP_WH_CONNECT_TIMEOUT]
+      -whrt WH_READ_TIMEOUT, --wh-read-timeout WH_READ_TIMEOUT
+                            Read timeout (in seconds) for webhook requests.
+                            [env var: POGOMAP_WH_READ_TIMEOUT]
       -whbf WH_BACKOFF_FACTOR, --wh-backoff-factor WH_BACKOFF_FACTOR
                             Factor (in seconds) by which the delay until next
                             retry will increase. [env var:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -413,8 +413,13 @@ def get_args():
                         help=('Number of times to retry sending webhook ' +
                               'data on failure.'),
                         type=int, default=3)
-    parser.add_argument('-wht', '--wh-timeout',
-                        help='Timeout (in seconds) for webhook requests.',
+    parser.add_argument('-whct', '--wh-connect-timeout',
+                        help=('Connect timeout (in seconds) for webhook' +
+                              ' requests.'),
+                        type=float, default=1.0)
+    parser.add_argument('-whrt', '--wh-read-timeout',
+                        help=('Read timeout (in seconds) for webhook' +
+                              'requests.'),
                         type=float, default=1.0)
     parser.add_argument('-whbf', '--wh-backoff-factor',
                         help=('Factor (in seconds) by which the delay ' +

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -22,14 +22,15 @@ def send_to_webhooks(args, session, message_frame):
         log.critical('Called send_to_webhook() without webhooks.')
         return
 
-    req_timeout = args.wh_timeout
+    connect_timeout = args.wh_connect_timeout
+    read_timeout = args.wh_read_timeout
 
     for w in args.webhooks:
         try:
             # Disable keep-alive and set streaming to True, so we can skip
             # the response content.
             future = session.post(w, json=message_frame,
-                                  timeout=(None, req_timeout),
+                                  timeout=(connect_timeout, read_timeout),
                                   background_callback=__wh_request_completed,
                                   headers={'Connection': 'close'},
                                   stream=True)


### PR DESCRIPTION
## Description
Adds a connect timeout to webhook messages.

## Motivation and Context
Avoids queue buildup when people have an unresponsive receiving webhook server.

This'll also help to make it clearer to people when they should get their receiving webhook servers fixed, instead of thinking that RocketMap is intentionally holding expired messages in the queue (one example which had a queue delay of over two hours).

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
