### PR TITLE
Make db migration transactional

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3123,7 +3123,7 @@ def database_migrate(db, old_ver):
 
 def migrate_transaction(db, migrator, old_ver, new_ver, query):
     if old_ver < new_ver:
-        with db.atomic() as transaction:
+        with db.atomic():
             try:
                 query(db, migrator)
                 # Update database schema version.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3108,8 +3108,7 @@ def database_migrate(db, old_ver):
     }
 
     for new_ver, query in migrations.iteritems():
-        result = migrate_transaction(db, migrator, old_ver, new_ver,
-                                          query)
+        result = migrate_transaction(db, migrator, old_ver, new_ver, query)
         if not result:
             # Something failed in migration, quiting
             return False
@@ -3117,7 +3116,7 @@ def database_migrate(db, old_ver):
     # Update database schema version.
     Versions.update(val=db_schema_version).where(
         Versions.key == 'schema_version').execute()
-    # Always log that we're done.
+    # Always log that we're done.lk
     log.info('Schema upgrade complete.')
     return True
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make database migration by transactions for each version.  This will avoid corruption of the database on failed migration. It will also allow continue the migration from the correct version in case of migration of several versions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Exception during migration can lead to schema corruption or data loss. Old migration method set new version value despite exceptions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on #2458 

## Screenshots (if appropriate):
### Case 1: failed migration on first version change
New DB version: 23
DB version before migration: 21
Add test value in 22 migration: 
```python
db.execute_sql('INSERT INTO `versions` VALUES (\'test\', \'1\');')
```
Run server:
![image](https://user-images.githubusercontent.com/19952171/35475241-007f7ada-03ac-11e8-83e8-519b6530eb77.png)
Error rised in migration_22
Versions table:
![image](https://user-images.githubusercontent.com/19952171/35475256-35985e08-03ac-11e8-828b-295ff24bc261.png)
Thats correct, inserted data was rolledback on error.


### Case 2: failed migration on second version change
New DB version: 23
DB version before migration: 21
Add test value 1 in 22 migration:
```python
db.execute_sql('INSERT INTO `versions` VALUES (\'test\', \'1\');')
```
Comment out `DROP CONSTRAINT` in 22 migration

Add test value 2 in 23 migration:
```python
db.execute_sql('INSERT INTO `versions` VALUES (\'test\', \'2\');')
```
And `DROP CONSTRAINT` into 23 migration for failing.
![image](https://user-images.githubusercontent.com/19952171/35475306-032dc5e2-03ad-11e8-93cf-5abed0cfddd0.png)
Error rised in migration_23.
Versions table:
![image](https://user-images.githubusercontent.com/19952171/35475317-240aac76-03ad-11e8-95d0-3847006e5fb8.png)
Thats correct, migration from 21 to 23 was sucessefull, but data inserted in migration_23 was rolledback on error.

### Case 3: no errors
New DB version: 23
DB version before migration: 21
Add test value 1 in 22 migration:
```python
db.execute_sql('INSERT INTO `versions` VALUES (\'test\', \'1\');')
```
Comment out `DROP CONSTRAINT` in 22 migration
Add test value 2 in 23 migration:
```python
db.execute_sql('INSERT INTO `versions` VALUES (\'test\', \'2\');')
```
![image](https://user-images.githubusercontent.com/19952171/35475368-5976bb9c-03ae-11e8-914f-5dfdbfce5572.png)
![image](https://user-images.githubusercontent.com/19952171/35475369-6290fe72-03ae-11e8-91f4-682baeff67ca.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
