### PR TITLE
Don't log stack trace for webhook exceptions.

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -152,7 +152,8 @@
 #wh-types:[]                    # List of events to be sent: pokemon, gym, raid, egg, tth, gym-info, pokestop, lure, captcha. (default= nothing)
 #wh-threads:                    # Number of webhook threads; increase if the webhook queue falls behind. (default=1)
 #wh-retries:                    # Number of times to retry sending webhook data on failure (default=5)
-#wh-timeout:                    # Timeout (in seconds) for webhook requests (default=1).
+#wh-connect-timeout:            # Connect timeout (in seconds) for webhook requests (default=1).
+#wh-read-timeout:               # Read timeout (in seconds) for webhook requests (default=1).
 #wh-concurrency:                # Async requests pool size. (default=25)
 #wh-backoff-factor:             # Factor (in seconds) by which the delay until next retry will increase. (default=0.25).
 #wh-lfu-size:                   # Webhook LFU cache max size (default=1000).

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -188,7 +188,7 @@ def __wh_future_completed(future):
         exc = future.exception(timeout=0)
 
         if exc:
-            log.exception("Something's wrong with your webhook: %s.", exc)
+            log.warning("Something's wrong with your webhook: %s.", exc)
     except Exception as ex:
         log.exception('Unexpected exception in exception info: %s.', ex)
 


### PR DESCRIPTION
## Description
Log a warning with the exception but without the stack trace for webhook posts.

I also went ahead and updated the example config for the new webhook timeouts. It seems I had forgotten to do that in #2418.

## Motivation and Context
Heavily reduces the logged lines. People running a receiving webhook server that can't handle the webhook load (PokeAlarm seems to be a common problem in our help chat) will get these error messages spammed in their logs.

We know what errors we can expect, and even just their types are descriptive enough to recognize what's going on (ReadTimeout, ConnectTimeout), so the stack trace is unnecessary.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

  