### PR TITLE
Add costume to Pokemon and costume/form to GymPokemon.

### DIFF
--- a/docs/extras/webhooks.md
+++ b/docs/extras/webhooks.md
@@ -226,6 +226,7 @@ A `pokemon` event is sent every time RocketMap detects that a Pokémon has spawn
 | `gender`                | The Pokémon's gender<sup>1</sup>                                    |       `2` |
 | `cp`                    | The Pokémon's CP<sup>2</sup>                                          |      `""` |
 | `form`                  | The Pokémon's form<sup>2</sup>                                        |      `""` |
+| `costume`               | The Pokémon's costume id<sup>2</sup>                                  |	     `""` |
 | `individual_attack`     | The Pokémon's attack IV<sup>2</sup>                                   |      `""` |
 | `individual_defense`    | The Pokémon's defence IV<sup>2</sup>                                  |      `""` |
 | `individual_stamina`    | The Pokémon's stamina IV<sup>2</sup>                                  |      `""` |
@@ -338,6 +339,7 @@ A `gym-info` event is sent whenever RocketMap fetches a gym's details.
 | `height`                   | The Pokémon's height                              | `1.746612787246704` |
 | `weight`                   | The Pokémon's weight                              | `51.84344482421875` |
 | `form`                     | The Pokémon's form                                       |          `0` |
+| `costume`                  | The Pokémon's costume                                    |          `0` |
 | `iv_attack`                | The Pokémon's attack IV                                  |         `12` |
 | `iv_defense`               | The Pokémon's defense IV                                 |         `14` |
 | `iv_stamina`               | The Pokémon's stamina IV                                 |         `14` |

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2012,13 +2012,8 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                 'weight': None,
                 'gender': p.pokemon_data.pokemon_display.gender,
                 'costume': p.pokemon_data.pokemon_display.costume,
-                'form': None
+                'form': p.pokemon_data.pokemon_display.form
             }
-
-            # Check for Unown's alphabetic character.
-            if pokemon_id == 201:
-                pokemon[p.encounter_id]['form'] = (p.pokemon_data
-                                                    .pokemon_display.form)
 
             # We need to check if exist and is not false due to a request error
             if pokemon_info:
@@ -2524,8 +2519,8 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'iv_defense': pokemon.individual_defense,
                 'iv_stamina': pokemon.individual_stamina,
                 'iv_attack': pokemon.individual_attack,
-                'costume': pokemon.costume,
-                'form': pokemon.form,
+                'costume': pokemon.pokemon_data.pokemon_display.costume,
+                'form': pokemon.pokemon_data.pokemon_display.form,
                 'last_seen': datetime.utcnow(),
             }
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3236,18 +3236,16 @@ def database_migrate(db, old_ver):
         )
 
     if old_ver < 25:
-        # Add `costume` column to `pokemon`
-        db.execute_sql('ALTER TABLE `pokemon` '
-                       'ADD `costume` SMALLINT(6) '
-                       'DEFAULT NULL AFTER `form`')
-        # Add `form` column to `gympokemon`
-        db.execute_sql('ALTER TABLE `gympokemon` '
-                       'ADD `form` SMALLINT(6) '
-                       'DEFAULT NULL AFTER `iv_attack`')
-        # Add `costume` column to `gympokemon`
-        db.execute_sql('ALTER TABLE `gympokemon` '
-                       'ADD `costume` SMALLINT(6) '
-                       'DEFAULT NULL AFTER `costume`')
+        migrate(
+            # Add `costume` column to `pokemon`
+            migrator.add_column('pokemon', 'costume',
+                                SmallIntegerField(null=True)),
+            # Add `form` column to `gympokemon`
+            migrator.add_column('gympokemon', 'form',
+                                SmallIntegerField(null=True)),
+            # Add `costume` column to `gympokemon`
+            migrator.add_column('gympokemon', 'costume',
+                                SmallIntegerField(null=True)))
 
     # Always log that we're done.
     log.info('Schema upgrade complete.')

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2519,8 +2519,8 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'iv_defense': pokemon.individual_defense,
                 'iv_stamina': pokemon.individual_stamina,
                 'iv_attack': pokemon.individual_attack,
-                'costume': pokemon.pokemon_data.pokemon_display.costume,
-                'form': pokemon.pokemon_data.pokemon_display.form,
+                'costume': pokemon.pokemon_display.costume,
+                'form': pokemon.pokemon_display.form,
                 'last_seen': datetime.utcnow(),
             }
 


### PR DESCRIPTION
Adds Costume during Pokemon and Gym Detection

This PR replaces #2370 

## Description
Checks for costume id during Pokemon detection process.  The costume is stored in the `pokemon` table under the column `costume` and is also sent via webhook data as `costume`.  Also added in checking for `costume` and `form` on GymPokemon and storing this detail in the database.  

## Motivation and Context
This fix allows for detection of the costume for Pokemon during special events.  Could also be used to change the sprite accordingly when the Costume is detected; however, this is not built in to this PR. 

## How Has This Been Tested?
My changes were tested on a local install of RocketMap

Testing was done to ensure that the Costume field is being captured and stored in the database as well as delivered via webhook. 

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
