### PR TITLE
Fix the levelup script.

### DIFF
--- a/tools/levelup.py
+++ b/tools/levelup.py
@@ -90,7 +90,7 @@ args = get_args()
 
 # Abort if we don't have a hash key set.
 if not args.hash_key:
-    log.critical('Hash key is required for levelling up accounts. Exiting.')
+    log.critical('Hash key is required for leveling up accounts. Exiting.')
     sys.exit(1)
 
 fake_queue = FakeQueue()

--- a/tools/levelup.py
+++ b/tools/levelup.py
@@ -87,10 +87,16 @@ set_log_and_verbosity(log)
 
 
 args = get_args()
+
+# Abort if we don't have a hash key set.
+if not args.hash_key:
+    log.critical('Hash key is required for levelling up accounts. Exiting.')
+    sys.exit(1)
+
 fake_queue = FakeQueue()
 key_scheduler = KeyScheduler(args.hash_key, fake_queue)
 position = extract_coordinates(args.location)
-startup_db(None, args.clear_db, args.db_type, args.db)
+startup_db(None, args.clear_db)
 args.player_locale = PlayerLocale.get_locale(args.location)
 if not args.player_locale:
     args.player_locale = gmaps_reverse_geolocate(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the levelup script.

## Motivation and Context
The levelup script was broken by the merge of #2288 (a call to `startup_db` still had a reference to `db-type`).

This also adds a check for a hash key before the levelup script starts.

## How Has This Been Tested?
Small test instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
