### PR TITLE
Fix exception if account isn't selected yet.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2406,10 +2406,13 @@ def encounter_pokemon(args, pokemon, account, api, account_sets, status,
                 result = pokemon_info
 
     except Exception as e:
-        log.exception('There was an error encountering Pokemon ID %s with ' +
-                      'account %s: %s.',
+        # Account may not be selected yet.
+        if hlvl_account:
+            log.warning('Exception occured during encounter with'
+                        ' high-level account %s.',
+                        hlvl_account['username'])
+        log.exception('There was an error encountering Pokemon ID %s: %s.',
                       pokemon_id,
-                      hlvl_account['username'],
                       e)
 
     # We're done with the encounter. If it's from an


### PR DESCRIPTION
## Description
An exception can occur before an account was selected.

## Motivation and Context
```
  File "/RocketMap/RocketMap-git/pogom/models.py", line 2413, in encounter_pokemon
    hlvl_account['username'],
TypeError: 'NoneType' object has no attribute '__getitem__'
```

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
