### PR TITLE
Add location marker + mobile Pokémon chunk processing controls in custom.js.

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -169,9 +169,7 @@ class Pogom(Flask):
         if args.on_demand_timeout > 0:
             self.control_flags['on_demand'].clear()
 
-        search_display = True if (args.search_control and
-                                  args.on_demand_timeout <= 0) else False
-
+        search_display = (args.search_control and args.on_demand_timeout <= 0)
         scan_display = False if (args.only_server or args.fixed_location or
                                  args.spawnpoint_scanning) else True
 

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -1,14 +1,13 @@
 $(function () {
     'use strict'
 
-    // Marker cluster might have loaded before custom.js.
-    const isMarkerClusterLoaded = typeof window.markerCluster !== 'undefined' && !!window.markerCluster
-
     /* Settings. */
 
+    const showLocationMarker = false // Show a marker on the map's scan location. Default: false.
+    const isLocationMarkerMovable = false // Let the user move the marker around. Doesn't do anything without --no-fixed-location. Default: false.
     const scaleByRarity = true // Enable scaling by rarity. Default: true.
     const upscalePokemon = false // Enable upscaling of certain Pokemon (upscaledPokemon and notify list). Default: false.
-    const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons.
+    const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons. Default: [].
 
     // Google Analytics property ID. Leave empty to disable.
     // Looks like 'UA-XXXXX-Y'.
@@ -33,17 +32,19 @@ $(function () {
     ]
 
     // Clustering! Different zoom levels for desktop vs mobile.
-    const disableClusters = false // Default: false
-    const maxClusterZoomLevel = 14 // Default: 14
-    const maxClusterZoomLevelMobile = 14 // Default: same as desktop
-    const clusterZoomOnClick = false // Default: false
-    const clusterZoomOnClickMobile = false // Default: same as desktop
-    const clusterGridSize = 60 // Default: 60
-    const clusterGridSizeMobile = 60 // Default: same as desktop
+    const disableClusters = false // Default: false.
+    const maxClusterZoomLevel = 14 // Default: 14.
+    const maxClusterZoomLevelMobile = 14 // Default: 14.
+    const clusterZoomOnClick = false // Default: false.
+    const clusterZoomOnClickMobile = false // Default: false.
+    const clusterGridSize = 60 // Default: 60.
+    const clusterGridSizeMobile = 60 // Default: 60.
 
     // Process Pokémon in chunks to improve responsiveness.
-    const processPokemonChunkSize = 100 // Default: 100
-    const processPokemonIntervalMs = 100 // Default: 100ms
+    const processPokemonChunkSize = 100 // Default: 100.
+    const processPokemonIntervalMs = 100 // Default: 100ms.
+    const processPokemonChunkSizeMobile = 100 // Default: 100.
+    const processPokemonIntervalMsMobile = 100 // Default: 100ms.
 
 
     /* Feature detection. */
@@ -63,7 +64,8 @@ $(function () {
     /* Do stuff. */
 
     const currentPage = window.location.pathname
-
+    // Marker cluster might have loaded before custom.js.
+    const isMarkerClusterLoaded = typeof window.markerCluster !== 'undefined' && !!window.markerCluster
 
     // Set custom Store values.
     Store.set('maxClusterZoomLevel', maxClusterZoomLevel)
@@ -74,11 +76,15 @@ $(function () {
     Store.set('scaleByRarity', scaleByRarity)
     Store.set('upscalePokemon', upscalePokemon)
     Store.set('upscaledPokemon', upscaledPokemon)
+    Store.set('showLocationMarker', showLocationMarker)
+    Store.set('isLocationMarkerMovable', isLocationMarkerMovable)
 
     if (typeof window.orientation !== 'undefined' || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
         Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)
         Store.set('clusterGridSize', clusterGridSizeMobile)
+        Store.set('processPokemonChunkSize', processPokemonChunkSizeMobile)
+        Store.set('processPokemonIntervalMs', processPokemonIntervalMsMobile)
     }
 
     if (disableClusters) {

--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -3,8 +3,10 @@ $(function () {
 
     /* Settings. */
 
-    const showLocationMarker = false // Show a marker on the map's scan location. Default: false.
-    const isLocationMarkerMovable = false // Let the user move the marker around. Doesn't do anything without --no-fixed-location. Default: false.
+    const showSearchMarker = true // Show a marker on the map's scan location. Default: false.
+    const isSearchMarkerMovable = false // Let the user move the scan location marker around. Doesn't do anything without --no-fixed-location. Default: false.
+    const showLocationMarker = true // Show a marker on the visitor's location. Default: false.
+    const isLocationMarkerMovable = false // Let the user move the visitor marker around. Default: false.
     const scaleByRarity = true // Enable scaling by rarity. Default: true.
     const upscalePokemon = false // Enable upscaling of certain Pokemon (upscaledPokemon and notify list). Default: false.
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons. Default: [].
@@ -76,6 +78,8 @@ $(function () {
     Store.set('scaleByRarity', scaleByRarity)
     Store.set('upscalePokemon', upscalePokemon)
     Store.set('upscaledPokemon', upscaledPokemon)
+    Store.set('showSearchMarker', showSearchMarker)
+    Store.set('isSearchMarkerMovable', isSearchMarkerMovable)
     Store.set('showLocationMarker', showLocationMarker)
     Store.set('isLocationMarkerMovable', isLocationMarkerMovable)
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1035,10 +1035,18 @@ var StoreOptions = {
         type: StoreTypes.Boolean
     },
     'showLocationMarker': {
-        default: false,
+        default: true,
         type: StoreTypes.Boolean
     },
     'isLocationMarkerMovable': {
+        default: false,
+        type: StoreTypes.Boolean
+    },
+    'showSearchMarker': {
+        default: true,
+        type: StoreTypes.Boolean
+    },
+    'isSearchMarkerMovable': {
         default: false,
         type: StoreTypes.Boolean
     }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1033,6 +1033,10 @@ var StoreOptions = {
     'isBounceDisabled': {
         default: false,
         type: StoreTypes.Boolean
+    },
+    'showLocationMarker': {
+        default: false,
+        type: StoreTypes.Boolean
     }
 }
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1037,6 +1037,10 @@ var StoreOptions = {
     'showLocationMarker': {
         default: false,
         type: StoreTypes.Boolean
+    },
+    'isLocationMarkerMovable': {
+        default: false,
+        type: StoreTypes.Boolean
     }
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -273,7 +273,14 @@ function initMap() { // eslint-disable-line no-unused-vars
     })
 
     searchMarker = createSearchMarker()
-    locationMarker = createLocationMarker()
+
+    const showLocationMarker = Store.get('showLocationMarker')
+    const isLocationMarkerMovable = Store.get('isLocationMarkerMovable')
+    if (showLocationMarker) {
+        locationMarker = createLocationMarker()
+        locationMarker.setDraggable(isLocationMarkerMovable)
+    }
+
     createMyLocationButton()
     initSidebar()
 
@@ -293,6 +300,11 @@ function initMap() { // eslint-disable-line no-unused-vars
 }
 
 function updateLocationMarker(style) {
+    // Don't do anything if it's disabled.
+    if (!locationMarker) {
+        return locationMarker
+    }
+
     if (style in searchMarkerStyles) {
         var url = searchMarkerStyles[style].icon
         if (url) {
@@ -2038,7 +2050,11 @@ function centerMapOnLocation() {
     if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(function (position) {
             var latlng = new google.maps.LatLng(position.coords.latitude, position.coords.longitude)
-            locationMarker.setPosition(latlng)
+
+            if (locationMarker) {
+                locationMarker.setPosition(latlng)
+            }
+
             map.setCenter(latlng)
             Store.set('followMyLocationPosition', {
                 lat: position.coords.latitude,
@@ -2911,7 +2927,17 @@ $(function () {
         } else {
             Store.set('followMyLocation', this.checked)
         }
-        locationMarker.setDraggable(!this.checked)
+
+        if (locationMarker) {
+            if (this.checked) {
+                // Follow our position programatically, so no dragging.
+                locationMarker.setDraggable(false)
+            } else {
+                // Go back to default non-follow.
+                const isMarkerMovable = Store.get('isLocationMarkerMovable')
+                locationMarker.setDraggable(isMarkerMovable)
+            }
+        }
     })
 
     $('#scan-here-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -302,7 +302,7 @@ function initMap() { // eslint-disable-line no-unused-vars
 function updateLocationMarker(style) {
     // Don't do anything if it's disabled.
     if (!locationMarker) {
-        return locationMarker
+        return
     }
 
     if (style in searchMarkerStyles) {
@@ -318,6 +318,7 @@ function updateLocationMarker(style) {
         Store.set('locationMarkerStyle', style)
     }
 
+    // Return value is currently unused.
     return locationMarker
 }
 


### PR DESCRIPTION
## Description
* Added options to show/hide the scan location and visitor location markers, and to make it (un-)draggable in Store.
* Added options to custom.js to control the Store settings for the markers.
* Updated comments to be consistent, and not to refer to "same as desktop".
* Added options to custom.js to allow Pokémon processing chunk size and interval for mobile devices.
* Made sure that code referencing locationMarker and searchMarker only runs when there is one.

## Motivation and Context
Fixes #2425.

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Enhancement
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.

  
  