### PR TITLE
Add calendar time to deployment time.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2254,6 +2254,17 @@ function getSidebarGymMember(pokemon) {
         colorIdx = 1
     }
 
+    // Skip getDateStr() so we can re-use the moment.js object.
+    var relativeTime = 'Unknown'
+    var absoluteTime = ''
+
+    if (pokemon.deployment_time) {
+        let deploymentTime = moment(pokemon.deployment_time)
+        relativeTime = deploymentTime.fromNow()
+        // Append as string so we show nothing when the time is Unknown.
+        absoluteTime = ' (' + deploymentTime.format('HH:mm') + ')'
+    }
+
     return `
                     <tr onclick=toggleGymPokemonDetails(this)>
                         <td width="30px">
@@ -2270,7 +2281,7 @@ function getSidebarGymMember(pokemon) {
                         </td>
                         <td width="190" align="center">
                             <div class="gym pokemon" style="line-height:1em;">${pokemon.trainer_name} (${pokemon.trainer_level})</div>
-                            <div class="gym pokemon">Deployed ${getDateStr(pokemon.deployment_time)}</div>
+                            <div class="gym pokemon">Deployed ${relativeTime}${absoluteTime}</div>
                         </td>
                         <td width="10">
                             <!--<a href="#" onclick="toggleGymPokemonDetails(this)">-->

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2261,8 +2261,10 @@ function getSidebarGymMember(pokemon) {
     if (pokemon.deployment_time) {
         let deploymentTime = moment(pokemon.deployment_time)
         relativeTime = deploymentTime.fromNow()
-        // Append as string so we show nothing when the time is Unknown.
-        absoluteTime = ' (' + deploymentTime.format('MMM Do HH:mm') + ')'
+        /*  Append as string so we show nothing when the time is Unknown.
+            We use a "bad practice" <br> to avoid having to add an additional
+            div unnecessarily, which would be empty if we'd have no time. */
+        absoluteTime = '<br>(' + deploymentTime.format('MMM Do HH:mm') + ')'
     }
 
     return `
@@ -2271,7 +2273,7 @@ function getSidebarGymMember(pokemon) {
                             <img class="gym pokemon sprite" src="static/icons/${pokemon.pokemon_id}.png">
                         </td>
                         <td>
-                            <div class="gym pokemon" style="line-height:1em;"><span class="gym pokemon name">${pokemon.pokemon_name}</span></div>
+                            <div class="gym pokemon"><span class="gym pokemon name">${pokemon.pokemon_name}</span></div>
                             <div>
                                 <span class="gym pokemon motivation decayed zone ${motivationZone[colorIdx].toLowerCase()}">${pokemon.cp_decayed}</span>
                             </div>
@@ -2280,7 +2282,7 @@ function getSidebarGymMember(pokemon) {
                             </div>
                         </td>
                         <td width="190" align="center">
-                            <div class="gym pokemon" style="line-height:1em;">${pokemon.trainer_name} (${pokemon.trainer_level})</div>
+                            <div class="gym pokemon">${pokemon.trainer_name} (${pokemon.trainer_level})</div>
                             <div class="gym pokemon">Deployed ${relativeTime}${absoluteTime}</div>
                         </td>
                         <td width="10">

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2261,10 +2261,8 @@ function getSidebarGymMember(pokemon) {
     if (pokemon.deployment_time) {
         let deploymentTime = moment(pokemon.deployment_time)
         relativeTime = deploymentTime.fromNow()
-        /*  Append as string so we show nothing when the time is Unknown.
-            We use a "bad practice" <br> to avoid having to add an additional
-            div unnecessarily, which would be empty if we'd have no time. */
-        absoluteTime = '<br>(' + deploymentTime.format('MMM Do HH:mm') + ')'
+        // Append as string so we show nothing when the time is Unknown.
+        absoluteTime = '<div class="gym pokemon">(' + deploymentTime.format('MMM Do HH:mm') + ')</div>'
     }
 
     return `
@@ -2283,7 +2281,8 @@ function getSidebarGymMember(pokemon) {
                         </td>
                         <td width="190" align="center">
                             <div class="gym pokemon">${pokemon.trainer_name} (${pokemon.trainer_level})</div>
-                            <div class="gym pokemon">Deployed ${relativeTime}${absoluteTime}</div>
+                            <div class="gym pokemon">Deployed ${relativeTime}</div>
+                            ${absoluteTime}
                         </td>
                         <td width="10">
                             <!--<a href="#" onclick="toggleGymPokemonDetails(this)">-->

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2262,7 +2262,7 @@ function getSidebarGymMember(pokemon) {
         let deploymentTime = moment(pokemon.deployment_time)
         relativeTime = deploymentTime.fromNow()
         // Append as string so we show nothing when the time is Unknown.
-        absoluteTime = ' (' + deploymentTime.format('HH:mm') + ')'
+        absoluteTime = ' (' + deploymentTime.format('MMM Do HH:mm') + ')'
     }
 
     return `

--- a/static/sass/layout/_gym-details.scss
+++ b/static/sass/layout/_gym-details.scss
@@ -342,7 +342,7 @@
       &.sprite {
         @media screen and (max-width: 480px) {
           height: 48px !important;
-          width:: 48px !important;
+          width: 48px !important;
         }
         display: block;
         height: 96px;

--- a/static/sass/layout/_gym-details.scss
+++ b/static/sass/layout/_gym-details.scss
@@ -351,7 +351,7 @@
         &.pokemon {
           @media screen and (max-width: 480px) {
             height: 30px !important;
-            width:: 30px !important;
+            width: 30px !important;
           }
           display: block;
           height: 48px;
@@ -402,6 +402,7 @@
 
       &.pokemon {
         font-size: 12px;
+        line-height: 1rem;
 
         &.motivation.decayed:before {
           content: '\f004';

--- a/static/sass/layout/_gym-details.scss
+++ b/static/sass/layout/_gym-details.scss
@@ -391,7 +391,7 @@
         &.strength {
           @media screen and (max-width: 480px) {
             height: 12px !important;
-            width:: 12px !important;
+            width: 12px !important;
           }
           font-weight: 900;
           height: 16px;


### PR DESCRIPTION
## Description
* Adds `(MMM Do HH:mm)` time to gym Pokémon deployment time.
* Removes some old in-line CSS to the SCSS file.
* Fixed some typos I came across in the SCSS file.

## Motivation and Context
Feature request.

## How Has This Been Tested?
Tested by the person who requested the feature:
![image](https://user-images.githubusercontent.com/4874269/35106317-36d30ff6-fc6e-11e7-8d22-43c8a35a8078.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
