### PR TITLE
Add toggle to show/hide Pokémon stats.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,9 +61,6 @@
     "setupPokemonMarker": true,
     "updatePokemonMarker": true,
 
-    "setPokemonAnimation": true,
-    "setPokemonAnimations": true,
-    
     "pokemonLabel": true,
     "updatePokemonLabel": true,
     "updatePokemonLabels": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,7 @@
 
     "setPokemonAnimation": true,
     "setPokemonAnimations": true,
+    "pokemonLabel": true,
     "updatePokemonLabel": true,
     "updatePokemonLabels": true
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,11 @@
     "countMarkers": true,
     "skel": true,
     "setupPokemonMarker": true,
-    "updatePokemonMarker": true
+    "updatePokemonMarker": true,
+
+    "setPokemonAnimation": true,
+    "setPokemonAnimations": true,
+    "updatePokemonLabel": true,
+    "updatePokemonLabels": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,7 @@
 
     "setPokemonAnimation": true,
     "setPokemonAnimations": true,
+    
     "pokemonLabel": true,
     "updatePokemonLabel": true,
     "updatePokemonLabels": true

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -25,7 +25,7 @@
 #speed-scan                     # Use speed-scan as the search scheduler.
 #location:                      # Location, can be an address or coordinates.
 #step-limit:                    # Steps (default=10)
-#scan-delay:                    # Time delay between requests in scan threads. (default=12)
+#scan-delay:                    # Time delay between requests in scan threads. (default=10)
 #no-gyms                        # Disables gym scanning (default=False)
 #no-pokemon                     # Disables pokemon scanning. (default=False)
 #no-pokestops                   # Disables pokestop scanning. (default=False)

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1193,6 +1193,22 @@ function updatePokemonLabels(pokemonList) {
     })
 }
 
+function setPokemonAnimation(item, enable) {
+    if (item.marker.animationDisabled && enable) {
+        item.marker.animationDisabled = false
+        item.marker.setAnimation(google.maps.Animation.BOUNCE)
+    } else if (!item.marker.animationDisabled && !enable) {
+        item.marker.animationDisabled = true
+        item.marker.setAnimation(null)
+    }
+}
+
+function setPokemonAnimations(pokemonList, enable) {
+    $.each(pokemonList, function (key, value) {
+        setPokemonAnimation(pokemonList[key], enable)
+    })
+}
+
 function isTouchDevice() {
     // Should cover most browsers
     return 'ontouchstart' in window || navigator.maxTouchPoints

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1174,6 +1174,7 @@ function setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity = true, i
 function updatePokemonMarker(item, map, scaleByRarity = true, isNotifyPkmn = false) {
     // Scale icon size up with the map exponentially, also size with rarity.
     const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity, isNotifyPkmn)
+	customizePokemonMarker(markerDetails, item)
     const icon = markerDetails.icon
     const marker = item.marker
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1191,7 +1191,7 @@ function updatePokemonLabels(pokemonList) {
     $.each(pokemonList, function (key, value) {
         var item = pokemonList[key]
 
-        updatePokemonLabel(pokemonList[key])
+        updatePokemonLabel(item)
     })
 }
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1180,6 +1180,19 @@ function updatePokemonMarker(item, map, scaleByRarity = true, isNotifyPkmn = fal
     marker.setIcon(icon)
 }
 
+function updatePokemonLabel(item) {
+    // only update label when pokemon has been encountered
+    if (item['cp'] !== null && item['cpMultiplier'] !== null) {
+        item.marker.infoWindow.setContent(pokemonLabel(item))
+    }
+}
+
+function updatePokemonLabels(pokemonList) {
+    $.each(pokemonList, function (key, value) {
+        updatePokemonLabel(pokemonList[key])
+    })
+}
+
 function isTouchDevice() {
     // Should cover most browsers
     return 'ontouchstart' in window || navigator.maxTouchPoints

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1181,7 +1181,7 @@ function updatePokemonMarker(item, map, scaleByRarity = true, isNotifyPkmn = fal
 }
 
 function updatePokemonLabel(item) {
-    // only update label when pokemon has been encountered
+    // Only update label when Pokémon has been encountered
     if (item['cp'] !== null && item['cpMultiplier'] !== null) {
         item.marker.infoWindow.setContent(pokemonLabel(item))
     }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1189,23 +1189,9 @@ function updatePokemonLabel(item) {
 
 function updatePokemonLabels(pokemonList) {
     $.each(pokemonList, function (key, value) {
+        var item = pokemonList[key]
+        
         updatePokemonLabel(pokemonList[key])
-    })
-}
-
-function setPokemonAnimation(item, enable) {
-    if (enable) {
-        item.marker.animationDisabled = false
-        item.marker.setAnimation(google.maps.Animation.BOUNCE)
-    } else {
-        item.marker.animationDisabled = true
-        item.marker.setAnimation(null)
-    }
-}
-
-function setPokemonAnimations(pokemonList, enable) {
-    $.each(pokemonList, function (key, value) {
-        setPokemonAnimation(pokemonList[key], enable)
     })
 }
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1174,7 +1174,6 @@ function setupPokemonMarker(item, map, isBounceDisabled, scaleByRarity = true, i
 function updatePokemonMarker(item, map, scaleByRarity = true, isNotifyPkmn = false) {
     // Scale icon size up with the map exponentially, also size with rarity.
     const markerDetails = setupPokemonMarkerDetails(item, map, scaleByRarity, isNotifyPkmn)
-	customizePokemonMarker(markerDetails, item)
     const icon = markerDetails.icon
     const marker = item.marker
 

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1197,7 +1197,7 @@ function setPokemonAnimation(item, enable) {
     if (enable) {
         item.marker.animationDisabled = false
         item.marker.setAnimation(google.maps.Animation.BOUNCE)
-    } else if (!enable) {
+    } else {
         item.marker.animationDisabled = true
         item.marker.setAnimation(null)
     }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1211,17 +1211,6 @@ function setPokemonAnimations(pokemonList, enable) {
     })
 }
 
-function getNotifyPerfectionPokemons(pokemonList) {
-    var notifyPerfectionPkmn = []
-    $.each(pokemonList, function (key, value) {
-        if (isNotifyPerfectionPoke(pokemonList[key])) {
-            notifyPerfectionPkmn.push(pokemonList[key])
-        }
-    })
-    console.log(notifyPerfectionPkmn)
-    return notifyPerfectionPkmn
-}
-
 function isTouchDevice() {
     // Should cover most browsers
     return 'ontouchstart' in window || navigator.maxTouchPoints

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -918,6 +918,10 @@ var StoreOptions = {
         default: true,
         type: StoreTypes.Boolean
     },
+    'showPokemonStats': {
+        default: true,
+        type: StoreTypes.Boolean
+    },
     'showPokestops': {
         default: true,
         type: StoreTypes.Boolean

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1194,10 +1194,12 @@ function updatePokemonLabels(pokemonList) {
 }
 
 function setPokemonAnimation(item, enable) {
-    if (item.marker.animationDisabled && enable) {
+    if (enable) {
+        console.log('jump!')
         item.marker.animationDisabled = false
         item.marker.setAnimation(google.maps.Animation.BOUNCE)
-    } else if (!item.marker.animationDisabled && !enable) {
+    } else if (!enable) {
+        console.log('don\'t jump')
         item.marker.animationDisabled = true
         item.marker.setAnimation(null)
     }
@@ -1207,6 +1209,17 @@ function setPokemonAnimations(pokemonList, enable) {
     $.each(pokemonList, function (key, value) {
         setPokemonAnimation(pokemonList[key], enable)
     })
+}
+
+function getNotifyPerfectionPokemons(pokemonList) {
+    var notifyPerfectionPkmn = []
+    $.each(pokemonList, function (key, value) {
+        if (isNotifyPerfectionPoke(pokemonList[key])) {
+            notifyPerfectionPkmn.push(pokemonList[key])
+        }
+    })
+    console.log(notifyPerfectionPkmn)
+    return notifyPerfectionPkmn
 }
 
 function isTouchDevice() {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1195,11 +1195,9 @@ function updatePokemonLabels(pokemonList) {
 
 function setPokemonAnimation(item, enable) {
     if (enable) {
-        console.log('jump!')
         item.marker.animationDisabled = false
         item.marker.setAnimation(google.maps.Animation.BOUNCE)
     } else if (!enable) {
-        console.log('don\'t jump')
         item.marker.animationDisabled = true
         item.marker.setAnimation(null)
     }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1181,7 +1181,7 @@ function updatePokemonMarker(item, map, scaleByRarity = true, isNotifyPkmn = fal
 }
 
 function updatePokemonLabel(item) {
-    // Only update label when Pokémon has been encountered
+    // Only update label when Pokémon has been encountered.
     if (item['cp'] !== null && item['cpMultiplier'] !== null) {
         item.marker.infoWindow.setContent(pokemonLabel(item))
     }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1190,7 +1190,7 @@ function updatePokemonLabel(item) {
 function updatePokemonLabels(pokemonList) {
     $.each(pokemonList, function (key, value) {
         var item = pokemonList[key]
-        
+
         updatePokemonLabel(pokemonList[key])
     })
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2893,7 +2893,8 @@ $(function () {
         markerCluster.repaint()
     })
     $('#pokemon-stats-switch').change(function () {
-        Store.set('showPokemonStats', this.checked)
+        Store.set('showPokemonStats, this.checked)
+		updateMap()
     })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2894,7 +2894,11 @@ $(function () {
     })
     $('#pokemon-stats-switch').change(function () {
         Store.set('showPokemonStats', this.checked)
-		updateMap()
+        redrawPokemon(mapData.pokemons)
+        redrawPokemon(mapData.lurePokemons)
+
+        // We're done processing the list. Repaint.
+        markerCluster.repaint()
     })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -643,6 +643,17 @@ function pokemonLabel(item) {
     return contentstring
 }
 
+function updatePokemonLabels(pokemonList) {
+    $.each(pokemonList, function (key, value) {
+        var item = pokemonList[key]
+
+        item.marker.infoWindow = new google.maps.InfoWindow({
+            content: pokemonLabel(item),
+            disableAutoPan: true
+        })
+    })
+}
+
 function isOngoingRaid(raid) {
     return raid && Date.now() < raid.end && Date.now() > raid.start
 }
@@ -2894,11 +2905,7 @@ $(function () {
     })
     $('#pokemon-stats-switch').change(function () {
         Store.set('showPokemonStats', this.checked)
-        redrawPokemon(mapData.pokemons)
-        redrawPokemon(mapData.lurePokemons)
-
-        // We're done processing the list. Repaint.
-        markerCluster.repaint()
+        updatePokemonLabels(mapData.pokemons)
     })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1042,16 +1042,21 @@ function playPokemonSound(pokemonID, cryFileTypes) {
     }
 }
 
-function isNotifyPoke(poke) {
-    const isOnNotifyList = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
+function isNotifyPerfectionPoke(poke) {
     var hasHighIV = false
 
-    if (Store.get('showPokemonStats') && poke['individual_attack'] != null) {
+    if (poke['individual_attack'] != null) {
         const perfection = getIv(poke['individual_attack'], poke['individual_defense'], poke['individual_stamina'])
         hasHighIV = notifiedMinPerfection > 0 && perfection >= notifiedMinPerfection
     }
 
-    return isOnNotifyList || hasHighIV
+    return hasHighIV
+}
+
+function isNotifyPoke(poke) {
+    const isOnNotifyList = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
+
+    return isOnNotifyList || (Store.get('showPokemonStats') && isNotifyPerfectionPoke(poke))
 }
 
 function customizePokemonMarker(marker, item, skipNotification) {
@@ -2898,17 +2903,19 @@ $(function () {
             'duration': 500
         }
         var wrapper = $('#notify-perfection-wrapper')
-        if (this.checked) {
+        var notifyPerfectionPkmn = getNotifyPerfectionPokemons(mapData.pokemons)
+		if (this.checked) {
             wrapper.show(options)
+			setPokemonAnimations(notifyPerfectionPkmn, true)
         } else {
             wrapper.hide(options)
+			setPokemonAnimations(notifyPerfectionPkmn, false)
         }
         updatePokemonLabels(mapData.pokemons)
-        redrawPokemon(mapData.pokemons)
-        redrawPokemon(mapData.lurePokemons)
+        redrawPokemon(notifyPerfectionPkmn)
 
         // We're done processing the list. Repaint.
-        markerCluster.repaint()
+        markerCluster.redraw()
     })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1068,7 +1068,7 @@ function getNotifyPerfectionPokemons(pokemonList) {
     $.each(pokemonList, function (key, value) {
         var item = pokemonList[key]
 
-        if (isNotifyPerfectionPoke(item) {
+        if (isNotifyPerfectionPoke(item)) {
             notifyPerfectionPkmn.push(item)
         }
     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2920,14 +2920,15 @@ $(function () {
         var options = {
             'duration': 500
         }
-        var wrapper = $('#notify-perfection-wrapper')
-        var notifyPerfectionPkmn = getNotifyPerfectionPokemons(mapData.pokemons)
+        const $wrapper = $('#notify-perfection-wrapper')
         if (this.checked) {
-            wrapper.show(options)
+            $wrapper.show(options)
         } else {
-            wrapper.hide(options)
+            $wrapper.hide(options)
         }
         updatePokemonLabels(mapData.pokemons)
+        // Only redraw Pokémon which are notified of perfection.
+        var notifyPerfectionPkmn = getNotifyPerfectionPokemons(mapData.pokemons)
         redrawPokemon(notifyPerfectionPkmn)
 
         markerCluster.redraw()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2892,6 +2892,9 @@ $(function () {
         buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon').bind(this)()
         markerCluster.repaint()
     })
+    $('#pokemon-stats-switch').change(function () {
+        Store.set('showPokemonStats', this.checked)
+    })
     $('#scanned-switch').change(function () {
         buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()
     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -458,6 +458,7 @@ function initSidebar() {
     $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
     $('#last-update-gyms-switch').val(Store.get('showLastUpdatedGymsOnly'))
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'))
+	$('#pokemon-stats-switch').prop('checked', Store.get('showPokemonStats'))
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
     $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'))
     $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'))
@@ -564,7 +565,7 @@ function pokemonLabel(item) {
       ${name} <span class='pokemon name pokedex'><a href='http://pokemon.gameinfo.io/en/pokemon/${id}' target='_blank' title='View in Pokédex'>#${id}</a></span> ${formString} <span class='pokemon gender rarity'>${genderType[gender - 1]} ${rarityDisplay}</span> ${typesDisplay}
     </div>`
 
-    if (cp !== null && cpMultiplier !== null) {
+    if (cp !== null && cpMultiplier !== null && Store.get('showPokemonStats')) {
         var pokemonLevel = getPokemonLevel(cpMultiplier)
 
         if (atk !== null && def !== null && sta !== null) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1934,6 +1934,7 @@ function redrawPokemon(pokemonList) {
         if (!item.hidden) {
             const scaleByRarity = Store.get('scaleByRarity')
             const isNotifyPkmn = isNotifyPoke(item)
+
             updatePokemonMarker(item, map, scaleByRarity, isNotifyPkmn)
         }
     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -458,7 +458,7 @@ function initSidebar() {
     $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
     $('#last-update-gyms-switch').val(Store.get('showLastUpdatedGymsOnly'))
     $('#pokemon-switch').prop('checked', Store.get('showPokemon'))
-	$('#pokemon-stats-switch').prop('checked', Store.get('showPokemonStats'))
+    $('#pokemon-stats-switch').prop('checked', Store.get('showPokemonStats'))
     $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
     $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'))
     $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'))
@@ -645,8 +645,8 @@ function pokemonLabel(item) {
 }
 
 function updatePokemonLabel(item) {
-    //only update label when pokemon has been encountered
-    if(item['cp'] !== null && item['cpMultiplier'] !== null) {
+    // only update label when pokemon has been encountered
+    if (item['cp'] !== null && item['cpMultiplier'] !== null) {
         item.marker.infoWindow.setContent(pokemonLabel(item))
     }
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1059,6 +1059,16 @@ function isNotifyPoke(poke) {
     return isOnNotifyList || (Store.get('showPokemonStats') && isNotifyPerfectionPoke(poke))
 }
 
+function getNotifyPerfectionPokemons(pokemonList) {
+    var notifyPerfectionPkmn = []
+    $.each(pokemonList, function (key, value) {
+        if (isNotifyPerfectionPoke(pokemonList[key])) {
+            notifyPerfectionPkmn.push(pokemonList[key])
+        }
+    })
+    return notifyPerfectionPkmn
+}
+
 function customizePokemonMarker(marker, item, skipNotification) {
     var notifyText = getNotifyText(item)
     marker.addListener('click', function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1066,10 +1066,13 @@ function isNotifyPoke(poke) {
 function getNotifyPerfectionPokemons(pokemonList) {
     var notifyPerfectionPkmn = []
     $.each(pokemonList, function (key, value) {
+        var item = pokemonList[key]
+
         if (isNotifyPerfectionPoke(pokemonList[key])) {
-            notifyPerfectionPkmn.push(pokemonList[key])
+            notifyPerfectionPkmn.push(item)
         }
     })
+
     return notifyPerfectionPkmn
 }
 
@@ -2921,15 +2924,12 @@ $(function () {
         var notifyPerfectionPkmn = getNotifyPerfectionPokemons(mapData.pokemons)
         if (this.checked) {
             wrapper.show(options)
-            setPokemonAnimations(notifyPerfectionPkmn, true)
         } else {
             wrapper.hide(options)
-            setPokemonAnimations(notifyPerfectionPkmn, false)
         }
         updatePokemonLabels(mapData.pokemons)
         redrawPokemon(notifyPerfectionPkmn)
 
-        // We're done processing the list. Repaint.
         markerCluster.redraw()
     })
     $('#scanned-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -643,14 +643,25 @@ function pokemonLabel(item) {
     return contentstring
 }
 
+function isInfoWindowOpen(infoWindow) {
+    var map = infoWindow.getMap()
+    return (map !== null && typeof map !== "undefined")
+}
+
 function updatePokemonLabels(pokemonList) {
     $.each(pokemonList, function (key, value) {
         var item = pokemonList[key]
+        var marker = item.marker
 
-        item.marker.infoWindow = new google.maps.InfoWindow({
+        marker.infoWindow = new google.maps.InfoWindow({
             content: pokemonLabel(item),
             disableAutoPan: true
         })
+
+        if(isInfoWindowOpen(marker.infoWindow)) {
+            marker.infoWindow.close()
+            marker.infoWindow.open(map, marker)
+        }
     })
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1068,7 +1068,7 @@ function getNotifyPerfectionPokemons(pokemonList) {
     $.each(pokemonList, function (key, value) {
         var item = pokemonList[key]
 
-        if (isNotifyPerfectionPoke(pokemonList[key])) {
+        if (isNotifyPerfectionPoke(item) {
             notifyPerfectionPkmn.push(item)
         }
     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1000,7 +1000,7 @@ function getNotifyText(item) {
     var replace = [((iv) ? iv.toFixed(1) : ''), item['pokemon_name'], item['individual_attack'],
         item['individual_defense'], item['individual_stamina']]
     const showStats = Store.get('showPokemonStats')
-	var ntitle = repArray(((showStats && iv) ? notifyIvTitle : notifyNoIvTitle), find, replace)
+    var ntitle = repArray(((showStats && iv) ? notifyIvTitle : notifyNoIvTitle), find, replace)
     var dist = moment(item['disappear_time']).format('HH:mm:ss')
     var until = getTimeUntil(item['disappear_time'])
     var udist = (until.hour > 0) ? until.hour + ':' : ''
@@ -1057,7 +1057,7 @@ function isNotifyPerfectionPoke(poke) {
 
 function isNotifyPoke(poke) {
     const isOnNotifyList = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
-	const isNotifyPerfectionPkmn = isNotifyPerfectionPoke(poke)
+    const isNotifyPerfectionPkmn = isNotifyPerfectionPoke(poke)
     const showStats = Store.get('showPokemonStats')
 
     return isOnNotifyList || (showStats && isNotifyPerfectionPkmn)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -644,19 +644,6 @@ function pokemonLabel(item) {
     return contentstring
 }
 
-function updatePokemonLabel(item) {
-    // only update label when pokemon has been encountered
-    if (item['cp'] !== null && item['cpMultiplier'] !== null) {
-        item.marker.infoWindow.setContent(pokemonLabel(item))
-    }
-}
-
-function updatePokemonLabels(pokemonList) {
-    $.each(pokemonList, function (key, value) {
-        updatePokemonLabel(pokemonList[key])
-    })
-}
-
 function isOngoingRaid(raid) {
     return raid && Date.now() < raid.end && Date.now() > raid.start
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2904,12 +2904,12 @@ $(function () {
         }
         var wrapper = $('#notify-perfection-wrapper')
         var notifyPerfectionPkmn = getNotifyPerfectionPokemons(mapData.pokemons)
-		if (this.checked) {
+        if (this.checked) {
             wrapper.show(options)
-			setPokemonAnimations(notifyPerfectionPkmn, true)
+            setPokemonAnimations(notifyPerfectionPkmn, true)
         } else {
             wrapper.hide(options)
-			setPokemonAnimations(notifyPerfectionPkmn, false)
+            setPokemonAnimations(notifyPerfectionPkmn, false)
         }
         updatePokemonLabels(mapData.pokemons)
         redrawPokemon(notifyPerfectionPkmn)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2893,7 +2893,7 @@ $(function () {
         markerCluster.repaint()
     })
     $('#pokemon-stats-switch').change(function () {
-        Store.set('showPokemonStats, this.checked)
+        Store.set('showPokemonStats', this.checked)
 		updateMap()
     })
     $('#scanned-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -547,6 +547,7 @@ function pokemonLabel(item) {
     var form = item['form']
     var cp = item['cp']
     var cpMultiplier = item['cp_multiplier']
+    const showStats = Store.get('showPokemonStats')
 
     $.each(types, function (index, type) {
         typesDisplay += getTypeSpan(type)
@@ -566,7 +567,7 @@ function pokemonLabel(item) {
       ${name} <span class='pokemon name pokedex'><a href='http://pokemon.gameinfo.io/en/pokemon/${id}' target='_blank' title='View in Pokédex'>#${id}</a></span> ${formString} <span class='pokemon gender rarity'>${genderType[gender - 1]} ${rarityDisplay}</span> ${typesDisplay}
     </div>`
 
-    if (Store.get('showPokemonStats') && cp !== null && cpMultiplier !== null) {
+    if (showStats && cp !== null && cpMultiplier !== null) {
         var pokemonLevel = getPokemonLevel(cpMultiplier)
 
         if (atk !== null && def !== null && sta !== null) {
@@ -998,7 +999,8 @@ function getNotifyText(item) {
     var find = ['<prc>', '<pkm>', '<atk>', '<def>', '<sta>']
     var replace = [((iv) ? iv.toFixed(1) : ''), item['pokemon_name'], item['individual_attack'],
         item['individual_defense'], item['individual_stamina']]
-    var ntitle = repArray(((Store.get('showPokemonStats') && iv) ? notifyIvTitle : notifyNoIvTitle), find, replace)
+    const showStats = Store.get('showPokemonStats')
+	var ntitle = repArray(((showStats && iv) ? notifyIvTitle : notifyNoIvTitle), find, replace)
     var dist = moment(item['disappear_time']).format('HH:mm:ss')
     var until = getTimeUntil(item['disappear_time'])
     var udist = (until.hour > 0) ? until.hour + ':' : ''
@@ -1055,8 +1057,10 @@ function isNotifyPerfectionPoke(poke) {
 
 function isNotifyPoke(poke) {
     const isOnNotifyList = notifiedPokemon.indexOf(poke['pokemon_id']) > -1 || notifiedRarity.indexOf(poke['pokemon_rarity']) > -1
+	const isNotifyPerfectionPkmn = isNotifyPerfectionPoke(poke)
+    const showStats = Store.get('showPokemonStats')
 
-    return isOnNotifyList || (Store.get('showPokemonStats') && isNotifyPerfectionPoke(poke))
+    return isOnNotifyList || (showStats && isNotifyPerfectionPkmn)
 }
 
 function getNotifyPerfectionPokemons(pokemonList) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -257,7 +257,7 @@
                 <option value="5">Ultra Rare and below</option>
               </select>
             </div>
-              {% if show.encounter %}
+                  {% if show.encounter %}
             <div class="form-control switch-container">
               <h3>Pokémon Stats</h3>
               <div class="onoffswitch">
@@ -268,7 +268,7 @@
                 </label>
               </div>
             </div>
-              {% endif %}
+                  {% endif %}
               {% endif %}
           </div>
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -257,7 +257,19 @@
                 <option value="5">Ultra Rare and below</option>
               </select>
             </div>
+              {% if show.encounter %}
+            <div class="form-control switch-container">
+              <h3>Pokémon Stats</h3>
+              <div class="onoffswitch">
+                <input id="pokemon-stats-switch" type="checkbox" name="pokemon-stats-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="pokemon-stats-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
               {% endif %}
+			  {% endif %}
           </div>
 
           <h3><i class="fa fa-location-arrow fa-fw"></i>Location &amp; Search Settings</h3>

--- a/templates/map.html
+++ b/templates/map.html
@@ -269,7 +269,7 @@
               </div>
             </div>
               {% endif %}
-			  {% endif %}
+              {% endif %}
           </div>
 
           <h3><i class="fa fa-location-arrow fa-fw"></i>Location &amp; Search Settings</h3>
@@ -370,11 +370,13 @@
             </div>
 
               {% if show.encounter %}
-            <div class="form-control">
-              <label for="notify-perfection">
-                <h3>Notify of Perfection</h3>
-                <input id="notify-perfection" type="text" name="notify-perfection" placeholder="Minimum perfection %"/>
-              </label>
+            <div id="notify-perfection-wrapper" style="display:none">
+              <div class="form-control">
+                <label for="notify-perfection">
+                  <h3>Notify of Perfection</h3>
+                  <input id="notify-perfection" type="text" name="notify-perfection" placeholder="Minimum perfection %"/>
+                </label>
+              </div>
             </div>
               {% endif %}
             <div class="form-control switch-container">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR brings a toggle which will show or hide pokemon stats (IV, CP, weight,) on the map.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some of my users did not want to see pokemon stats, so I thought lets make a toggle for that. :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested it on my main instance.
Testing environment: Windows, Google Chrome.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
