### PR TITLE
Remove iPhone 5/5c from device info

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -914,11 +914,7 @@ def dottedQuadToNum(ip):
 
 # Generate random device info.
 # Original by Noctem.
-IPHONES = {'iPhone5,1': 'N41AP',
-           'iPhone5,2': 'N42AP',
-           'iPhone5,3': 'N48AP',
-           'iPhone5,4': 'N49AP',
-           'iPhone6,1': 'N51AP',
+IPHONES = {'iPhone6,1': 'N51AP',
            'iPhone6,2': 'N53AP',
            'iPhone7,1': 'N56AP',
            'iPhone7,2': 'N61AP',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -966,9 +966,6 @@ def generate_device_info(identifier):
         # iPhone SE started on 9.3.
         ios_pool = ('9.3', '9.3.1', '9.3.2', '9.3.3', '9.3.4', '9.3.5') \
                    + ios10 + ios11
-    elif device_pick in ('iPhone5,1', 'iPhone5,2', 'iPhone5,3', 'iPhone5,4'):
-        # iPhone 5/5c doesn't support iOS 11.
-        ios_pool = ios9 + ios10
     else:
         ios_pool = ios9 + ios10 + ios11
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the iPhone 5 and 5c from device info choices.
## Description
<!--- Describe your changes in detail -->
iPhone 5 is 5,1 and 5,2, 5c is 5,3 and 5,4. iOS versions don't require changing, as they're not blacklisting iOS versions this go around but rather devices. The versions specific iPhones can run is already handled as well.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Niantic is ending support for all devices that cannot run iOS 11 (which, of the ones we had left, is only the 5/5c). https://pokemongolive.com/en/post/iphone5discontinuedsupport
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
not tested. please test.
## Screenshots (if appropriate):
n/a
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
