### PR TITLE
Dynamic rarity

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,9 @@
 
     "pokemonLabel": true,
     "updatePokemonLabel": true,
-    "updatePokemonLabels": true
+    "updatePokemonLabels": true,
+
+    "getPokemonRarity": true,
+    "updatePokemonRarities": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ static/icons-large-sprite.png
 static/icons/*.png
 static/css/custom.css
 static/js/custom.js
+static/rarity.json
 *.csv
 *.bat
 *.sh

--- a/docs/common-issues/faq.md
+++ b/docs/common-issues/faq.md
@@ -4,6 +4,12 @@
 
 No, it is gross to charge people for maps when the information should be provided by Niantic! We do not endorse paid maps, which is why this platform is opensource.
 
+### All Pokemon are set as ultra rare, what is going on?
+We now use a dynamic rarity system to determine the rarity of pokemon, the rarity is calculated by what you scan so it unique to your area. The rarity is updated every hour so when you start an initial scan everything will probably say it is ultra rare for the first hour and then will adjust itself.
+
+### Does dynamic rarity mean that all future pokemon will get a rarity automatically?
+Yes.
+
 ### What do the spawn point colors mean?
 
 * A **grey** dot represents a spawn point that is more than 5 minutes from spawning.

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -124,10 +124,14 @@ which override config file values which override defaults.
       -sd SCAN_DELAY, --scan-delay SCAN_DELAY
                             Time delay between requests in scan threads. [env var:
                             POGOMAP_SCAN_DELAY]
-      -rh RARITY_HOURS, --rarity-hours RARITY_HOURS
+      -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
                             Number of hours of Pokemon data to use to calculate
                             dynamic rarity. Default: 48. 0 to use all data.
                             [env var: POGOMAP_RARITY_HOURS]
+      -Rf RARITY_UPDATE_FREQUENCY, --rarity-update-frequency RARITY_UPDATE_FREQUENCY
+                            How often (in minutes) the dynamic rarity should be
+                            updated. Default: 60. 0 to disable.
+                            [env var: POGOMAP_RARITY_UPDATE_FREQUENCY]
       --spawn-delay SPAWN_DELAY
                             Number of seconds after spawn time to wait before
                             scanning to be sure the Pokemon is there. [env var:

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -7,7 +7,7 @@
                     [-hlvl HIGH_LVL_ACCOUNTS] [-bh] [-wph WORKERS_PER_HIVE]
                     [-l LOCATION] [-alt ALTITUDE] [-altv ALTITUDE_VARIANCE]
                     [-uac] [-j] [-al] [-st STEP_LIMIT] [-gf GEOFENCE_FILE]
-                    [-gef GEOFENCE_EXCLUDED_FILE] [-sd SCAN_DELAY] [-rh RARITY_HOURS]
+                    [-gef GEOFENCE_EXCLUDED_FILE] [-sd SCAN_DELAY]
                     [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
                     [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
                     [-mcr MANUAL_CAPTCHA_REFRESH]
@@ -43,16 +43,19 @@
                     [--disable-blacklist] [-tp TRUSTED_PROXIES]
                     [--api-version API_VERSION] [--no-file-logs]
                     [--log-path LOG_PATH] [--dump] [-v | --verbosity VERBOSE]
+                    [-Rh RARITY_HOURS] [-Rf RARITY_UPDATE_FREQUENCY]
 
 Args that start with '--' (eg. -a) can also be set in a config file
-(config/config.ini or specified via
--cf or -scf). Config file syntax allows: key=value, flag=true, stuff=[a,b,c]
-(for details, see syntax at https://goo.gl/R74nmi). If an arg is specified in
-more than one place, then commandline values override environment variables
-which override config file values which override defaults.
+(config/config.ini or specified via -cf or -scf). The recognized syntax
+for setting (key, value) pairs is based on the INI and YAML formats
+(e.g. key=value or foo=TRUE). For full documentation of the differences
+from the standards please refer to the ConfigArgParse documentation. If an
+arg is specified in more than one place, then commandline values override
+environment variables which override config file values which override defaults.
 
     optional arguments:
-      -h, --help            show this help message and exit
+      -h, --help            show this help message and exit [env var:
+                            POGOMAP_HELP]
       -cf CONFIG, --config CONFIG
                             Set configuration file
       -scf SHARED_CONFIG, --shared-config SHARED_CONFIG
@@ -124,14 +127,6 @@ which override config file values which override defaults.
       -sd SCAN_DELAY, --scan-delay SCAN_DELAY
                             Time delay between requests in scan threads. [env var:
                             POGOMAP_SCAN_DELAY]
-      -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
-                            Number of hours of Pokemon data to use to calculate
-                            dynamic rarity. Decimals allowed. Default: 48. 0 to use
-                            all data. [env var: POGOMAP_RARITY_HOURS]
-      -Rf RARITY_UPDATE_FREQUENCY, --rarity-update-frequency RARITY_UPDATE_FREQUENCY
-                            How often (in minutes) the dynamic rarity should be
-                            updated. Decimals allowed. Default: 0. 0 to disable.
-                            [env var: POGOMAP_RARITY_UPDATE_FREQUENCY]
       --spawn-delay SPAWN_DELAY
                             Number of seconds after spawn time to wait before
                             scanning to be sure the Pokemon is there. [env var:
@@ -269,12 +264,12 @@ which override config file values which override defaults.
       -ams ACCOUNT_MAX_SPINS, --account-max-spins ACCOUNT_MAX_SPINS
                             Maximum number of Pokestop spins per hour. [env var:
                             POGOMAP_ACCOUNT_MAX_SPINS]
-      -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement.
-                            0 to disable. Default: 35. [env var: POGOMAP_KPH]
+      -kph KPH, --kph KPH   Set a maximum speed in km/hour for scanner movement. 0
+                            to disable. Default: 35. [env var: POGOMAP_KPH]
       -hkph HLVL_KPH, --hlvl-kph HLVL_KPH
                             Set a maximum speed in km/hour for scanner movement,
-                            for high-level (L30) accounts. 0 to disable.
-                            Default: 25. [env var: POGOMAP_HLVL_KPH]
+                            for high-level (L30) accounts. 0 to disable. Default:
+                            25. [env var: POGOMAP_HLVL_KPH]
       -ldur LURE_DURATION, --lure-duration LURE_DURATION
                             Change duration for lures set on pokestops. This is
                             useful for events that extend lure duration. [env var:
@@ -415,3 +410,13 @@ which override config file values which override defaults.
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
                             behind. [env var: POGOMAP_DB_THREADS]
+
+    Dynamic Rarity:
+      -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
+                            Number of hours of Pokemon data to use to calculate
+                            dynamic rarity. Decimals allowed. Default: 48. 0 to
+                            use all data. [env var: POGOMAP_RARITY_HOURS]
+      -Rf RARITY_UPDATE_FREQUENCY, --rarity-update-frequency RARITY_UPDATE_FREQUENCY
+                            How often (in minutes) the dynamic rarity should be
+                            updated. Decimals allowed. Default: 0. 0 to disable.
+                            [env var: POGOMAP_RARITY_UPDATE_FREQUENCY]

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -7,7 +7,7 @@
                     [-hlvl HIGH_LVL_ACCOUNTS] [-bh] [-wph WORKERS_PER_HIVE]
                     [-l LOCATION] [-alt ALTITUDE] [-altv ALTITUDE_VARIANCE]
                     [-uac] [-j] [-al] [-st STEP_LIMIT] [-gf GEOFENCE_FILE]
-                    [-gef GEOFENCE_EXCLUDED_FILE] [-sd SCAN_DELAY]
+                    [-gef GEOFENCE_EXCLUDED_FILE] [-sd SCAN_DELAY] [-rh RARITY_HOURS]
                     [--spawn-delay SPAWN_DELAY] [-enc] [-cs] [-ck CAPTCHA_KEY]
                     [-cds CAPTCHA_DSK] [-mcd MANUAL_CAPTCHA_DOMAIN]
                     [-mcr MANUAL_CAPTCHA_REFRESH]
@@ -124,6 +124,10 @@ which override config file values which override defaults.
       -sd SCAN_DELAY, --scan-delay SCAN_DELAY
                             Time delay between requests in scan threads. [env var:
                             POGOMAP_SCAN_DELAY]
+      -rh RARITY_HOURS, --rarity-hours RARITY_HOURS
+                            Number of hours of Pokemon data to use to calculate
+                            dynamic rarity. Default: 48. 0 to use all data.
+                            [env var: POGOMAP_RARITY_HOURS]
       --spawn-delay SPAWN_DELAY
                             Number of seconds after spawn time to wait before
                             scanning to be sure the Pokemon is there. [env var:

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -126,11 +126,11 @@ which override config file values which override defaults.
                             POGOMAP_SCAN_DELAY]
       -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
                             Number of hours of Pokemon data to use to calculate
-                            dynamic rarity. Default: 48. 0 to use all data.
-                            [env var: POGOMAP_RARITY_HOURS]
+                            dynamic rarity. Decimals allowed. Default: 48. 0 to use
+                            all data. [env var: POGOMAP_RARITY_HOURS]
       -Rf RARITY_UPDATE_FREQUENCY, --rarity-update-frequency RARITY_UPDATE_FREQUENCY
                             How often (in minutes) the dynamic rarity should be
-                            updated. Default: 60. 0 to disable.
+                            updated. Decimals allowed. Default: 0. 0 to disable.
                             [env var: POGOMAP_RARITY_UPDATE_FREQUENCY]
       --spawn-delay SPAWN_DELAY
                             Number of seconds after spawn time to wait before

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -25,6 +25,30 @@ from .blacklist import fingerprints, get_ip_blacklist
 log = logging.getLogger(__name__)
 compress = Compress()
 
+def get_rarity(pokemon_id):
+    seen = Pokemon.get_seen(48)
+    total = seen['total']
+    found = 0
+    spawn_group = ''
+    for pokemon in seen['pokemon']:
+            if pokemon['pokemon_id'] == pokemon_id:
+                found = 1
+                pokemon_count = pokemon['count']
+    if found == 0:
+        pokemon_count = 0
+    spawn_rate = round(100 * pokemon_count / float(total), 4)
+    if spawn_rate < 0.01:
+       spawn_group = 'Ultra Rare'
+    elif spawn_rate < 0.03:
+       spawn_group = 'Very Rare'
+    elif spawn_rate < 0.5:
+       spawn_group = 'Rare'
+    elif spawn_rate < 1:
+       spawn_group = 'Uncommon'
+    else:   # anything >= 1
+       spawn_group = 'Common'
+
+    return spawn_group
 
 def convert_pokemon_list(pokemon):
     args = get_args()
@@ -35,7 +59,7 @@ def convert_pokemon_list(pokemon):
     pokemon_result = []
     for p in pokemon:
         p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-        p['pokemon_rarity'] = get_pokemon_rarity(p['pokemon_id'])
+        p['pokemon_rarity'] = get_rarity(p['pokemon_id'])
         p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
         p['encounter_id'] = str(p['encounter_id'])
         if args.china:

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -17,13 +17,14 @@ from bisect import bisect_left
 from .models import (Pokemon, Gym, Pokestop, ScannedLocation,
                      MainWorker, WorkerStatus, Token, HashKeys,
                      SpawnPoint)
-from .utils import (get_pokemon_name, get_pokemon_types, get_pokemon_rarity,
+from .utils import (get_pokemon_name, get_pokemon_types,
                     now, dottedQuadToNum)
 from .transform import transform_from_wgs_to_gcj
 from .blacklist import fingerprints, get_ip_blacklist
 
 log = logging.getLogger(__name__)
 compress = Compress()
+
 
 def get_rarity(pokemon_id):
     seen = Pokemon.get_seen(48)
@@ -38,17 +39,18 @@ def get_rarity(pokemon_id):
         pokemon_count = 0
     spawn_rate = round(100 * pokemon_count / float(total), 4)
     if spawn_rate < 0.01:
-       spawn_group = 'Ultra Rare'
+        spawn_group = 'Ultra Rare'
     elif spawn_rate < 0.03:
-       spawn_group = 'Very Rare'
+        spawn_group = 'Very Rare'
     elif spawn_rate < 0.5:
-       spawn_group = 'Rare'
+        spawn_group = 'Rare'
     elif spawn_rate < 1:
-       spawn_group = 'Uncommon'
+        spawn_group = 'Uncommon'
     else:   # anything >= 1
-       spawn_group = 'Common'
+        spawn_group = 'Common'
 
     return spawn_group
+
 
 def convert_pokemon_list(pokemon):
     args = get_args()

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -36,11 +36,13 @@ def get_rarity(pokemon_id):
         now_time = default_timer()
 
         rarity_is_loaded = hasattr(get_rarity, 'last_seen')
+        should_refresh = False
 
-        # Refresh once in a while.
-        rarity_refresh_seconds = 60 * 60  # Once an hour.
-        time_diff = now_time - get_rarity.last_seen_time
-        should_refresh = time_diff > rarity_refresh_seconds
+        if rarity_is_loaded:
+            # Refresh once in a while.
+            rarity_refresh_seconds = 60 * 60  # Once an hour.
+            time_diff = now_time - get_rarity.last_seen_time
+            should_refresh = time_diff > rarity_refresh_seconds
 
         # Load or refresh.
         if not rarity_is_loaded or should_refresh:

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -34,7 +34,6 @@ def convert_pokemon_list(pokemon):
     pokemon_result = []
     for p in pokemon:
         p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-        p['pokemon_rarity'] = Pokemon.get_rarity(p['pokemon_id'])
         p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
         p['encounter_id'] = str(p['encounter_id'])
         if args.china:

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -30,6 +30,8 @@ rarity_lock = Lock()
 
 
 def get_rarity(pokemon_id):
+    args = get_args()
+    raritytime = args.raritytime
     # Data shared by several threads. Only one should be here to check/update.
     with rarity_lock:
         # Can't call it "now" because utils has a now() method...
@@ -47,7 +49,7 @@ def get_rarity(pokemon_id):
         # Load or refresh.
         if not rarity_is_loaded or should_refresh:
             log.info('Updating dynamic rarity...')
-            get_rarity.last_seen = Pokemon.get_seen(48)
+            get_rarity.last_seen = Pokemon.get_seen(raritytime)
             get_rarity.last_seen_time = now_time
             log.info('Updated dynamic rarity.')
 

--- a/pogom/customLog.py
+++ b/pogom/customLog.py
@@ -1,4 +1,4 @@
-from .utils import get_pokemon_rarity, get_pokemon_name
+from .utils import get_pokemon_name
 from pogom.utils import get_args
 from datetime import datetime
 
@@ -16,7 +16,6 @@ args = get_args()
 def printPokemon(id, lat, lng, itime):
     if args.display_in_console:
         pokemon_name = get_pokemon_name(id).lower()
-        pokemon_rarity = get_pokemon_rarity(id).lower()
         pokemon_id = str(id)
         doPrint = True
         # if args.ignore:
@@ -28,8 +27,7 @@ def printPokemon(id, lat, lng, itime):
         if doPrint:
             timeLeft = itime - datetime.utcnow()
             print(("======================================\n Name: %s\n " +
-                   "Rarity: %s\n Coord: (%f,%f)\n ID: %s \n Remaining " +
+                   "Coord: (%f,%f)\n ID: %s \n Remaining " +
                    "Time: %s\n======================================") % (
-                       pokemon_name.encode('utf-8'),
-                       pokemon_rarity.encode('utf-8'), lat, lng,
+                       pokemon_name.encode('utf-8'), lat, lng,
                        pokemon_id, str(timeLeft)))

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3119,7 +3119,8 @@ def database_migrate(db, old_ver):
     if old_ver < 24:
         migrate(
             migrator.drop_index('pokemon', 'pokemon_disappear_time'),
-            migrator.add_index('pokemon', ('disappear_time', 'pokemon_id'), False)
+            migrator.add_index('pokemon',
+                               ('disappear_time', 'pokemon_id'), False)
         )
 
     # Always log that we're done.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -22,8 +22,6 @@ from datetime import datetime, timedelta
 from cachetools import TTLCache
 from cachetools import cached
 from timeit import default_timer
-from threading import Lock
-from bisect import bisect_left
 
 from .utils import (get_pokemon_name, get_pokemon_types,
                     get_args, cellid, in_radius, date_secs, clock_between,
@@ -128,9 +126,6 @@ class Pokemon(LatLongModel):
     last_modified = DateTimeField(
         null=True, index=True, default=datetime.utcnow)
 
-    # Thread safety.
-    rarity_lock = Lock()
-
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
 
@@ -203,83 +198,13 @@ class Pokemon(LatLongModel):
 
         return list(query)
 
-    # Get a Pokémon's rarity by Pokémon ID. This method is cached
-    # locally by keeping a reference to the result for x time.
-    @staticmethod
-    def get_rarity(pokemon_id):
-        args = get_args()
-        hours = args.rarity_hours
-
-        # Shorter reference. Python would see get_rarity as a global if we
-        # don't do this.
-        get_rarity = Pokemon.get_rarity
-
-        # Data shared by several threads. Only one should be here to
-        # check/update.
-        with Pokemon.rarity_lock:
-            now = default_timer()
-            rarity_is_loaded = hasattr(get_rarity, 'last_seen')
-            should_refresh = False
-
-            # Refresh once in a while.
-            # TODO: Move to background task so queries aren't interrupted
-            # once #2445 is merged.
-            if rarity_is_loaded:
-                rarity_refresh_seconds = 60 * 60  # Once an hour.
-                time_diff = now - get_rarity.last_seen_time
-                should_refresh = time_diff > rarity_refresh_seconds
-
-            # Load or refresh.
-            if not rarity_is_loaded or should_refresh:
-                log.info('Updating dynamic rarity...')
-                get_rarity.last_seen = Pokemon.query_rarity(hours)
-                get_rarity.last_seen_time = now
-                log.info('Updated dynamic rarity.')
-
-                # Sort by Pokémon ID for binary search.
-                def cmp_pokeid(x, y):
-                    return x['pokemon_id'] - y['pokemon_id']
-
-                pokemon = get_rarity.last_seen['pokemon']
-                get_rarity.last_seen['pokemon'] = sorted(pokemon,
-                                                         cmp_pokeid)
-                # Store Pokémon IDs for searching.
-                get_rarity.last_seen_ids = [x['pokemon_id'] for x in pokemon]
-
-        # State checking is done. Code here is thread safe.
-        seen = get_rarity.last_seen
-        seen_ids = get_rarity.last_seen_ids
-
-        spawn_group = 'Common'
-        pokemon_count = 0
-        total = seen['total']
-        pokemon = seen['pokemon']
-
-        # Use spawn count if the Pokémon is in our list.
-        poke_idx = bisect_left(seen_ids, pokemon_id)
-
-        if (poke_idx != len(seen_ids) and
-                pokemon[poke_idx]['pokemon_id'] == pokemon_id):
-            pokemon_count = pokemon[poke_idx]['count']
-
-        spawn_rate_pct = round(100 * pokemon_count / float(total), 4)
-        if spawn_rate_pct < 0.01:
-            spawn_group = 'Ultra Rare'
-        elif spawn_rate_pct < 0.03:
-            spawn_group = 'Very Rare'
-        elif spawn_rate_pct < 0.5:
-            spawn_group = 'Rare'
-        elif spawn_rate_pct < 1:
-            spawn_group = 'Uncommon'
-
-        return spawn_group
-
-    # Get all Pokémon rarity based on the last x hours.
+    # Get all Pokémon spawn counts based on the last x hours.
     # More efficient than get_seen(): we don't do any unnecessary mojo.
-    # Returns a list of dicts: { 'pokemon_id': x, 'count': y }.
+    # Returns a dict:
+    #   { 'pokemon': [ {'pokemon_id': '', 'count': 1} ], 'total': 1 }.
     @staticmethod
-    def query_rarity(hours):
-        # Allow 0 to disable.
+    def get_spawn_counts(hours):
+        # Allow 0 to query everything.
         if hours:
             hours = datetime.utcnow() - timedelta(hours=hours)
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -279,12 +279,14 @@ class Pokemon(LatLongModel):
     # Returns a list of dicts: { 'pokemon_id': x, 'count': y }.
     @staticmethod
     def query_rarity(hours):
-        timediff = datetime.utcnow() - timedelta(hours=hours)
+        # Allow 0 to disable.
+        if hours:
+            hours = datetime.utcnow() - timedelta(hours=hours)
 
         query = (Pokemon
                  .select(Pokemon.pokemon_id,
                          fn.Count(Pokemon.pokemon_id).alias('count'))
-                 .where(Pokemon.disappear_time > timediff)
+                 .where(Pokemon.disappear_time > hours)
                  .group_by(Pokemon.pokemon_id)
                  .dicts())
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -23,7 +23,6 @@ from requests.adapters import HTTPAdapter
 from cHaversine import haversine
 from pprint import pformat
 from timeit import default_timer
-from pogom.models import Pokemon
 
 log = logging.getLogger(__name__)
 
@@ -1352,6 +1351,10 @@ def get_pokemon_rarity(total_spawns_all, total_spawns_pokemon):
 
 
 def dynamic_rarity_refresher():
+    # If we import at the top, pogom.models will import pogom.utils,
+    # causing the cyclic import to make some things unavailable.
+    from pogom.models import Pokemon
+
     # Refresh every x hours.
     args = get_args()
     hours = args.rarity_hours

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -137,16 +137,6 @@ def get_args():
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads.',
                         type=float, default=10)
-    parser.add_argument('-Rh', '--rarity-hours',
-                        help=('Number of hours of Pokemon data to use' +
-                              ' to calculate dynamic rarity. Decimals' +
-                              ' allowed. Default: 48. 0 to use all data.'),
-                        type=float, default=48)
-    parser.add_argument('-Rf', '--rarity-update-frequency',
-                        help=('How often (in minutes) the dynamic rarity' +
-                              ' should be updated. Decimals allowed.' +
-                              ' Default: 0. 0 to disable.'),
-                        type=float, default=0)
     parser.add_argument('--spawn-delay',
                         help=('Number of seconds after spawn time to wait ' +
                               'before scanning to be sure the Pokemon ' +
@@ -515,6 +505,17 @@ def get_args():
                          help=('Show debug messages from RocketMap ' +
                                'and pgoapi.'),
                          type=int, dest='verbose')
+    rarity = parser.add_argument_group('Dynamic Rarity')
+    rarity.add_argument('-Rh', '--rarity-hours',
+                        help=('Number of hours of Pokemon data to use' +
+                              ' to calculate dynamic rarity. Decimals' +
+                              ' allowed. Default: 48. 0 to use all data.'),
+                        type=float, default=48)
+    rarity.add_argument('-Rf', '--rarity-update-frequency',
+                        help=('How often (in minutes) the dynamic rarity' +
+                              ' should be updated. Decimals allowed.' +
+                              ' Default: 0. 0 to disable.'),
+                        type=float, default=0)
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -136,6 +136,10 @@ def get_args():
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads.',
                         type=float, default=10)
+    parser.add_argument('-rt', '--raritytime',
+                        help='Number of previous hours ' + 
+                             'used to calculate rarity.', type=int,
+                        default=48)
     parser.add_argument('--spawn-delay',
                         help=('Number of seconds after spawn time to wait ' +
                               'before scanning to be sure the Pokemon ' +

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -139,14 +139,14 @@ def get_args():
                         type=float, default=10)
     parser.add_argument('-Rh', '--rarity-hours',
                         help=('Number of hours of Pokemon data to use' +
-                              ' to calculate dynamic rarity. Default: 48.' +
-                              ' 0 to use all data.'),
-                        type=int, default=48)
+                              ' to calculate dynamic rarity. Decimals' +
+                              ' allowed. Default: 48. 0 to use all data.'),
+                        type=float, default=48)
     parser.add_argument('-Rf', '--rarity-update-frequency',
                         help=('How often (in minutes) the dynamic rarity' +
-                              ' should be updated. Default: 60.' +
-                              ' 0 to disable.'),
-                        type=int, default=60)
+                              ' should be updated. Decimals allowed.' +
+                              ' Default: 0. 0 to disable.'),
+                        type=float, default=0)
     parser.add_argument('--spawn-delay',
                         help=('Number of seconds after spawn time to wait ' +
                               'before scanning to be sure the Pokemon ' +

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -137,8 +137,9 @@ def get_args():
                         help='Time delay between requests in scan threads.',
                         type=float, default=10)
     parser.add_argument('-rh', '--rarity-hours',
-                        help=('Number of hours of Pokemon data to use ' +
-                              'to calculate dynamic rarity. Default: 48.'),
+                        help=('Number of hours of Pokemon data to use' +
+                              ' to calculate dynamic rarity. Default: 48.' +
+                              ' 0 to use all data.'),
                         type=int, default=48)
     parser.add_argument('--spawn-delay',
                         help=('Number of seconds after spawn time to wait ' +

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -137,7 +137,7 @@ def get_args():
                         help='Time delay between requests in scan threads.',
                         type=float, default=10)
     parser.add_argument('-rt', '--raritytime',
-                        help='Number of previous hours ' + 
+                        help='Number of previous hours ' +
                              'used to calculate rarity.', type=int,
                         default=48)
     parser.add_argument('--spawn-delay',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -136,10 +136,10 @@ def get_args():
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads.',
                         type=float, default=10)
-    parser.add_argument('-rt', '--raritytime',
-                        help='Number of previous hours ' +
-                             'used to calculate rarity.', type=int,
-                        default=48)
+    parser.add_argument('-rh', '--rarity-hours',
+                        help=('Number of hours of Pokemon data to use ' +
+                              'to calculate dynamic rarity. Default: 48.'),
+                        type=int, default=48)
     parser.add_argument('--spawn-delay',
                         help=('Number of seconds after spawn time to wait ' +
                               'before scanning to be sure the Pokemon ' +

--- a/runserver.py
+++ b/runserver.py
@@ -463,9 +463,13 @@ def main():
                                name='search-overseer', args=argset)
         search_thread.daemon = True
         search_thread.start()
-    else:
-        # -os only.
 
+    if args.no_server:
+        # This loop allows for ctrl-c interupts to work since flask won't be
+        # holding the program open.
+        while search_thread.is_alive():
+            time.sleep(60)
+    else:
         # Dynamic rarity.
         if args.rarity_update_frequency:
             t = Thread(target=dynamic_rarity_refresher,
@@ -475,13 +479,6 @@ def main():
             log.info('Dynamic rarity is enabled.')
         else:
             log.info('Dynamic rarity is disabled.')
-
-    if args.no_server:
-        # This loop allows for ctrl-c interupts to work since flask won't be
-        # holding the program open.
-        while search_thread.is_alive():
-            time.sleep(60)
-    else:
 
         if args.cors:
             CORS(app)

--- a/runserver.py
+++ b/runserver.py
@@ -203,6 +203,12 @@ def can_start_scanning(args):
         log.critical(api_version_error)
         return False
 
+    # Only allow dynamic rarity on -os.
+    if args.rarity_update_frequency:
+        log.critical(
+            'Dynamic rarity can only be enabled on -os instances.')
+        return False
+
     return True
 
 
@@ -254,7 +260,7 @@ def main():
 
     set_log_and_verbosity(log)
 
-    # Abort if only-server and no-server are used together
+    # Abort if only-server and no-server are used together.
     if args.only_server and args.no_server:
         log.critical(
             "You can't use no-server and only-server at the same time, silly.")
@@ -430,16 +436,6 @@ def main():
         else:
             log.info('Dynamic list refresher is disabled.')
 
-        # Dynamic rarity.
-        if args.rarity_update_frequency:
-            t = Thread(target=dynamic_rarity_refresher,
-                       name='dynamic-rarity')
-            t.daemon = True
-            t.start()
-            log.info('Dynamic rarity is enabled.')
-        else:
-            log.info('Dynamic rarity is disabled.')
-
         # Update player locale if not set correctly yet.
         args.player_locale = PlayerLocale.get_locale(args.location)
         if not args.player_locale:
@@ -467,6 +463,18 @@ def main():
                                name='search-overseer', args=argset)
         search_thread.daemon = True
         search_thread.start()
+    else:
+        # -os only.
+
+        # Dynamic rarity.
+        if args.rarity_update_frequency:
+            t = Thread(target=dynamic_rarity_refresher,
+                       name='dynamic-rarity')
+            t.daemon = True
+            t.start()
+            log.info('Dynamic rarity is enabled.')
+        else:
+            log.info('Dynamic rarity is disabled.')
 
     if args.no_server:
         # This loop allows for ctrl-c interupts to work since flask won't be

--- a/runserver.py
+++ b/runserver.py
@@ -19,7 +19,7 @@ from flask_cache_bust import init_cache_busting
 from pogom.app import Pogom
 from pogom.utils import (get_args, now, gmaps_reverse_geolocate,
                          log_resource_usage_loop, get_debug_dump_link,
-                         dynamic_loading_refresher)
+                         dynamic_loading_refresher, dynamic_rarity_refresher)
 from pogom.altitude import get_gmaps_altitude
 
 from pogom.models import (init_database, create_tables, drop_tables,
@@ -429,6 +429,16 @@ def main():
             log.info('Dynamic list refresher is enabled.')
         else:
             log.info('Dynamic list refresher is disabled.')
+
+        # Dynamic rarity.
+        if args.rarity_update_frequency:
+            t = Thread(target=dynamic_rarity_refresher,
+                       name='dynamic-rarity')
+            t.daemon = True
+            t.start()
+            log.info('Dynamic rarity is enabled.')
+        else:
+            log.info('Dynamic rarity is disabled.')
 
         # Update player locale if not set correctly yet.
         args.player_locale = PlayerLocale.get_locale(args.location)

--- a/runserver.py
+++ b/runserver.py
@@ -203,12 +203,6 @@ def can_start_scanning(args):
         log.critical(api_version_error)
         return False
 
-    # Only allow dynamic rarity on -os.
-    if args.rarity_update_frequency:
-        log.critical(
-            'Dynamic rarity can only be enabled on -os instances.')
-        return False
-
     return True
 
 

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -1,9333 +1,8719 @@
 {
   "1": {
-    "name": "Bulbasaur",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "61"
+    "name": "Bulbasaur"
   },
   "2": {
-    "name": "Ivysaur",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "421"
+    "name": "Ivysaur"
   },
   "3": {
-    "name": "Venusaur",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "641"
+    "name": "Venusaur"
   },
   "4": {
-    "name": "Charmander",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "119"
+    "name": "Charmander"
   },
   "5": {
-    "name": "Charmeleon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1025"
+    "name": "Charmeleon"
   },
   "6": {
-    "name": "Charizard",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Charizard"
   },
   "7": {
-    "name": "Squirtle",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "65"
+    "name": "Squirtle"
   },
   "8": {
-    "name": "Wartortle",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "484"
+    "name": "Wartortle"
   },
   "9": {
-    "name": "Blastoise",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "843"
+    "name": "Blastoise"
   },
   "10": {
-    "name": "Caterpie",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "51"
+    "name": "Caterpie"
   },
   "11": {
-    "name": "Metapod",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "433"
+    "name": "Metapod"
   },
   "12": {
-    "name": "Butterfree",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "843"
+    "name": "Butterfree"
   },
   "13": {
-    "name": "Weedle",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "21"
+    "name": "Weedle"
   },
   "14": {
-    "name": "Kakuna",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "204"
+    "name": "Kakuna"
   },
   "15": {
-    "name": "Beedrill",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "377"
+    "name": "Beedrill"
   },
   "16": {
-    "name": "Pidgey",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "10"
+    "name": "Pidgey"
   },
   "17": {
-    "name": "Pidgeotto",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "75"
+    "name": "Pidgeotto"
   },
   "18": {
-    "name": "Pidgeot",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "203"
+    "name": "Pidgeot"
   },
   "19": {
-    "name": "Rattata",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "13"
+    "name": "Rattata"
   },
   "20": {
-    "name": "Raticate",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "159"
+    "name": "Raticate"
   },
   "21": {
-    "name": "Spearow",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "31"
+    "name": "Spearow"
   },
   "22": {
-    "name": "Fearow",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "221"
+    "name": "Fearow"
   },
   "23": {
-    "name": "Ekans",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "75"
+    "name": "Ekans"
   },
   "24": {
-    "name": "Arbok",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "544"
+    "name": "Arbok"
   },
   "25": {
-    "name": "Pikachu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "92"
+    "name": "Pikachu"
   },
   "26": {
-    "name": "Raichu",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Raichu"
   },
   "27": {
-    "name": "Sandshrew",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "163"
+    "name": "Sandshrew"
   },
   "28": {
-    "name": "Sandslash",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1619"
+    "name": "Sandslash"
   },
   "29": {
-    "name": "Nidoran♀",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Nidoran♀"
   },
   "30": {
-    "name": "Nidorina",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "504"
+    "name": "Nidorina"
   },
   "31": {
-    "name": "Nidoqueen",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1398"
+    "name": "Nidoqueen"
   },
   "32": {
-    "name": "Nidoran♂",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Nidoran♂"
   },
   "33": {
-    "name": "Nidorino",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "586"
+    "name": "Nidorino"
   },
   "34": {
-    "name": "Nidoking",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1025"
+    "name": "Nidoking"
   },
   "35": {
-    "name": "Clefairy",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "85"
+    "name": "Clefairy"
   },
   "36": {
-    "name": "Clefable",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "1309"
+    "name": "Clefable"
   },
   "37": {
-    "name": "Vulpix",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "188"
+    "name": "Vulpix"
   },
   "38": {
-    "name": "Ninetales",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1538"
+    "name": "Ninetales"
   },
   "39": {
-    "name": "Jigglypuff",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "101"
+    "name": "Jigglypuff"
   },
   "40": {
-    "name": "Wigglytuff",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Wigglytuff"
   },
   "41": {
-    "name": "Zubat",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "24"
+    "name": "Zubat"
   },
   "42": {
-    "name": "Golbat",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "209"
+    "name": "Golbat"
   },
   "43": {
-    "name": "Oddish",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "91"
+    "name": "Oddish"
   },
   "44": {
-    "name": "Gloom",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "592"
+    "name": "Gloom"
   },
   "45": {
-    "name": "Vileplume",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1864"
+    "name": "Vileplume"
   },
   "46": {
-    "name": "Paras",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "44"
+    "name": "Paras"
   },
   "47": {
-    "name": "Parasect",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "397"
+    "name": "Parasect"
   },
   "48": {
-    "name": "Venonat",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "38"
+    "name": "Venonat"
   },
   "49": {
-    "name": "Venomoth",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "300"
+    "name": "Venomoth"
   },
   "50": {
-    "name": "Diglett",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "211"
+    "name": "Diglett"
   },
   "51": {
-    "name": "Dugtrio",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1663"
+    "name": "Dugtrio"
   },
   "52": {
-    "name": "Meowth",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "106"
+    "name": "Meowth"
   },
   "53": {
-    "name": "Persian",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "1282"
+    "name": "Persian"
   },
   "54": {
-    "name": "Psyduck",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "108"
+    "name": "Psyduck"
   },
   "55": {
-    "name": "Golduck",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "707"
+    "name": "Golduck"
   },
   "56": {
-    "name": "Mankey",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "114"
+    "name": "Mankey"
   },
   "57": {
-    "name": "Primeape",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1061"
+    "name": "Primeape"
   },
   "58": {
-    "name": "Growlithe",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Growlithe"
   },
   "59": {
-    "name": "Arcanine",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "932"
+    "name": "Arcanine"
   },
   "60": {
-    "name": "Poliwag",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "95"
+    "name": "Poliwag"
   },
   "61": {
-    "name": "Poliwhirl",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "481"
+    "name": "Poliwhirl"
   },
   "62": {
-    "name": "Poliwrath",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1709"
+    "name": "Poliwrath"
   },
   "63": {
-    "name": "Abra",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "104"
+    "name": "Abra"
   },
   "64": {
-    "name": "Kadabra",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "779"
+    "name": "Kadabra"
   },
   "65": {
-    "name": "Alakazam",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "2461"
+    "name": "Alakazam"
   },
   "66": {
-    "name": "Machop",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "217"
+    "name": "Machop"
   },
   "67": {
-    "name": "Machoke",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "1465"
+    "name": "Machoke"
   },
   "68": {
-    "name": "Machamp",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "3418"
+    "name": "Machamp"
   },
   "69": {
-    "name": "Bellsprout",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "86"
+    "name": "Bellsprout"
   },
   "70": {
-    "name": "Weepinbell",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "496"
+    "name": "Weepinbell"
   },
   "71": {
-    "name": "Victreebel",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Victreebel"
   },
   "72": {
-    "name": "Tentacool",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "275"
+    "name": "Tentacool"
   },
   "73": {
-    "name": "Tentacruel",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "615"
+    "name": "Tentacruel"
   },
   "74": {
-    "name": "Geodude",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "121"
+    "name": "Geodude"
   },
   "75": {
-    "name": "Graveler",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "707"
+    "name": "Graveler"
   },
   "76": {
-    "name": "Golem",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "2797"
+    "name": "Golem"
   },
   "77": {
-    "name": "Ponyta",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "121"
+    "name": "Ponyta"
   },
   "78": {
-    "name": "Rapidash",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "992"
+    "name": "Rapidash"
   },
   "79": {
-    "name": "Slowpoke",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "175"
+    "name": "Slowpoke"
   },
   "80": {
-    "name": "Slowbro",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "947"
+    "name": "Slowbro"
   },
   "81": {
-    "name": "Magnemite",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": "200"
+    "name": "Magnemite"
   },
   "82": {
-    "name": "Magneton",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": "2051"
+    "name": "Magneton"
   },
   "83": {
-    "name": "Farfetch'd",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "61527"
+    "name": "Farfetch'd"
   },
   "84": {
-    "name": "Doduo",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Doduo"
   },
   "85": {
-    "name": "Dodrio",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "634"
+    "name": "Dodrio"
   },
   "86": {
-    "name": "Seel",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "196"
+    "name": "Seel"
   },
   "87": {
-    "name": "Dewgong",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1578"
+    "name": "Dewgong"
   },
   "88": {
-    "name": "Grimer",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Grimer"
   },
   "89": {
-    "name": "Muk",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "7691"
+    "name": "Muk"
   },
   "90": {
-    "name": "Shellder",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "177"
+    "name": "Shellder"
   },
   "91": {
-    "name": "Cloyster",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1578"
+    "name": "Cloyster"
   },
   "92": {
-    "name": "Gastly",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "77"
+    "name": "Gastly"
   },
   "93": {
-    "name": "Haunter",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "419"
+    "name": "Haunter"
   },
   "94": {
-    "name": "Gengar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1758"
+    "name": "Gengar"
   },
   "95": {
-    "name": "Onix",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "269"
+    "name": "Onix"
   },
   "96": {
-    "name": "Drowzee",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "39"
+    "name": "Drowzee"
   },
   "97": {
-    "name": "Hypno",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "322"
+    "name": "Hypno"
   },
   "98": {
-    "name": "Krabby",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "73"
+    "name": "Krabby"
   },
   "99": {
-    "name": "Kingler",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "530"
+    "name": "Kingler"
   },
   "100": {
-    "name": "Voltorb",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "276"
+    "name": "Voltorb"
   },
   "101": {
-    "name": "Electrode",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "1985"
+    "name": "Electrode"
   },
   "102": {
-    "name": "Exeggcute",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "123"
+    "name": "Exeggcute"
   },
   "103": {
-    "name": "Exeggutor",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "1231"
+    "name": "Exeggutor"
   },
   "104": {
-    "name": "Cubone",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "163"
+    "name": "Cubone"
   },
   "105": {
-    "name": "Marowak",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": "1431"
+    "name": "Marowak"
   },
   "106": {
-    "name": "Hitmonlee",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "504"
+    "name": "Hitmonlee"
   },
   "107": {
-    "name": "Hitmonchan",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": "446"
+    "name": "Hitmonchan"
   },
   "108": {
-    "name": "Lickitung",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "443"
+    "name": "Lickitung"
   },
   "109": {
-    "name": "Koffing",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "213"
+    "name": "Koffing"
   },
   "110": {
-    "name": "Weezing",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": "1398"
+    "name": "Weezing"
   },
   "111": {
-    "name": "Rhyhorn",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": "110"
+    "name": "Rhyhorn"
   },
   "112": {
-    "name": "Rhydon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": "867"
+    "name": "Rhydon"
   },
   "113": {
-    "name": "Chansey",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "1256"
+    "name": "Chansey"
   },
   "114": {
-    "name": "Tangela",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": "346"
+    "name": "Tangela"
   },
   "115": {
-    "name": "Kangaskhan",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "2461"
+    "name": "Kangaskhan"
   },
   "116": {
-    "name": "Horsea",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "104"
+    "name": "Horsea"
   },
   "117": {
-    "name": "Seadra",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "760"
+    "name": "Seadra"
   },
   "118": {
-    "name": "Goldeen",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "103"
+    "name": "Goldeen"
   },
   "119": {
-    "name": "Seaking",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "684"
+    "name": "Seaking"
   },
   "120": {
-    "name": "Staryu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "97"
+    "name": "Staryu"
   },
   "121": {
-    "name": "Starmie",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "1206"
+    "name": "Starmie"
   },
   "122": {
-    "name": "Mr. Mime",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": "1431"
+    "name": "Mr. Mime"
   },
   "123": {
-    "name": "Scyther",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "155"
+    "name": "Scyther"
   },
   "124": {
-    "name": "Jynx",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "152"
+    "name": "Jynx"
   },
   "125": {
-    "name": "Electabuzz",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "261"
+    "name": "Electabuzz"
   },
   "126": {
-    "name": "Magmar",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "213"
+    "name": "Magmar"
   },
   "127": {
-    "name": "Pinsir",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": "99"
+    "name": "Pinsir"
   },
   "128": {
-    "name": "Tauros",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "153"
+    "name": "Tauros"
   },
   "129": {
-    "name": "Magikarp",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "79"
+    "name": "Magikarp"
   },
   "130": {
-    "name": "Gyarados",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "2279"
+    "name": "Gyarados"
   },
   "131": {
-    "name": "Lapras",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": "1183"
+    "name": "Lapras"
   },
   "132": {
-    "name": "Ditto",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "30764"
+    "name": "Ditto"
   },
   "133": {
-    "name": "Eevee",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "24"
+    "name": "Eevee"
   },
   "134": {
-    "name": "Vaporeon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "1465"
+    "name": "Vaporeon"
   },
   "135": {
-    "name": "Jolteon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": "1309"
+    "name": "Jolteon"
   },
   "136": {
-    "name": "Flareon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": "1568"
+    "name": "Flareon"
   },
   "137": {
-    "name": "Porygon",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "867"
+    "name": "Porygon"
   },
   "138": {
-    "name": "Omanyte",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "346"
+    "name": "Omanyte"
   },
   "139": {
-    "name": "Omastar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "6153"
+    "name": "Omastar"
   },
   "140": {
-    "name": "Kabuto",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "356"
+    "name": "Kabuto"
   },
   "141": {
-    "name": "Kabutops",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": "2930"
+    "name": "Kabutops"
   },
   "142": {
-    "name": "Aerodactyl",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "879"
+    "name": "Aerodactyl"
   },
   "143": {
-    "name": "Snorlax",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": "284"
+    "name": "Snorlax"
   },
   "144": {
-    "name": "Articuno",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Articuno"
   },
   "145": {
-    "name": "Zapdos",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Zapdos"
   },
   "146": {
-    "name": "Moltres",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Moltres"
   },
   "147": {
-    "name": "Dratini",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": "91"
+    "name": "Dratini"
   },
   "148": {
-    "name": "Dragonair",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": "699"
+    "name": "Dragonair"
   },
   "149": {
-    "name": "Dragonite",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": "580"
+    "name": "Dragonite"
   },
   "150": {
-    "name": "Mewtwo",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Mewtwo"
   },
   "151": {
-    "name": "Mew",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": "99999"
+    "name": "Mew"
   },
   "152": {
-    "name": "Chikorita",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chikorita"
   },
   "153": {
-    "name": "Bayleef",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bayleef"
   },
   "154": {
-    "name": "Meganium",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Meganium"
   },
   "155": {
-    "name": "Cyndaquil",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cyndaquil"
   },
   "156": {
-    "name": "Quilava",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quilava"
   },
   "157": {
-    "name": "Typhlosion",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Typhlosion"
   },
   "158": {
-    "name": "Totodile",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Totodile"
   },
   "159": {
-    "name": "Croconaw",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Croconaw"
   },
   "160": {
-    "name": "Feraligatr",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Feraligatr"
   },
   "161": {
-    "name": "Sentret",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sentret"
   },
   "162": {
-    "name": "Furret",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Furret"
   },
   "163": {
-    "name": "Hoothoot",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hoothoot"
   },
   "164": {
-    "name": "Noctowl",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Noctowl"
   },
   "165": {
-    "name": "Ledyba",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ledyba"
   },
   "166": {
-    "name": "Ledian",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ledian"
   },
   "167": {
-    "name": "Spinarak",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spinarak"
   },
   "168": {
-    "name": "Ariados",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ariados"
   },
   "169": {
-    "name": "Crobat",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Crobat"
   },
   "170": {
-    "name": "Chinchou",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chinchou"
   },
   "171": {
-    "name": "Lanturn",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lanturn"
   },
   "172": {
-    "name": "Pichu",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pichu"
   },
   "173": {
-    "name": "Cleffa",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cleffa"
   },
   "174": {
-    "name": "Igglybuff",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Igglybuff"
   },
   "175": {
-    "name": "Togepi",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togepi"
   },
   "176": {
-    "name": "Togetic",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togetic"
   },
   "177": {
-    "name": "Natu",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Natu"
   },
   "178": {
-    "name": "Xatu",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Xatu"
   },
   "179": {
-    "name": "Mareep",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mareep"
   },
   "180": {
-    "name": "Flaaffy",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Flaaffy"
   },
   "181": {
-    "name": "Ampharos",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ampharos"
   },
   "182": {
-    "name": "Bellossom",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bellossom"
   },
   "183": {
-    "name": "Marill",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Marill"
   },
   "184": {
-    "name": "Azumarill",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Azumarill"
   },
   "185": {
-    "name": "Sudowoodo",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sudowoodo"
   },
   "186": {
-    "name": "Politoed",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Politoed"
   },
   "187": {
-    "name": "Hoppip",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hoppip"
   },
   "188": {
-    "name": "Skiploom",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skiploom"
   },
   "189": {
-    "name": "Jumpluff",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Jumpluff"
   },
   "190": {
-    "name": "Aipom",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aipom"
   },
   "191": {
-    "name": "Sunkern",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sunkern"
   },
   "192": {
-    "name": "Sunflora",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sunflora"
   },
   "193": {
-    "name": "Yanma",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Yanma"
   },
   "194": {
-    "name": "Wooper",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wooper"
   },
   "195": {
-    "name": "Quagsire",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quagsire"
   },
   "196": {
-    "name": "Espeon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Espeon"
   },
   "197": {
-    "name": "Umbreon",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Umbreon"
   },
   "198": {
-    "name": "Murkrow",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Murkrow"
   },
   "199": {
-    "name": "Slowking",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slowking"
   },
   "200": {
-    "name": "Misdreavus",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Misdreavus"
   },
   "201": {
-    "name": "Unown",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Unown"
   },
   "202": {
-    "name": "Wobbuffet",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wobbuffet"
   },
   "203": {
-    "name": "Girafarig",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Girafarig"
   },
   "204": {
-    "name": "Pineco",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pineco"
   },
   "205": {
-    "name": "Forretress",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Forretress"
   },
   "206": {
-    "name": "Dunsparce",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dunsparce"
   },
   "207": {
-    "name": "Gligar",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gligar"
   },
   "208": {
-    "name": "Steelix",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Steelix"
   },
   "209": {
-    "name": "Snubbull",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Snubbull"
   },
   "210": {
-    "name": "Granbull",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Granbull"
   },
   "211": {
-    "name": "Qwilfish",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Qwilfish"
   },
   "212": {
-    "name": "Scizor",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scizor"
   },
   "213": {
-    "name": "Shuckle",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shuckle"
   },
   "214": {
-    "name": "Heracross",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Heracross"
   },
   "215": {
-    "name": "Sneasel",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sneasel"
   },
   "216": {
-    "name": "Teddiursa",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Teddiursa"
   },
   "217": {
-    "name": "Ursaring",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ursaring"
   },
   "218": {
-    "name": "Slugma",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slugma"
   },
   "219": {
-    "name": "Magcargo",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magcargo"
   },
   "220": {
-    "name": "Swinub",
-    "rarity": "Common",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swinub"
   },
   "221": {
-    "name": "Piloswine",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Piloswine"
   },
   "222": {
-    "name": "Corsola",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Corsola"
   },
   "223": {
-    "name": "Remoraid",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Remoraid"
   },
   "224": {
-    "name": "Octillery",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Octillery"
   },
   "225": {
-    "name": "Delibird",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Delibird"
   },
   "226": {
-    "name": "Mantine",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mantine"
   },
   "227": {
-    "name": "Skarmory",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skarmory"
   },
   "228": {
-    "name": "Houndour",
-    "rarity": "Uncommon",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Houndour"
   },
   "229": {
-    "name": "Houndoom",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Houndoom"
   },
   "230": {
-    "name": "Kingdra",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kingdra"
   },
   "231": {
-    "name": "Phanpy",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Phanpy"
   },
   "232": {
-    "name": "Donphan",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Donphan"
   },
   "233": {
-    "name": "Porygon2",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Porygon2"
   },
   "234": {
-    "name": "Stantler",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Stantler"
   },
   "235": {
-    "name": "Smeargle",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Smeargle"
   },
   "236": {
-    "name": "Tyrogue",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyrogue"
   },
   "237": {
-    "name": "Hitmontop",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hitmontop"
   },
   "238": {
-    "name": "Smoochum",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Smoochum"
   },
   "239": {
-    "name": "Elekid",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Elekid"
   },
   "240": {
-    "name": "Magby",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magby"
   },
   "241": {
-    "name": "Miltank",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Miltank"
   },
   "242": {
-    "name": "Blissey",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Blissey"
   },
   "243": {
-    "name": "Raikou",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Raikou"
   },
   "244": {
-    "name": "Entei",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Entei"
   },
   "245": {
-    "name": "Suicune",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Suicune"
   },
   "246": {
-    "name": "Larvitar",
-    "rarity": "Very Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Larvitar"
   },
   "247": {
-    "name": "Pupitar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pupitar"
   },
   "248": {
-    "name": "Tyranitar",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyranitar"
   },
   "249": {
-    "name": "Lugia",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lugia"
   },
   "250": {
-    "name": "Ho-Oh",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ho-Oh"
   },
   "251": {
-    "name": "Celebi",
-    "rarity": "Ultra Rare",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Celebi"
   },
   "252": {
-    "name": "Treecko",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Treecko"
   },
   "253": {
-    "name": "Grovyle",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Grovyle"
   },
   "254": {
-    "name": "Sceptile",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sceptile"
   },
   "255": {
-    "name": "Torchic",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Torchic"
   },
   "256": {
-    "name": "Combusken",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Combusken"
   },
   "257": {
-    "name": "Blaziken",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Blaziken"
   },
   "258": {
-    "name": "Mudkip",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mudkip"
   },
   "259": {
-    "name": "Marshtomp",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Marshtomp"
   },
   "260": {
-    "name": "Swampert",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swampert"
   },
   "261": {
-    "name": "Poochyena",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Poochyena"
   },
   "262": {
-    "name": "Mightyena",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mightyena"
   },
   "263": {
-    "name": "Zigzagoon",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zigzagoon"
   },
   "264": {
-    "name": "Linoone",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Linoone"
   },
   "265": {
-    "name": "Wurmple",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wurmple"
   },
   "266": {
-    "name": "Silcoon",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Silcoon"
   },
   "267": {
-    "name": "Beautifly",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Beautifly"
   },
   "268": {
-    "name": "Cascoon",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cascoon"
   },
   "269": {
-    "name": "Dustox",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dustox"
   },
   "270": {
-    "name": "Lotad",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lotad"
   },
   "271": {
-    "name": "Lombre",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lombre"
   },
   "272": {
-    "name": "Ludicolo",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ludicolo"
   },
   "273": {
-    "name": "Seedot",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Seedot"
   },
   "274": {
-    "name": "Nuzleaf",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Nuzleaf"
   },
   "275": {
-    "name": "Shiftry",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shiftry"
   },
   "276": {
-    "name": "Taillow",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Taillow"
   },
   "277": {
-    "name": "Swellow",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swellow"
   },
   "278": {
-    "name": "Wingull",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wingull"
   },
   "279": {
-    "name": "Pelipper",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pelipper"
   },
   "280": {
-    "name": "Ralts",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ralts"
   },
   "281": {
-    "name": "Kirlia",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kirlia"
   },
   "282": {
-    "name": "Gardevoir",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gardevoir"
   },
   "283": {
-    "name": "Surskit",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Surskit"
   },
   "284": {
-    "name": "Masquerain",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Masquerain"
   },
   "285": {
-    "name": "Shroomish",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shroomish"
   },
   "286": {
-    "name": "Breloom",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Breloom"
   },
   "287": {
-    "name": "Slakoth",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slakoth"
   },
   "288": {
-    "name": "Vigoroth",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vigoroth"
   },
   "289": {
-    "name": "Slaking",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slaking"
   },
   "290": {
-    "name": "Nincada",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Nincada"
   },
   "291": {
-    "name": "Ninjask",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ninjask"
   },
   "292": {
-    "name": "Shedinja",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shedinja"
   },
   "293": {
-    "name": "Whismur",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Whismur"
   },
   "294": {
-    "name": "Loudred",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Loudred"
   },
   "295": {
-    "name": "Exploud",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Exploud"
   },
   "296": {
-    "name": "Makuhita",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Makuhita"
   },
   "297": {
-    "name": "Hariyama",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hariyama"
   },
   "298": {
-    "name": "Azurill",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Azurill"
   },
   "299": {
-    "name": "Nosepass",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Nosepass"
   },
   "300": {
-    "name": "Skitty",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skitty"
   },
   "301": {
-    "name": "Delcatty",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Delcatty"
   },
   "302": {
-    "name": "Sableye",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sableye"
   },
   "303": {
-    "name": "Mawile",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mawile"
   },
   "304": {
-    "name": "Aron",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aron"
   },
   "305": {
-    "name": "Lairon",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lairon"
   },
   "306": {
-    "name": "Aggron",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aggron"
   },
   "307": {
-    "name": "Meditite",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Meditite"
   },
   "308": {
-    "name": "Medicham",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Medicham"
   },
   "309": {
-    "name": "Electrike",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Electrike"
   },
   "310": {
-    "name": "Manectric",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Manectric"
   },
   "311": {
-    "name": "Plusle",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Plusle"
   },
   "312": {
-    "name": "Minun",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Minun"
   },
   "313": {
-    "name": "Volbeat",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Volbeat"
   },
   "314": {
-    "name": "Illumise",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Illumise"
   },
   "315": {
-    "name": "Roselia",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Roselia"
   },
   "316": {
-    "name": "Gulpin",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gulpin"
   },
   "317": {
-    "name": "Swalot",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swalot"
   },
   "318": {
-    "name": "Carvanha",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Carvanha"
   },
   "319": {
-    "name": "Sharpedo",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sharpedo"
   },
   "320": {
-    "name": "Wailmer",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wailmer"
   },
   "321": {
-    "name": "Wailord",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wailord"
   },
   "322": {
-    "name": "Numel",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Numel"
   },
   "323": {
-    "name": "Camerupt",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Camerupt"
   },
   "324": {
-    "name": "Torkoal",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Torkoal"
   },
   "325": {
-    "name": "Spoink",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spoink"
   },
   "326": {
-    "name": "Grumpig",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Grumpig"
   },
   "327": {
-    "name": "Spinda",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spinda"
   },
   "328": {
-    "name": "Trapinch",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Trapinch"
   },
   "329": {
-    "name": "Vibrava",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vibrava"
   },
   "330": {
-    "name": "Flygon",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Flygon"
   },
   "331": {
-    "name": "Cacnea",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cacnea"
   },
   "332": {
-    "name": "Cacturne",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cacturne"
   },
   "333": {
-    "name": "Swablu",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swablu"
   },
   "334": {
-    "name": "Altaria",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Altaria"
   },
   "335": {
-    "name": "Zangoose",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zangoose"
   },
   "336": {
-    "name": "Seviper",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Seviper"
   },
   "337": {
-    "name": "Lunatone",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lunatone"
   },
   "338": {
-    "name": "Solrock",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Solrock"
   },
   "339": {
-    "name": "Barboach",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Barboach"
   },
   "340": {
-    "name": "Whiscash",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Whiscash"
   },
   "341": {
-    "name": "Corphish",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Corphish"
   },
   "342": {
-    "name": "Crawdaunt",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Crawdaunt"
   },
   "343": {
-    "name": "Baltoy",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Baltoy"
   },
   "344": {
-    "name": "Claydol",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Claydol"
   },
   "345": {
-    "name": "Lileep",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lileep"
   },
   "346": {
-    "name": "Cradily",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cradily"
   },
   "347": {
-    "name": "Anorith",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Anorith"
   },
   "348": {
-    "name": "Armaldo",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Armaldo"
   },
   "349": {
-    "name": "Feebas",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Feebas"
   },
   "350": {
-    "name": "Milotic",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Milotic"
   },
   "351": {
-    "name": "Castform",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Castform"
   },
   "352": {
-    "name": "Kecleon",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kecleon"
   },
   "353": {
-    "name": "Shuppet",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shuppet"
   },
   "354": {
-    "name": "Banette",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Banette"
   },
   "355": {
-    "name": "Duskull",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Duskull"
   },
   "356": {
-    "name": "Dusclops",
-    "rarity": "Rare",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dusclops"
   },
   "357": {
-    "name": "Tropius",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tropius"
   },
   "358": {
-    "name": "Chimecho",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chimecho"
   },
   "359": {
-    "name": "Absol",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Absol"
   },
   "360": {
-    "name": "Wynaut",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Wynaut"
   },
   "361": {
-    "name": "Snorunt",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Snorunt"
   },
   "362": {
-    "name": "Glalie",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Glalie"
   },
   "363": {
-    "name": "Spheal",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spheal"
   },
   "364": {
-    "name": "Sealeo",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sealeo"
   },
   "365": {
-    "name": "Walrein",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Walrein"
   },
   "366": {
-    "name": "Clamperl",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Clamperl"
   },
   "367": {
-    "name": "Huntail",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Huntail"
   },
   "368": {
-    "name": "Gorebyss",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gorebyss"
   },
   "369": {
-    "name": "Relicanth",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Relicanth"
   },
   "370": {
-    "name": "Luvdisc",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Luvdisc"
   },
   "371": {
-    "name": "Bagon",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bagon"
   },
   "372": {
-    "name": "Shelgon",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shelgon"
   },
   "373": {
-    "name": "Salamence",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Salamence"
   },
   "374": {
-    "name": "Beldum",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Beldum"
   },
   "375": {
-    "name": "Metang",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Metang"
   },
   "376": {
-    "name": "Metagross",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Metagross"
   },
   "377": {
-    "name": "Regirock",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Regirock"
   },
   "378": {
-    "name": "Regice",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Regice"
   },
   "379": {
-    "name": "Registeel",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Registeel"
   },
   "380": {
-    "name": "Latias",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Latias"
   },
   "381": {
-    "name": "Latios",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Latios"
   },
   "382": {
-    "name": "Kyogre",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kyogre"
   },
   "383": {
-    "name": "Groudon",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Groudon"
   },
   "384": {
-    "name": "Rayquaza",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Rayquaza"
   },
   "385": {
-    "name": "Jirachi",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Jirachi"
   },
   "386": {
-    "name": "Deoxys",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Deoxys"
   },
   "387": {
-    "name": "Turtwig",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Turtwig"
   },
   "388": {
-    "name": "Grotle",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Grotle"
   },
   "389": {
-    "name": "Torterra",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Torterra"
   },
   "390": {
-    "name": "Chimchar",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chimchar"
   },
   "391": {
-    "name": "Monferno",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Monferno"
   },
   "392": {
-    "name": "Infernape",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Infernape"
   },
   "393": {
-    "name": "Piplup",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Piplup"
   },
   "394": {
-    "name": "Prinplup",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Prinplup"
   },
   "395": {
-    "name": "Empoleon",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Empoleon"
   },
   "396": {
-    "name": "Starly",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Starly"
   },
   "397": {
-    "name": "Staravia",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Staravia"
   },
   "398": {
-    "name": "Staraptor",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Staraptor"
   },
   "399": {
-    "name": "Bidoof",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bidoof"
   },
   "400": {
-    "name": "Bibarel",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bibarel"
   },
   "401": {
-    "name": "Kricketot",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kricketot"
   },
   "402": {
-    "name": "Kricketune",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kricketune"
   },
   "403": {
-    "name": "Shinx",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shinx"
   },
   "404": {
-    "name": "Luxio",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Luxio"
   },
   "405": {
-    "name": "Luxray",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Luxray"
   },
   "406": {
-    "name": "Budew",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Budew"
   },
   "407": {
-    "name": "Roserade",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Roserade"
   },
   "408": {
-    "name": "Cranidos",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cranidos"
   },
   "409": {
-    "name": "Rampardos",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Rampardos"
   },
   "410": {
-    "name": "Shieldon",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shieldon"
   },
   "411": {
-    "name": "Bastiodon",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bastiodon"
   },
   "412": {
-    "name": "Burmy",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
-  },
-  "413": {
-    "name": "Wormadam",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Bug",
-        "color": "#a8b820"
-      },
-      {
-        "type": "Grass",
-        "color": "#78c850"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Burmy"
   },
   "414": {
-    "name": "Mothim",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mothim"
   },
   "415": {
-    "name": "Combee",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Combee"
   },
   "416": {
-    "name": "Vespiquen",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vespiquen"
   },
   "417": {
-    "name": "Pachirisu",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pachirisu"
   },
   "418": {
-    "name": "Buizel",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Buizel"
   },
   "419": {
-    "name": "Floatzel",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Floatzel"
   },
   "420": {
-    "name": "Cherubi",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cherubi"
   },
   "421": {
-    "name": "Cherrim",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cherrim"
   },
   "422": {
-    "name": "Shellos",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shellos"
   },
   "423": {
-    "name": "Gastrodon",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gastrodon"
   },
   "424": {
-    "name": "Ambipom",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ambipom"
   },
   "425": {
-    "name": "Drifloon",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Drifloon"
   },
   "426": {
-    "name": "Drifblim",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Drifblim"
   },
   "427": {
-    "name": "Buneary",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Buneary"
   },
   "428": {
-    "name": "Lopunny",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lopunny"
   },
   "429": {
-    "name": "Mismagius",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mismagius"
   },
   "430": {
-    "name": "Honchkrow",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Honchkrow"
   },
   "431": {
-    "name": "Glameow",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Glameow"
   },
   "432": {
-    "name": "Purugly",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Purugly"
   },
   "433": {
-    "name": "Chingling",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chingling"
   },
   "434": {
-    "name": "Stunky",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Stunky"
   },
   "435": {
-    "name": "Skuntank",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skuntank"
   },
   "436": {
-    "name": "Bronzor",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bronzor"
   },
   "437": {
-    "name": "Bronzong",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bronzong"
   },
   "438": {
-    "name": "Bonsly",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bonsly"
   },
   "439": {
-    "name": "Mime Jr.",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mime Jr."
   },
   "440": {
-    "name": "Happiny",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Happiny"
   },
   "441": {
-    "name": "Chatot",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chatot"
   },
   "442": {
-    "name": "Spiritomb",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spiritomb"
   },
   "443": {
-    "name": "Gible",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gible"
   },
   "444": {
-    "name": "Gabite",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gabite"
   },
   "445": {
-    "name": "Garchomp",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Garchomp"
   },
   "446": {
-    "name": "Munchlax",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Munchlax"
   },
   "447": {
-    "name": "Riolu",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Riolu"
   },
   "448": {
-    "name": "Lucario",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lucario"
   },
   "449": {
-    "name": "Hippopotas",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hippopotas"
   },
   "450": {
-    "name": "Hippowdon",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hippowdon"
   },
   "451": {
-    "name": "Skorupi",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skorupi"
   },
   "452": {
-    "name": "Drapion",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Drapion"
   },
   "453": {
-    "name": "Croagunk",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Croagunk"
   },
   "454": {
-    "name": "Toxicroak",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Toxicroak"
   },
   "455": {
-    "name": "Carnivine",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Carnivine"
   },
   "456": {
-    "name": "Finneon",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Finneon"
   },
   "457": {
-    "name": "Lumineon",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lumineon"
   },
   "458": {
-    "name": "Mantyke",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mantyke"
   },
   "459": {
-    "name": "Snover",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Snover"
   },
   "460": {
-    "name": "Abomasnow",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Abomasnow"
   },
   "461": {
-    "name": "Weavile",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Weavile"
   },
   "462": {
-    "name": "Magnezone",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magnezone"
   },
   "463": {
-    "name": "Lickilicky",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lickilicky"
   },
   "464": {
-    "name": "Rhyperior",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Rhyperior"
   },
   "465": {
-    "name": "Tangrowth",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tangrowth"
   },
   "466": {
-    "name": "Electivire",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Electivire"
   },
   "467": {
-    "name": "Magmortar",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Magmortar"
   },
   "468": {
-    "name": "Togekiss",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Togekiss"
   },
   "469": {
-    "name": "Yanmega",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Yanmega"
   },
   "470": {
-    "name": "Leafeon",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Leafeon"
   },
   "471": {
-    "name": "Glaceon",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Glaceon"
   },
   "472": {
-    "name": "Gliscor",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gliscor"
   },
   "473": {
-    "name": "Mamoswine",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mamoswine"
   },
   "474": {
-    "name": "Porygon-Z",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Porygon-Z"
   },
   "475": {
-    "name": "Gallade",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gallade"
   },
   "476": {
-    "name": "Probopass",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Probopass"
   },
   "477": {
-    "name": "Dusknoir",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dusknoir"
   },
   "478": {
-    "name": "Froslass",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Froslass"
   },
   "479": {
-    "name": "Rotom",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Rotom"
   },
   "480": {
-    "name": "Uxie",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Uxie"
   },
   "481": {
-    "name": "Mesprit",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mesprit"
   },
   "482": {
-    "name": "Azelf",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Azelf"
   },
   "483": {
-    "name": "Dialga",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dialga"
   },
   "484": {
-    "name": "Palkia",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Palkia"
   },
   "485": {
-    "name": "Heatran",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Heatran"
   },
   "486": {
-    "name": "Regigigas",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
-  },
-  "487": {
-    "name": "Giratina",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Ghost",
-        "color": "#705898"
-      },
-      {
-        "type": "Dragon",
-        "color": "#7038f8"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Regigigas"
   },
   "488": {
-    "name": "Cresselia",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cresselia"
   },
   "489": {
-    "name": "Phione",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Phione"
   },
   "490": {
-    "name": "Manaphy",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Manaphy"
   },
   "491": {
-    "name": "Darkrai",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
-  },
-  "492": {
-    "name": "Shaymin",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Grass",
-        "color": "#78c850"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Darkrai"
   },
   "493": {
-    "name": "Arceus",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Arceus"
   },
   "494": {
-    "name": "Victini",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Victini"
   },
   "495": {
-    "name": "Snivy",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Snivy"
   },
   "496": {
-    "name": "Servine",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Servine"
   },
   "497": {
-    "name": "Serperior",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Serperior"
   },
   "498": {
-    "name": "Tepig",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tepig"
   },
   "499": {
-    "name": "Pignite",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pignite"
   },
   "500": {
-    "name": "Emboar",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Emboar"
   },
   "501": {
-    "name": "Oshawott",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Oshawott"
   },
   "502": {
-    "name": "Dewott",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dewott"
   },
   "503": {
-    "name": "Samurott",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Samurott"
   },
   "504": {
-    "name": "Patrat",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Patrat"
   },
   "505": {
-    "name": "Watchog",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Watchog"
   },
   "506": {
-    "name": "Lillipup",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lillipup"
   },
   "507": {
-    "name": "Herdier",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Herdier"
   },
   "508": {
-    "name": "Stoutland",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Stoutland"
   },
   "509": {
-    "name": "Purrloin",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Purrloin"
   },
   "510": {
-    "name": "Liepard",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Liepard"
   },
   "511": {
-    "name": "Pansage",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pansage"
   },
   "512": {
-    "name": "Simisage",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Simisage"
   },
   "513": {
-    "name": "Pansear",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pansear"
   },
   "514": {
-    "name": "Simisear",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Simisear"
   },
   "515": {
-    "name": "Panpour",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Panpour"
   },
   "516": {
-    "name": "Simipour",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Simipour"
   },
   "517": {
-    "name": "Munna",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Munna"
   },
   "518": {
-    "name": "Musharna",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Musharna"
   },
   "519": {
-    "name": "Pidove",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pidove"
   },
   "520": {
-    "name": "Tranquill",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tranquill"
   },
   "521": {
-    "name": "Unfezant",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Unfezant"
   },
   "522": {
-    "name": "Blitzle",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Blitzle"
   },
   "523": {
-    "name": "Zebstrika",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zebstrika"
   },
   "524": {
-    "name": "Roggenrola",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Roggenrola"
   },
   "525": {
-    "name": "Boldore",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Boldore"
   },
   "526": {
-    "name": "Gigalith",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gigalith"
   },
   "527": {
-    "name": "Woobat",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Woobat"
   },
   "528": {
-    "name": "Swoobat",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swoobat"
   },
   "529": {
-    "name": "Drilbur",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Drilbur"
   },
   "530": {
-    "name": "Excadrill",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Excadrill"
   },
   "531": {
-    "name": "Audino",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Audino"
   },
   "532": {
-    "name": "Timburr",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Timburr"
   },
   "533": {
-    "name": "Gurdurr",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gurdurr"
   },
   "534": {
-    "name": "Conkeldurr",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Conkeldurr"
   },
   "535": {
-    "name": "Tympole",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tympole"
   },
   "536": {
-    "name": "Palpitoad",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Palpitoad"
   },
   "537": {
-    "name": "Seismitoad",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Seismitoad"
   },
   "538": {
-    "name": "Throh",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Throh"
   },
   "539": {
-    "name": "Sawk",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sawk"
   },
   "540": {
-    "name": "Sewaddle",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sewaddle"
   },
   "541": {
-    "name": "Swadloon",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swadloon"
   },
   "542": {
-    "name": "Leavanny",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Leavanny"
   },
   "543": {
-    "name": "Venipede",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Venipede"
   },
   "544": {
-    "name": "Whirlipede",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Whirlipede"
   },
   "545": {
-    "name": "Scolipede",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scolipede"
   },
   "546": {
-    "name": "Cottonee",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cottonee"
   },
   "547": {
-    "name": "Whimsicott",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Whimsicott"
   },
   "548": {
-    "name": "Petilil",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Petilil"
   },
   "549": {
-    "name": "Lilligant",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lilligant"
   },
   "550": {
-    "name": "Basculin",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Basculin"
   },
   "551": {
-    "name": "Sandile",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sandile"
   },
   "552": {
-    "name": "Krokorok",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Krokorok"
   },
   "553": {
-    "name": "Krookodile",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Krookodile"
   },
   "554": {
-    "name": "Darumaka",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Darumaka"
   },
   "555": {
-    "name": "Darmanitan",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Darmanitan"
   },
   "556": {
-    "name": "Maractus",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Maractus"
   },
   "557": {
-    "name": "Dwebble",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dwebble"
   },
   "558": {
-    "name": "Crustle",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Crustle"
   },
   "559": {
-    "name": "Scraggy",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scraggy"
   },
   "560": {
-    "name": "Scrafty",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scrafty"
   },
   "561": {
-    "name": "Sigilyph",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sigilyph"
   },
   "562": {
-    "name": "Yamask",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Yamask"
   },
   "563": {
-    "name": "Cofagrigus",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cohagrigus"
   },
   "564": {
-    "name": "Tirtouga",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tirtouga"
   },
   "565": {
-    "name": "Carracosta",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       }
     ],
-    "spawn_rate": ""
+    "name": "Carracosta"
   },
   "566": {
-    "name": "Archen",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Archen"
   },
   "567": {
-    "name": "Archeops",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Archeops"
   },
   "568": {
-    "name": "Trubbish",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Trubbish"
   },
   "569": {
-    "name": "Garbodor",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Garbodor"
   },
   "570": {
-    "name": "Zorua",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zorua"
   },
   "571": {
-    "name": "Zoroark",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zoroark"
   },
   "572": {
-    "name": "Minccino",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Minccino"
   },
   "573": {
-    "name": "Cinccino",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cinccino"
   },
   "574": {
-    "name": "Gothita",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gothita"
   },
   "575": {
-    "name": "Gothorita",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gothorita"
   },
   "576": {
-    "name": "Gothitelle",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gothitelle"
   },
   "577": {
-    "name": "Solosis",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Solosis"
   },
   "578": {
-    "name": "Duosion",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Duosion"
   },
   "579": {
-    "name": "Reuniclus",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Reuniclus"
   },
   "580": {
-    "name": "Ducklett",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ducklett"
   },
   "581": {
-    "name": "Swanna",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swanna"
   },
   "582": {
-    "name": "Vanillite",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vanillite"
   },
   "583": {
-    "name": "Vanillish",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vanillish"
   },
   "584": {
-    "name": "Vanilluxe",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vanilluxe"
   },
   "585": {
-    "name": "Deerling",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Deerling"
   },
   "586": {
-    "name": "Sawsbuck",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sawsbuck"
   },
   "587": {
-    "name": "Emolga",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Emolga"
   },
   "588": {
-    "name": "Karrablast",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Karrablast"
   },
   "589": {
-    "name": "Escavalier",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Escavalier"
   },
   "590": {
-    "name": "Foongus",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Foongus"
   },
   "591": {
-    "name": "Amoonguss",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Amoonguss"
   },
   "592": {
-    "name": "Frillish",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Frillish"
   },
   "593": {
-    "name": "Jellicent",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Jellicent"
   },
   "594": {
-    "name": "Alomomola",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Alomomola"
   },
   "595": {
-    "name": "Joltik",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Joltik"
   },
   "596": {
-    "name": "Galvantula",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Galvantula"
   },
   "597": {
-    "name": "Ferroseed",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ferroseed"
   },
   "598": {
-    "name": "Ferrothorn",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Ferrothorn"
   },
   "599": {
-    "name": "Klink",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Klink"
   },
   "600": {
-    "name": "Klang",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Klang"
   },
   "601": {
-    "name": "Klinklang",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Klinklang"
   },
   "602": {
-    "name": "Tynamo",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tynamo"
   },
   "603": {
-    "name": "Eelektrik",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Eelektrik"
   },
   "604": {
-    "name": "Eelektross",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Eelektross"
   },
   "605": {
-    "name": "Elgyem",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Elgyem"
   },
   "606": {
-    "name": "Beheeyem",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Beheeyem"
   },
   "607": {
-    "name": "Litwick",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Litwick"
   },
   "608": {
-    "name": "Lampent",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Lampent"
   },
   "609": {
-    "name": "Chandelure",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chandelure"
   },
   "610": {
-    "name": "Axew",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Axew"
   },
   "611": {
-    "name": "Fraxure",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Fraxure"
   },
   "612": {
-    "name": "Haxorus",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Haxorus"
   },
   "613": {
-    "name": "Cubchoo",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cubchoo"
   },
   "614": {
-    "name": "Beartic",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Beartic"
   },
   "615": {
-    "name": "Cryogonal",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cryogonal"
   },
   "616": {
-    "name": "Shelmet",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Shelmet"
   },
   "617": {
-    "name": "Accelgor",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Accelgor"
   },
   "618": {
-    "name": "Stunfisk",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Stunfisk"
   },
   "619": {
-    "name": "Mienfoo",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mienfoo"
   },
   "620": {
-    "name": "Mienshao",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mienshao"
   },
   "621": {
-    "name": "Druddigon",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Druddigon"
   },
   "622": {
-    "name": "Golett",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Golett"
   },
   "623": {
-    "name": "Golurk",
-    "rarity": "",
     "types": [
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Golurk"
   },
   "624": {
-    "name": "Pawniard",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pawniard"
   },
   "625": {
-    "name": "Bisharp",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bisharp"
   },
   "626": {
-    "name": "Bouffalant",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bouffalant"
   },
   "627": {
-    "name": "Rufflet",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Rufflet"
   },
   "628": {
-    "name": "Braviary",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Braviary"
   },
   "629": {
-    "name": "Vullaby",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vullaby"
   },
   "630": {
-    "name": "Mandibuzz",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Mandibuzz"
   },
   "631": {
-    "name": "Heatmor",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Heatmor"
   },
   "632": {
-    "name": "Durant",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Durant"
   },
   "633": {
-    "name": "Deino",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Deino"
   },
   "634": {
-    "name": "Zweilous",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zweilous"
   },
   "635": {
-    "name": "Hydreigon",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hydreigon"
   },
   "636": {
-    "name": "Larvesta",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Larvesta"
   },
   "637": {
-    "name": "Volcarona",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Volcarona"
   },
   "638": {
-    "name": "Cobalion",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Cobalion"
   },
   "639": {
-    "name": "Terrakion",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Terrakion"
   },
   "640": {
-    "name": "Virizion",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
-  },
-  "641": {
-    "name": "Tornadus",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Flying",
-        "color": "#a890f0"
-      }
-    ],
-    "spawn_rate": ""
-  },
-  "642": {
-    "name": "Thundurus",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Electric",
-        "color": "#f8d030"
-      },
-      {
-        "type": "Flying",
-        "color": "#a890f0"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Virizion"
   },
   "643": {
-    "name": "Reshiram",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Reshiram"
   },
   "644": {
-    "name": "Zekrom",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       }
     ],
-    "spawn_rate": ""
-  },
-  "645": {
-    "name": "Landorus",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Ground",
-        "color": "#e0c068"
-      },
-      {
-        "type": "Flying",
-        "color": "#a890f0"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Zekrom"
   },
   "646": {
-    "name": "Kyurem",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Kyurem"
   },
   "647": {
-    "name": "Keldeo",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
-  },
-  "648": {
-    "name": "Meloetta",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Normal",
-        "color": "#8a8a59"
-      },
-      {
-        "type": "Psychic",
-        "color": "#f85888"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Keldeo"
   },
   "649": {
-    "name": "Genesect",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Genesect"
   },
   "650": {
-    "name": "Chespin",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chespin"
   },
   "651": {
-    "name": "Quilladin",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Quilladin"
   },
   "652": {
-    "name": "Chesnaught",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       },
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Chesnaught"
   },
   "653": {
-    "name": "Fennekin",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Fennekin"
   },
   "654": {
-    "name": "Braixen",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       }
     ],
-    "spawn_rate": ""
+    "name": "Braixen"
   },
   "655": {
-    "name": "Delphox",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Delphox"
   },
   "656": {
-    "name": "Froakie",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Froakie"
   },
   "657": {
-    "name": "Frogadier",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Frogadier"
   },
   "658": {
-    "name": "Greninja",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Greninja"
   },
   "659": {
-    "name": "Bunnelby",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bunnelby"
   },
   "660": {
-    "name": "Diggersby",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Diggersby"
   },
   "661": {
-    "name": "Fletchling",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Fletchling"
   },
   "662": {
-    "name": "Fletchinder",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Fletchinder"
   },
   "663": {
-    "name": "Talonflame",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Talonflame"
   },
   "664": {
-    "name": "Scatterbug",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Scatterbug"
   },
   "665": {
-    "name": "Spewpa",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spewpa"
   },
   "666": {
-    "name": "Vivillon",
-    "rarity": "",
     "types": [
       {
-        "type": "Bug",
-        "color": "#a8b820"
+      "type": "Bug",
+      "color": "#a8b820"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Vivillon"
   },
   "667": {
-    "name": "Litleo",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Litleo"
   },
   "668": {
-    "name": "Pyroar",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pyroar"
   },
   "669": {
-    "name": "Flabébé",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Flabébé"
   },
   "670": {
-    "name": "Floette",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Floette"
   },
   "671": {
-    "name": "Florges",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Florges"
   },
   "672": {
-    "name": "Skiddo",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skiddo"
   },
   "673": {
-    "name": "Gogoat",
-    "rarity": "",
     "types": [
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gogoat"
   },
   "674": {
-    "name": "Pancham",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pancham"
   },
   "675": {
-    "name": "Pangoro",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       },
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pangoro"
   },
   "676": {
-    "name": "Furfrou",
-    "rarity": "",
     "types": [
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Furfrou"
   },
   "677": {
-    "name": "Espurr",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Espurr"
   },
   "678": {
-    "name": "Meowstic",
-    "rarity": "",
     "types": [
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Meowstic"
   },
   "679": {
-    "name": "Honedge",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
+    "name": "Honedge"
   },
   "680": {
-    "name": "Doublade",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       }
     ],
-    "spawn_rate": ""
-  },
-  "681": {
-    "name": "Aegislash",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Steel",
-        "color": "#b8b8d0"
-      },
-      {
-        "type": "Ghost",
-        "color": "#705898"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Doublade"
   },
   "682": {
-    "name": "Spritzee",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Spritzee"
   },
   "683": {
-    "name": "Aromatisse",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aromatisse"
   },
   "684": {
-    "name": "Swirlix",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Swirlix"
   },
   "685": {
-    "name": "Slurpuff",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Slurpuff"
   },
   "686": {
-    "name": "Inkay",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Inkay"
   },
   "687": {
-    "name": "Malamar",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Psychic",
-        "color": "#f85888"
+      "type": "Psychic",
+      "color": "#f85888"
       }
     ],
-    "spawn_rate": ""
+    "name": "Malamar"
   },
   "688": {
-    "name": "Binacle",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Binacle"
   },
   "689": {
-    "name": "Barbaracle",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Barbaracle"
   },
   "690": {
-    "name": "Skrelp",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Skrelp"
   },
   "691": {
-    "name": "Dragalge",
-    "rarity": "",
     "types": [
       {
-        "type": "Poison",
-        "color": "#a040a0"
+      "type": "Poison",
+      "color": "#a040a0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dragalge"
   },
   "692": {
-    "name": "Clauncher",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Clauncher"
   },
   "693": {
-    "name": "Clawitzer",
-    "rarity": "",
     "types": [
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Clawitzer"
   },
   "694": {
-    "name": "Helioptile",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Helioptile"
   },
   "695": {
-    "name": "Heliolisk",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Normal",
-        "color": "#8a8a59"
+      "type": "Normal",
+      "color": "#8a8a59"
       }
     ],
-    "spawn_rate": ""
+    "name": "Heliolisk"
   },
   "696": {
-    "name": "Tyrunt",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyrunt"
   },
   "697": {
-    "name": "Tyrantrum",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Tyrantrum"
   },
   "698": {
-    "name": "Amaura",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Amaura"
   },
   "699": {
-    "name": "Aurorus",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Aurorus"
   },
   "700": {
-    "name": "Sylveon",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sylveon"
   },
   "701": {
-    "name": "Hawlucha",
-    "rarity": "",
     "types": [
       {
-        "type": "Fighting",
-        "color": "#c03028"
+      "type": "Fighting",
+      "color": "#c03028"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Hawlucha"
   },
   "702": {
-    "name": "Dedenne",
-    "rarity": "",
     "types": [
       {
-        "type": "Electric",
-        "color": "#f8d030"
+      "type": "Electric",
+      "color": "#f8d030"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Dedenne"
   },
   "703": {
-    "name": "Carbink",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Carbink"
   },
   "704": {
-    "name": "Goomy",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Goomy"
   },
   "705": {
-    "name": "Sliggoo",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Sliggoo"
   },
   "706": {
-    "name": "Goodra",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Goodra"
   },
   "707": {
-    "name": "Klefki",
-    "rarity": "",
     "types": [
       {
-        "type": "Steel",
-        "color": "#b8b8d0"
+      "type": "Steel",
+      "color": "#b8b8d0"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Klefki"
   },
   "708": {
-    "name": "Phantump",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Phantump"
   },
   "709": {
-    "name": "Trevenant",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Trevenant"
   },
   "710": {
-    "name": "Pumpkaboo",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Pumpkaboo"
   },
   "711": {
-    "name": "Gourgeist",
-    "rarity": "",
     "types": [
       {
-        "type": "Ghost",
-        "color": "#705898"
+      "type": "Ghost",
+      "color": "#705898"
       },
       {
-        "type": "Grass",
-        "color": "#78c850"
+      "type": "Grass",
+      "color": "#78c850"
       }
     ],
-    "spawn_rate": ""
+    "name": "Gourgeist"
   },
   "712": {
-    "name": "Bergmite",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Bergmite"
   },
   "713": {
-    "name": "Avalugg",
-    "rarity": "",
     "types": [
       {
-        "type": "Ice",
-        "color": "#98d8d8"
+      "type": "Ice",
+      "color": "#98d8d8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Avalugg"
   },
   "714": {
-    "name": "Noibat",
-    "rarity": "",
     "types": [
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Noibat"
   },
   "715": {
-    "name": "Noivern",
-    "rarity": "",
     "types": [
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       },
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Noivern"
   },
   "716": {
-    "name": "Xerneas",
-    "rarity": "",
     "types": [
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
+    "name": "Xerneas"
   },
   "717": {
-    "name": "Yveltal",
-    "rarity": "",
     "types": [
       {
-        "type": "Dark",
-        "color": "#707070"
+      "type": "Dark",
+      "color": "#707070"
       },
       {
-        "type": "Flying",
-        "color": "#a890f0"
+      "type": "Flying",
+      "color": "#a890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Yveltal"
   },
   "718": {
-    "name": "Zygarde",
-    "rarity": "",
     "types": [
       {
-        "type": "Dragon",
-        "color": "#7038f8"
+      "type": "Dragon",
+      "color": "#7038f8"
       },
       {
-        "type": "Ground",
-        "color": "#e0c068"
+      "type": "Ground",
+      "color": "#e0c068"
       }
     ],
-    "spawn_rate": ""
+    "name": "Zygarde"
   },
   "719": {
-    "name": "Diancie",
-    "rarity": "",
     "types": [
       {
-        "type": "Rock",
-        "color": "#b8a038"
+      "type": "Rock",
+      "color": "#b8a038"
       },
       {
-        "type": "Fairy",
-        "color": "#e898e8"
+      "type": "Fairy",
+      "color": "#e898e8"
       }
     ],
-    "spawn_rate": ""
-  },
-  "720": {
-    "name": "Hoopa",
-    "rarity": "",
-    "types": [
-      {
-        "type": "Psychic",
-        "color": "#f85888"
-      },
-      {
-        "type": "Ghost",
-        "color": "#705898"
-      }
-    ],
-    "spawn_rate": ""
+    "name": "Diancie"
   },
   "721": {
-    "name": "Volcanion",
-    "rarity": "",
     "types": [
       {
-        "type": "Fire",
-        "color": "#f08030"
+      "type": "Fire",
+      "color": "#f08030"
       },
       {
-        "type": "Water",
-        "color": "#6890f0"
+      "type": "Water",
+      "color": "#6890f0"
       }
     ],
-    "spawn_rate": ""
+    "name": "Volcanion"
+  },
+  "722": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Rowlet"
+  },
+  "723": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Dartrix"
+  },
+  "724": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Decidueye"
+  },
+  "725": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Litten"
+  },
+  "726": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Torracat"
+  },
+  "727": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Dark",
+      "color": "#707070"
+      }
+    ],
+    "name": "Incineroar"
+  },
+  "728": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Popplio"
+  },
+  "729": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Brionne"
+  },
+  "730": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Primarina"
+  },
+  "731": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Pikipek"
+  },
+  "732": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Trumbeak"
+  },
+  "733": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Toucannon"
+  },
+  "734": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Yungoos"
+  },
+  "735": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Gumshoos"
+  },
+  "736": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Grubbin"
+  },
+  "737": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Charjabug"
+  },
+  "738": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Vikavolt"
+  },
+  "739": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Crabrawler"
+  },
+  "740": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Ice",
+      "color": "#98d8d8"
+      }
+    ],
+    "name": "Crabominable"
+  },
+  "741": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Oricorio"
+  },
+  "742": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Cutiefly"
+  },
+  "743": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Ribombee"
+  },
+  "744": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Rockruff"
+  },
+  "745": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      }
+    ],
+    "name": "Lycanroc"
+  },
+  "746": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wishiwashi"
+  },
+  "747": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Mareanie"
+  },
+  "748": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Toxapex"
+  },
+  "749": {
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mudbray"
+  },
+  "750": {
+    "types": [
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Mudsdale"
+  },
+  "751": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Dewpider"
+  },
+  "752": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      }
+    ],
+    "name": "Araquanid"
+  },
+  "753": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Fomantis"
+  },
+  "754": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Lurantis"
+  },
+  "755": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Morelull"
+  },
+  "756": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Shiinotic"
+  },
+  "757": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Salandit"
+  },
+  "758": {
+    "types": [
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      },
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      }
+    ],
+    "name": "Salazzle"
+  },
+  "759": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Stufful"
+  },
+  "760": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Bewear"
+  },
+  "761": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Bounsweet"
+  },
+  "762": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Steenee"
+  },
+  "763": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Tsareena"
+  },
+  "764": {
+    "types": [
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Comfey"
+  },
+  "765": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Oranguru"
+  },
+  "766": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Passimian"
+  },
+  "767": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Wimpod"
+  },
+  "768": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Golisopod"
+  },
+  "769": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Sandygast"
+  },
+  "770": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Ground",
+      "color": "#e0c068"
+      }
+    ],
+    "name": "Palossand"
+  },
+  "771": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      }
+    ],
+    "name": "Pyukumuku"
+  },
+  "772": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Type: Null"
+  },
+  "773": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Silvally"
+  },
+  "774": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Minior (Core)"
+  },
+  "775": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      }
+    ],
+    "name": "Komala"
+  },
+  "776": {
+    "types": [
+      {
+      "type": "Fire",
+      "color": "#f08030"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Turtonator"
+  },
+  "777": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Togedemaru"
+  },
+  "778": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Mimikyu"
+  },
+  "779": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Bruxish"
+  },
+  "780": {
+    "types": [
+      {
+      "type": "Normal",
+      "color": "#8a8a59"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Drampa"
+  },
+  "781": {
+    "types": [
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      },
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      }
+    ],
+    "name": "Dhelmise"
+  },
+  "782": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Jangmo-o"
+  },
+  "783": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Hakamo-o"
+  },
+  "784": {
+    "types": [
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Kommo-o"
+  },
+  "785": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Koko"
+  },
+  "786": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Lele"
+  },
+  "787": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Bulu"
+  },
+  "788": {
+    "types": [
+      {
+      "type": "Water",
+      "color": "#6890f0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Tapu Fini"
+  },
+  "789": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cosmog"
+  },
+  "790": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Cosmoem"
+  },
+  "791": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Solgaleo"
+  },
+  "792": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Lunala"
+  },
+  "793": {
+    "types": [
+      {
+      "type": "Rock",
+      "color": "#b8a038"
+      },
+      {
+      "type": "Poison",
+      "color": "#a040a0"
+      }
+    ],
+    "name": "Nihilego"
+  },
+  "794": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Buzzwole"
+  },
+  "795": {
+    "types": [
+      {
+      "type": "Bug",
+      "color": "#a8b820"
+      },
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      }
+    ],
+    "name": "Pheromosa"
+  },
+  "796": {
+    "types": [
+      {
+      "type": "Electric",
+      "color": "#f8d030"
+      }
+    ],
+    "name": "Xurkitree"
+  },
+  "797": {
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Flying",
+      "color": "#a890f0"
+      }
+    ],
+    "name": "Celesteela"
+  },
+  "798": {
+    "types": [
+      {
+      "type": "Grass",
+      "color": "#78c850"
+      },
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      }
+    ],
+    "name": "Kartana"
+  },
+  "799": {
+    "types": [
+      {
+      "type": "Dark",
+      "color": "#707070"
+      },
+      {
+      "type": "Dragon",
+      "color": "#7038f8"
+      }
+    ],
+    "name": "Guzzlord"
+  },
+  "800": {
+    "types": [
+      {
+      "type": "Psychic",
+      "color": "#f85888"
+      }
+    ],
+    "name": "Necrozma"
+  },
+  "801": {
+    "types": [
+      {
+      "type": "Steel",
+      "color": "#b8b8d0"
+      },
+      {
+      "type": "Fairy",
+      "color": "#e898e8"
+      }
+    ],
+    "name": "Magearna"
+  },
+  "802": {
+    "types": [
+      {
+      "type": "Fighting",
+      "color": "#c03028"
+      },
+      {
+      "type": "Ghost",
+      "color": "#705898"
+      }
+    ],
+    "name": "Marshadow"
   }
 }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1094,6 +1094,26 @@ var mapData = {
     spawnpoints: {}
 }
 
+// Populated by a JSON request.
+var pokemonRarities = {}
+
+function updatePokemonRarities() {
+    $.getJSON('static/dist/data/rarity.json').done(function (data) {
+        pokemonRarities = data
+    }).fail(function () {
+        // Could be disabled/removed.
+        console.log("Couldn't load dynamic rarity JSON.")
+    })
+}
+
+function getPokemonRarity(pokemonId) {
+    if (pokemonRarities.hasOwnProperty(pokemonId)) {
+        return pokemonRarities[pokemonId]
+    }
+
+    return ''
+}
+
 function getGoogleSprite(index, sprite, displayHeight) {
     displayHeight = Math.max(displayHeight, 3)
     var scale = displayHeight / sprite.iconHeight
@@ -1136,12 +1156,10 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true, isNotifyPkmn
             'legendary': 50
         }
 
-        if (item.hasOwnProperty('pokemon_rarity')) {
-            const pokemonRarity = item['pokemon_rarity'].toLowerCase()
+        const pokemonRarity = getPokemonRarity(item['pokemon_id']).toLowerCase()
 
-            if (rarityValues.hasOwnProperty(pokemonRarity)) {
-                rarityValue = rarityValues[pokemonRarity]
-            }
+        if (rarityValues.hasOwnProperty(pokemonRarity)) {
+            rarityValue = rarityValues[pokemonRarity]
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Tired of seeing Mr mime as ultra rare when you see 100's an hour?
This will set rarity for all pokemon from what you actually scan!

You can use `-rh` or  `--rarity-hours` to set the time period it uses to calculate rarity - default is 48 hours

I deleted my repo so had to close and reopen the PR
I also reduced the time frame it checks from all in db down to 2 days to try help with huge databases

**Seb edit:**

* Works on all instances except scanners only `-ns`.
* Dynamic rarity is disabled by default, similar to the database cleaner. It should be enabled on a single instance. (If enabled on multiple instances, you will create problems.)
* Reworked DB query and indexes to be more efficient.
   * 10 million Pokémon entries without limit = 5 seconds.
   * 10 million Pokémon entries filtered by the last 48h = **0.5 seconds**.
* Config items are now
   * `-Rh, --rarity-hours`, number of hours of Pokémon data to include. Decimals allowed. Default 48. 0 for all data.
   * `-Rf, --rarity-update-frequency`, how often to update, in minutes. Decimals allowed. Default 0. 0 to disable).
* Moved Pokémon rarity to front-end. Removes the need to cache data on back-end and makes it possible to serve the JSON file via nginx/apache2 (e.g. via symlink). Less overhead per request.

When pulling, remember to:
```
npm run build
```

## Description
sets rarity group dependant what you actually see.
Updated pokemon.json

## Motivation and Context
Rarity is area dependent, what one person scans in America is not valid for what someone scans in England so having a 1 size fits all pokemon.json does not work for all. 

All gen 3 and all future pokemon will automatically get set a rarity without needing to update pokemon.json

Scaling by rarity will also be more accurate because of this.


## How Has This Been Tested?
looked on map and checked it works like it did before changes but dynamically

Tested on a clean DB everything starts as ultra rare because its never seen them before but quickly changes during initial scan

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
