### PR TITLE
Sync the "Exclude Rarity" dropdown with the stored value on load

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2742,6 +2742,7 @@ $(function () {
 
         // recall saved lists
         $selectExclude.val(Store.get('remember_select_exclude')).trigger('change')
+        $selectExcludeRarity.val(Store.get('excludedRarity')).trigger('change')
         $selectPokemonNotify.val(Store.get('remember_select_notify')).trigger('change')
         $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
         $textPerfectionNotify.val(Store.get('remember_text_perfection_notify')).trigger('change')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR syncs the "Exclude Rarity" dropdown with the value stored locally upon load.    

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed that coming back to the map in a separate session/window will show "None Selected" in the "Exclude Rarity" dropdown, even though a filter _is_ actually being applied. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with my local map with the following steps:

1. Make sure we are in the initial state (Make sure `Store.get('excludedRarity')` returns 0 and "None Selected" is chosen in the dropdown).
2. Change "Exclude Rarity" to something else ("Uncommon and below", for example).
3. Refresh the page.
4. Check the value shown in "Exclude Rarity"

Expected: Selection should be retained.  

## Screenshots (if appropriate):

With no rarity exclusion applied:

![screenshot 2018-01-15 at 12 51 28 pm](https://user-images.githubusercontent.com/764580/34958618-b48cf314-fa00-11e7-81b3-37d0339b3969.png)

After choosing "Uncommon and below":
![screenshot 2018-01-15 at 12 51 56 pm](https://user-images.githubusercontent.com/764580/34958645-cdf087b2-fa00-11e7-9802-ed18b530f58f.png)

Upon refresh (before the change in this PR):
![screenshot 2018-01-15 at 12 54 15 pm](https://user-images.githubusercontent.com/764580/34958666-e408561a-fa00-11e7-96fb-36c5d95a8088.png)

Upon refresh (after the change in this PR):
![screenshot 2018-01-15 at 2 01 26 pm](https://user-images.githubusercontent.com/764580/34958679-f14057ec-fa00-11e7-8b0d-94f0df26854e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
