### PR TITLE
Update speed-scheduler.md

### DIFF
--- a/docs/scanning-method/speed-scheduler.md
+++ b/docs/scanning-method/speed-scheduler.md
@@ -14,6 +14,8 @@ Speed Scheduler is an alternative scheduler to Hex Scan or Spawnpoint Scan with 
 
 To use Speed Scheduler, always put -speed in the command line or set `speed-scan` in your config file.
 
+Please note: Speed Scheduler does not work for gym only scanning.
+
 ## Commands and configs
 
 What command line args should I use for Speed Scheduler?

--- a/docs/scanning-method/speed-scheduler.md
+++ b/docs/scanning-method/speed-scheduler.md
@@ -14,7 +14,7 @@ Speed Scheduler is an alternative scheduler to Hex Scan or Spawnpoint Scan with 
 
 To use Speed Scheduler, always put -speed in the command line or set `speed-scan` in your config file.
 
-Speed Scheduler is optomized for scanning for Pokemon so it does not work well for gym/pokestop only scanning. If you are interested in scanning for just gyms/pokestops consider using Hex Scheduler.
+Speed Scheduler is optimized for scanning for Pokémon so it doesn't work well for gym/pokéstop only scanning. If you are interested in scanning for just gyms/pokéstops consider using Hex Scheduler.
 
 ## Commands and configs
 

--- a/docs/scanning-method/speed-scheduler.md
+++ b/docs/scanning-method/speed-scheduler.md
@@ -14,7 +14,7 @@ Speed Scheduler is an alternative scheduler to Hex Scan or Spawnpoint Scan with 
 
 To use Speed Scheduler, always put -speed in the command line or set `speed-scan` in your config file.
 
-Please note: Speed Scheduler does not work for gym only scanning.
+Speed Scheduler is optomized for scanning for Pokemon so it does not work well for gym/pokestop only scanning. If you are interested in scanning for just gyms/pokestops consider using Hex Scheduler.
 
 ## Commands and configs
 


### PR DESCRIPTION
Add note about not using Speed Scheduling for Gym only scans

## Description
Add a small note warning users to not use the speed scheduling option unless they are scanning for pokemon as the speed scheduler only starts scans where pokemon are spawning so if disabled stops scanning after the 1st scan.

## Motivation and Context
To help other users avoid the lengthy process of figuring out why there gym only scanners aren't working as expected.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
Change to documentation only for Speed Scheduling

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.

  