### PR TITLE
Add Weather Boost to Pokemon.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -90,6 +90,8 @@ const excludedRaritiesList = [
   ['common', 'uncommon', 'rare', 'very rare', 'ultra rare']
 ]
 
+const weatherBoosts = ['None', 'Clear', 'Rain', 'Partly Cloudy', 'Cloudy', 'Windy', 'Snow', 'Fog']
+
 /*
  text place holders:
  <pkm> - pokemon name
@@ -552,6 +554,7 @@ function pokemonLabel(item) {
     var form = item['form']
     var cp = item['cp']
     var cpMultiplier = item['cp_multiplier']
+    var weatherBoostedCondition = item['weather_boosted_condition']
     const showStats = Store.get('showPokemonStats')
 
     $.each(types, function (index, type) {
@@ -571,6 +574,14 @@ function pokemonLabel(item) {
     <div class='pokemon name'>
       ${name} <span class='pokemon name pokedex'><a href='http://pokemon.gameinfo.io/en/pokemon/${id}' target='_blank' title='View in Pokédex'>#${id}</a></span> ${formString} <span class='pokemon gender rarity'>${genderType[gender - 1]} ${rarityDisplay}</span> ${typesDisplay}
     </div>`
+
+    if (weatherBoostedCondition !== null) {
+        var boost = weatherBoosts[weatherBoostedCondition]
+        contentstring += `
+        <div class='pokemon'>
+          Weather Boost: ${boost}
+        </div>`
+    }
 
     if (showStats && cp !== null && cpMultiplier !== null) {
         var pokemonLevel = getPokemonLevel(cpMultiplier)


### PR DESCRIPTION
# Note: This PR comes with a database schema update. Please create a new database before using this PR, or use at your own risk.


## Description
Add weather boosted conditions to Pokemon in database.

## Motivation and Context
This PR adds basic weather support to RocketMap. This PR is **NOT** a fully-fledged weather map, it simply adds it to Pokemon if they are boosted.

## How Has This Been Tested?
Tested on local installation.

## Screenshots (if appropriate):
[Weather boost](https://images2.imgbox.com/cb/97/gkcY8d1o_o.png  "Weather Boost")

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
