### PR TITLE
devkat: DB upsert performance improvements.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2689,28 +2689,37 @@ def bulk_upsert(cls, data, db):
     # properly escaped. We use placeholders for 
     # VALUES(%s, %s, ...) so we can use executemany().
     row_fields = rows[0].keys()
-    fields = ['`'+conn.escape_string(f)+'`' for f in row_fields]    
     table = '`'+conn.escape_string(cls._meta.db_table)+'`'
-    placeholders = ['%s' for field in fields]
-    assignments = ['`{x}` = VALUES(`{x}`)'.format(
-        x=conn.escape_string(x)
-    ) for x in row_fields]
-    
+
     # Store defaults so we can fall back to them if a value
     # isn't set.
     defaults = {}
 
-    for f in row_fields:
-        if f in cls._meta.defaults:
-            field_default = cls._meta.defaults[f]
-        else:
-            field_default = None
+    for f in cls._meta.fields.values():
+        field_name = f.db_column
+        field_default = cls._meta.defaults.get(f, None)
 
         # peewee's defaults can be callable, e.g. current time.
         if callable(field_default):
             field_default = field_default()
 
-        defaults[f] = field_default
+        if field_default is not None:
+            # Make sure ones w/ a default are in our query.
+            if field_name not in row_fields:
+                row_fields.append(field_name)
+
+        defaults[field_name] = field_default
+
+    # Sort our keys. We'll do the same for row.items() later.
+    row_fields = sorted(row_fields)
+
+    # Assign fields, placeholders and assignments after defaults
+    # so our lists/keys stay in order.
+    fields = ['`'+conn.escape_string(f)+'`' for f in row_fields]
+    placeholders = ['%s' for field in fields]
+    assignments = ['`{x}` = VALUES(`{x}`)'.format(
+        x=conn.escape_string(x)
+    ) for x in row_fields]
 
     # We build our own MySQL query because peewee only supports
     # REPLACE INTO for upserting, which deletes the old row before
@@ -2737,11 +2746,21 @@ def bulk_upsert(cls, data, db):
 
                 for row in rows[i:min(i + step, num_rows)]:
                     # Fall back to default if no value is set.
-                    for field in row:
+                    for field in row.keys():
                         if row[field] is None:
-                            row[field] = defaults[field]
+                            default = defaults.get(field, None)
+                            row[field] = default
 
-                    row = row.values()
+                    # If we're missing a field that has a default, add it.
+                    for field in defaults:
+                        default = defaults.get(field, None)
+
+                        if field not in row and default is not None:
+                            row[field] = default
+                    
+                    # Dicts are unordered. Any modification to a dict can
+                    # change its order, so we keep an alphabetical one.
+                    row = [val for (key, val) in sorted(row.items())]
                     batch.append(row)
 
                 # Format query, and go.
@@ -2751,9 +2770,6 @@ def bulk_upsert(cls, data, db):
                     placeholders=', '.join(placeholders),
                     assignments=', '.join(assignments)
                 )
-
-                log.debug(formatted_query)
-                log.debug(batch[0])
 
                 cursor.executemany(formatted_query, batch)
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2712,6 +2712,8 @@ def bulk_upsert(cls, data, db):
 
     # Sort our keys. We'll do the same for row.items() later.
     row_fields = sorted(row_fields)
+    log.debug('Defaults: %s.', defaults)
+    log.debug('Fields: %s.', row_fields)
 
     # Assign fields, placeholders and assignments after defaults
     # so our lists/keys stay in order.
@@ -2731,7 +2733,12 @@ def bulk_upsert(cls, data, db):
     # Prepare transaction.
     with db.atomic():
         while i < num_rows:
-            log.debug('Inserting items %d to %d.', i, min(i + step, num_rows))
+            start = i
+            end = min(i + step, num_rows)
+            name = cls.__name__
+
+            log.debug('Inserting items %d to %d for %s.', start, end, name)
+
             try:
                 # Turn off FOREIGN_KEY_CHECKS on MySQL, because apparently it's
                 # unable to recognize strings to update unicode keys for
@@ -2747,10 +2754,25 @@ def bulk_upsert(cls, data, db):
                 for row in rows[i:min(i + step, num_rows)]:
                     # Fall back to default if no value is set.
                     for field in row.keys():
+                        # Take a default if we need it.
                         if row[field] is None:
                             default = defaults.get(field, None)
                             row[field] = default
 
+                        # Translate to proper column name, e.g. foreign keys.
+                        field_column = getattr(cls, field)
+
+                        # Only try to do it on populated fields.
+                        if field_column is not None:
+                            field_column = field_column.db_column
+
+                        if field == 'scannedlocation' or field_column == 'scannedlocation':
+                            log.debug('Field %s col %s.', field, field_column)
+                        if field != field_column:
+                            log.debug('Field %s col %s.', field, field_column)
+                            row[field_column] = row[field]
+                            row.pop(field)
+                    log.debug(row)
                     # If we're missing a field that has a default, add it.
                     for field in defaults:
                         default = defaults.get(field, None)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -26,7 +26,7 @@ from timeit import default_timer
 from .utils import (get_pokemon_name, get_pokemon_types,
                     get_args, cellid, in_radius, date_secs, clock_between,
                     get_move_name, get_move_damage, get_move_energy,
-                    get_move_type, calc_pokemon_level)
+                    get_move_type, calc_pokemon_level, peewee_attr_to_col)
 from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 
@@ -2686,7 +2686,7 @@ def bulk_upsert(cls, data, db):
 
     # We build our own INSERT INTO ... ON DUPLICATE KEY
     # UPDATE x=VALUES(x) query, making sure all data is
-    # properly escaped. We use placeholders for 
+    # properly escaped. We use placeholders for
     # VALUES(%s, %s, ...) so we can use executemany().
     row_fields = rows[0].keys()
     table = '`'+conn.escape_string(cls._meta.db_table)+'`'
@@ -2710,18 +2710,19 @@ def bulk_upsert(cls, data, db):
 
         defaults[field_name] = field_default
 
+    # Translate to proper column name, e.g. foreign keys.
+    row_fields = [peewee_attr_to_col(cls, f) for f in row_fields]
+
     # Sort our keys. We'll do the same for row.items() later.
     row_fields = sorted(row_fields)
-    log.debug('Defaults: %s.', defaults)
-    log.debug('Fields: %s.', row_fields)
 
     # Assign fields, placeholders and assignments after defaults
     # so our lists/keys stay in order.
     fields = ['`'+conn.escape_string(f)+'`' for f in row_fields]
     placeholders = ['%s' for field in fields]
-    assignments = ['`{x}` = VALUES(`{x}`)'.format(
-        x=conn.escape_string(x)
-    ) for x in row_fields]
+    assignments = ['{x} = VALUES({x})'.format(
+        x=escaped_field
+    ) for escaped_field in fields]
 
     # We build our own MySQL query because peewee only supports
     # REPLACE INTO for upserting, which deletes the old row before
@@ -2754,34 +2755,28 @@ def bulk_upsert(cls, data, db):
                 for row in rows[i:min(i + step, num_rows)]:
                     # Fall back to default if no value is set.
                     for field in row.keys():
+                        # Translate to proper column name, e.g. foreign keys.
+                        field_column = peewee_attr_to_col(cls, field)
+
+                        # Field name differs.
+                        if field != field_column:
+                            row[field_column] = row[field]
+                            row.pop(field)
+
                         # Take a default if we need it.
-                        if row[field] is None:
+                        if row[field_column] is None:
                             default = defaults.get(field, None)
                             row[field] = default
 
-                        # Translate to proper column name, e.g. foreign keys.
-                        field_column = getattr(cls, field)
-
-                        # Only try to do it on populated fields.
-                        if field_column is not None:
-                            field_column = field_column.db_column
-
-                        if field == 'scannedlocation' or field_column == 'scannedlocation':
-                            log.debug('Field %s col %s.', field, field_column)
-                        if field != field_column:
-                            log.debug('Field %s col %s.', field, field_column)
-                            row[field_column] = row[field]
-                            row.pop(field)
-                    log.debug(row)
                     # If we're missing a field that has a default, add it.
                     for field in defaults:
                         default = defaults.get(field, None)
 
                         if field not in row and default is not None:
                             row[field] = default
-                    
+
                     # Dicts are unordered. Any modification to a dict can
-                    # change its order, so we keep an alphabetical one.
+                    # change its order, so we keep a sorted one.
                     row = [val for (key, val) in sorted(row.items())]
                     batch.append(row)
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2668,10 +2668,38 @@ def clean_db_loop(args):
 
 
 def bulk_upsert(cls, data, db):
-    num_rows = len(data.values())
+    rows = data.values()
+    num_rows = len(rows)
     i = 0
+
+    # This shouldn't happen, ever, but anyways...
+    if num_rows < 1:
+        return
+
+    # We used to support SQLite and it has a default max 999 parameters,
+    # so we need to limit how many rows we insert for it.
     step = 250
 
+    # Prepare for our query.
+    conn = db.get_conn()
+    cursor = db.get_cursor()
+
+    fields = rows[0].keys()
+    fields = [conn.escape_string(f) for f in fields]    
+    table = '`'+conn.escape_string(cls._meta.db_table)+'`'
+    placeholders = ['%s' for field in fields]
+    assignments = ['`{x}` = VALUES(`{x}`)'.format(
+        x=conn.escape_string(x)
+    ) for x in fields]
+
+    # We build our own MySQL query because peewee only supports
+    # REPLACE INTO for upserting, which deletes the old row before
+    # adding the new one, giving a serious performance hit.
+    query_string = ('INSERT INTO {table} ({fields}) VALUES'
+                    + ' ({placeholders}) ON DUPLICATE KEY UPDATE'
+                    + ' {assignments}')
+
+    # Prepare transaction.
     with db.atomic():
         while i < num_rows:
             log.debug('Inserting items %d to %d.', i, min(i + step, num_rows))
@@ -2682,9 +2710,21 @@ def bulk_upsert(cls, data, db):
                 # constraint errors.
                 db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
 
-                # Use peewee's own implementation of the insert_many() method.
-                InsertQuery(cls, rows=data.values()[
-                            i:min(i + step, num_rows)]).upsert().execute()
+                # Time to bulk upsert our data. Convert objects to a list of
+                # values for executemany().
+                batch = [r.values() for r in rows[i:min(i + step, num_rows)]]
+
+                formatted_query = query_string.format(
+                    table=table,
+                    fields=', '.join(fields),
+                    placeholders=', '.join(placeholders),
+                    assignments=', '.join(assignments)
+                )
+
+                log.debug(formatted_query)
+                log.debug(batch[0])
+
+                cursor.executemany(formatted_query, batch)
 
                 db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2684,45 +2684,51 @@ def bulk_upsert(cls, data, db):
     conn = db.get_conn()
     cursor = db.get_cursor()
 
-    # We build our own INSERT INTO ... ON DUPLICATE KEY
-    # UPDATE x=VALUES(x) query, making sure all data is
-    # properly escaped. We use placeholders for
-    # VALUES(%s, %s, ...) so we can use executemany().
-    row_fields = rows[0].keys()
-    table = '`'+conn.escape_string(cls._meta.db_table)+'`'
+    # We build our own INSERT INTO ... ON DUPLICATE KEY UPDATE x=VALUES(x)
+    # query, making sure all data is properly escaped. We use
+    # placeholders for VALUES(%s, %s, ...) so we can use executemany().
+    # We use peewee's InsertQuery to retrieve the fields because it
+    # takes care of peewee's internals (e.g. required default fields).
+    query = InsertQuery(cls, rows=[ rows[0] ])
+    # Take the first row. We need to call _iter_rows() for peewee internals.
+    # Using next() for a single item is not considered "pythonic".
+    first_row = {}
+    for row in query._iter_rows():
+        first_row = row
+        break
+    # Convert the row to its fields, sorted by peewee.
+    row_fields = sorted(first_row.keys(), key=lambda x: x._sort_key)
+    row_fields = map(lambda x: x.name, row_fields)
+     # Translate to proper column name, e.g. foreign keys.
+    db_columns = [peewee_attr_to_col(cls, f) for f in row_fields]
 
     # Store defaults so we can fall back to them if a value
     # isn't set.
     defaults = {}
 
     for f in cls._meta.fields.values():
-        field_name = f.db_column
+        # Use DB column name as key.
+        field_name = f.name
         field_default = cls._meta.defaults.get(f, None)
 
         # peewee's defaults can be callable, e.g. current time.
         if callable(field_default):
             field_default = field_default()
 
-        if field_default is not None:
-            # Make sure ones w/ a default are in our query.
-            if field_name not in row_fields:
-                row_fields.append(field_name)
-
         defaults[field_name] = field_default
 
-    # Translate to proper column name, e.g. foreign keys.
-    row_fields = [peewee_attr_to_col(cls, f) for f in row_fields]
-
-    # Sort our keys. We'll do the same for row.items() later.
-    row_fields = sorted(row_fields)
+    log.debug('Fields: %s.', row_fields)
+    log.debug('DB columns: %s.', db_columns)
+    log.debug('Defaults: %s.', defaults)
 
     # Assign fields, placeholders and assignments after defaults
     # so our lists/keys stay in order.
-    fields = ['`'+conn.escape_string(f)+'`' for f in row_fields]
-    placeholders = ['%s' for field in fields]
+    table = '`'+conn.escape_string(cls._meta.db_table)+'`'
+    escaped_fields = ['`'+conn.escape_string(f)+'`' for f in db_columns]
+    placeholders = ['%s' for escaped_field in escaped_fields]
     assignments = ['{x} = VALUES({x})'.format(
         x=escaped_field
-    ) for escaped_field in fields]
+    ) for escaped_field in escaped_fields]
 
     # We build our own MySQL query because peewee only supports
     # REPLACE INTO for upserting, which deletes the old row before
@@ -2751,39 +2757,30 @@ def bulk_upsert(cls, data, db):
                 # values for executemany(), and fall back to defaults if
                 # necessary.
                 batch = []
+                batch_rows = rows[i:min(i + step, num_rows)]
 
-                for row in rows[i:min(i + step, num_rows)]:
-                    # Fall back to default if no value is set.
-                    for field in row.keys():
-                        # Translate to proper column name, e.g. foreign keys.
-                        field_column = peewee_attr_to_col(cls, field)
+                # We pop them off one by one so we can gradually release
+                # memory as we pass each item. No duplicate memory usage.
+                while len(batch_rows) > 0:
+                    row = batch_rows.pop()
+                    row_data = []
 
-                        # Field name differs.
-                        if field != field_column:
-                            row[field_column] = row[field]
-                            row.pop(field)
-
+                    # Parse rows, build arrays of values sorted via row_fields.
+                    for field in row_fields:
                         # Take a default if we need it.
-                        if row[field_column] is None:
+                        if field not in row:
                             default = defaults.get(field, None)
                             row[field] = default
 
-                    # If we're missing a field that has a default, add it.
-                    for field in defaults:
-                        default = defaults.get(field, None)
+                        # Append to keep the exact order, and only these fields.
+                        row_data.append(row[field])
+                    # Done preparing, add it to the batch.
+                    batch.append(row_data)
 
-                        if field not in row and default is not None:
-                            row[field] = default
-
-                    # Dicts are unordered. Any modification to a dict can
-                    # change its order, so we keep a sorted one.
-                    row = [val for (key, val) in sorted(row.items())]
-                    batch.append(row)
-
-                # Format query, and go.
+                # Format query and go.
                 formatted_query = query_string.format(
                     table=table,
-                    fields=', '.join(fields),
+                    fields=', '.join(escaped_fields),
                     placeholders=', '.join(placeholders),
                     assignments=', '.join(assignments)
                 )

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2689,7 +2689,7 @@ def bulk_upsert(cls, data, db):
     # placeholders for VALUES(%s, %s, ...) so we can use executemany().
     # We use peewee's InsertQuery to retrieve the fields because it
     # takes care of peewee's internals (e.g. required default fields).
-    query = InsertQuery(cls, rows=[ rows[0] ])
+    query = InsertQuery(cls, rows=[rows[0]])
     # Take the first row. We need to call _iter_rows() for peewee internals.
     # Using next() for a single item is not considered "pythonic".
     first_row = {}
@@ -2699,7 +2699,7 @@ def bulk_upsert(cls, data, db):
     # Convert the row to its fields, sorted by peewee.
     row_fields = sorted(first_row.keys(), key=lambda x: x._sort_key)
     row_fields = map(lambda x: x.name, row_fields)
-     # Translate to proper column name, e.g. foreign keys.
+    # Translate to proper column name, e.g. foreign keys.
     db_columns = [peewee_attr_to_col(cls, f) for f in row_fields]
 
     # Store defaults so we can fall back to them if a value
@@ -2710,16 +2710,7 @@ def bulk_upsert(cls, data, db):
         # Use DB column name as key.
         field_name = f.name
         field_default = cls._meta.defaults.get(f, None)
-
-        # peewee's defaults can be callable, e.g. current time.
-        if callable(field_default):
-            field_default = field_default()
-
         defaults[field_name] = field_default
-
-    log.debug('Fields: %s.', row_fields)
-    log.debug('DB columns: %s.', db_columns)
-    log.debug('Defaults: %s.', defaults)
 
     # Assign fields, placeholders and assignments after defaults
     # so our lists/keys stay in order.
@@ -2770,9 +2761,16 @@ def bulk_upsert(cls, data, db):
                         # Take a default if we need it.
                         if field not in row:
                             default = defaults.get(field, None)
+
+                            # peewee's defaults can be callable, e.g. current
+                            # time. We only call when needed to insert.
+                            if callable(default):
+                                default = default()
+
                             row[field] = default
 
-                        # Append to keep the exact order, and only these fields.
+                        # Append to keep the exact order, and only these
+                        # fields.
                         row_data.append(row[field])
                     # Done preparing, add it to the batch.
                     batch.append(row_data)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2684,13 +2684,33 @@ def bulk_upsert(cls, data, db):
     conn = db.get_conn()
     cursor = db.get_cursor()
 
-    fields = rows[0].keys()
-    fields = [conn.escape_string(f) for f in fields]    
+    # We build our own INSERT INTO ... ON DUPLICATE KEY
+    # UPDATE x=VALUES(x) query, making sure all data is
+    # properly escaped. We use placeholders for 
+    # VALUES(%s, %s, ...) so we can use executemany().
+    row_fields = rows[0].keys()
+    fields = ['`'+conn.escape_string(f)+'`' for f in row_fields]    
     table = '`'+conn.escape_string(cls._meta.db_table)+'`'
     placeholders = ['%s' for field in fields]
     assignments = ['`{x}` = VALUES(`{x}`)'.format(
         x=conn.escape_string(x)
-    ) for x in fields]
+    ) for x in row_fields]
+    
+    # Store defaults so we can fall back to them if a value
+    # isn't set.
+    defaults = {}
+
+    for f in row_fields:
+        if f in cls._meta.defaults:
+            field_default = cls._meta.defaults[f]
+        else:
+            field_default = None
+
+        # peewee's defaults can be callable, e.g. current time.
+        if callable(field_default):
+            field_default = field_default()
+
+        defaults[f] = field_default
 
     # We build our own MySQL query because peewee only supports
     # REPLACE INTO for upserting, which deletes the old row before
@@ -2711,9 +2731,20 @@ def bulk_upsert(cls, data, db):
                 db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
 
                 # Time to bulk upsert our data. Convert objects to a list of
-                # values for executemany().
-                batch = [r.values() for r in rows[i:min(i + step, num_rows)]]
+                # values for executemany(), and fall back to defaults if
+                # necessary.
+                batch = []
 
+                for row in rows[i:min(i + step, num_rows)]:
+                    # Fall back to default if no value is set.
+                    for field in row:
+                        if row[field] is None:
+                            row[field] = defaults[field]
+
+                    row = row.values()
+                    batch.append(row)
+
+                # Format query, and go.
                 formatted_query = query_string.format(
                     table=table,
                     fields=', '.join(fields),

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2677,8 +2677,12 @@ def bulk_upsert(cls, data, db):
         return
 
     # We used to support SQLite and it has a default max 999 parameters,
-    # so we need to limit how many rows we insert for it.
-    step = 250
+    # so we limited how many rows we insert for it.
+    # Oracle: 64000
+    # MySQL: 65535
+    # PostgreSQL: 34464
+    # Sqlite: 999
+    step = 500
 
     # Prepare for our query.
     conn = db.get_conn()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1393,3 +1393,16 @@ def dynamic_rarity_refresher():
         log.debug('Waiting %d minutes before next dynamic rarity update.',
                   refresh_time_sec / 60)
         time.sleep(refresh_time_sec)
+
+
+# Translate peewee model class attribute to database column name.
+def peewee_attr_to_col(cls, field):
+    field_column = getattr(cls, field)
+
+    # Only try to do it on populated fields.
+    if field_column is not None:
+        field_column = field_column.db_column
+    else:
+        field_column = field
+
+    return field_column


### PR DESCRIPTION
## Description
* Changes our bulk upsert code to use `INSERT ... ON DUPLICATE KEY UPDATE` instead of relying on peewee, which only supports `REPLACE INTO`.
* Also leverages the cursor's `.executemany`, allowing the DB to properly prepare for a batched query.

Long-term, we can look at increasing the batch step (currently 250) and analyze the performance with `executemany`.

## Motivation and Context
`REPLACE INTO` first deletes the old entry before inserting the new one. This causes several issues:

* Unnecessary overhead.
* The auto-increment ID for the row doesn't stay the same, it gets a new one when inserted. #2440 is affected by this.
* Table indexes have to be updated each time.
* Strongly affects DB lock wait times and eventually causes deadlocks once it reaches its limit.

## How Has This Been Tested?
Tested by devkat's grapefruit patrons as well as a 2-week testing period by our NAG patrons, per our usual patron-only release/testing schedule.

Feedback:

> stock RM:
> Upserted to ScannedLocation, 7957 records (upsert queue remaining: 0) in 1.981721 seconds.
> 
> new:
> Upserted to ScannedLocation, 7957 records (upsert queue remaining: 0) in 0.909359 seconds.

> [9:04 PM] -censored-: Jesus H Crust that upsert commit really helped. Changed from 16 db threads and still getting db-queues and eventually locks to 1 db-thread and smooth sailing.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
