### PR TITLE
Generation Addition and added to pokemon label window

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -17,7 +17,7 @@ from .models import (Pokemon, Gym, Pokestop, ScannedLocation,
                      MainWorker, WorkerStatus, Token, HashKeys,
                      SpawnPoint)
 from .utils import (get_args, get_pokemon_name, get_pokemon_types,
-                    now, dottedQuadToNum)
+                    get_pokemon_gen, now, dottedQuadToNum)
 from .transform import transform_from_wgs_to_gcj
 from .blacklist import fingerprints, get_ip_blacklist
 
@@ -34,6 +34,7 @@ def convert_pokemon_list(pokemon):
     pokemon_result = []
     for p in pokemon:
         p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
+        p['pokemon_gen'] = get_pokemon_gen(p['pokemon_id'])
         p['pokemon_types'] = get_pokemon_types(p['pokemon_id'])
         p['encounter_id'] = str(p['encounter_id'])
         if args.china:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -913,6 +913,10 @@ def get_pokemon_name(pokemon_id):
     return i8ln(get_pokemon_data(pokemon_id)['name'])
 
 
+def get_pokemon_gen(pokemon_id):
+    return get_pokemon_data(pokemon_id)['generation']
+
+
 def get_pokemon_types(pokemon_id):
     pokemon_types = get_pokemon_data(pokemon_id)['types']
     return map(lambda x: {"type": i8ln(x['type']), "color": x['color']},

--- a/static/data/pokemon.json
+++ b/static/data/pokemon.json
@@ -2,8718 +2,9511 @@
   "1": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Bulbasaur"
+    "name": "Bulbasaur",
+    "generation": "1"
   },
   "2": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Ivysaur"
+    "name": "Ivysaur",
+    "generation": "1"
   },
   "3": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venusaur"
+    "name": "Venusaur",
+    "generation": "1"
   },
   "4": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Charmander"
+    "name": "Charmander",
+    "generation": "1"
   },
   "5": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Charmeleon"
+    "name": "Charmeleon",
+    "generation": "1"
   },
   "6": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Charizard"
+    "name": "Charizard",
+    "generation": "1"
   },
   "7": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Squirtle"
+    "name": "Squirtle",
+    "generation": "1"
   },
   "8": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wartortle"
+    "name": "Wartortle",
+    "generation": "1"
   },
   "9": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Blastoise"
+    "name": "Blastoise",
+    "generation": "1"
   },
   "10": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Caterpie"
+    "name": "Caterpie",
+    "generation": "1"
   },
   "11": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Metapod"
+    "name": "Metapod",
+    "generation": "1"
   },
   "12": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Butterfree"
+    "name": "Butterfree",
+    "generation": "1"
   },
   "13": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Weedle"
+    "name": "Weedle",
+    "generation": "1"
   },
   "14": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Kakuna"
+    "name": "Kakuna",
+    "generation": "1"
   },
   "15": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Beedrill"
+    "name": "Beedrill",
+    "generation": "1"
   },
   "16": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidgey"
+    "name": "Pidgey",
+    "generation": "1"
   },
   "17": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidgeotto"
+    "name": "Pidgeotto",
+    "generation": "1"
   },
   "18": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidgeot"
+    "name": "Pidgeot",
+    "generation": "1"
   },
   "19": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Rattata"
+    "name": "Rattata",
+    "generation": "1"
   },
   "20": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Raticate"
+    "name": "Raticate",
+    "generation": "1"
   },
   "21": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Spearow"
+    "name": "Spearow",
+    "generation": "1"
   },
   "22": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Fearow"
+    "name": "Fearow",
+    "generation": "1"
   },
   "23": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Ekans"
+    "name": "Ekans",
+    "generation": "1"
   },
   "24": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Arbok"
+    "name": "Arbok",
+    "generation": "1"
   },
   "25": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Pikachu"
+    "name": "Pikachu",
+    "generation": "1"
   },
   "26": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Raichu"
+    "name": "Raichu",
+    "generation": "1"
   },
   "27": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Sandshrew"
+    "name": "Sandshrew",
+    "generation": "1"
   },
   "28": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Sandslash"
+    "name": "Sandslash",
+    "generation": "1"
   },
   "29": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidoran♀"
+    "name": "Nidoran♀",
+    "generation": "1"
   },
   "30": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidorina"
+    "name": "Nidorina",
+    "generation": "1"
   },
   "31": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Nidoqueen"
+    "name": "Nidoqueen",
+    "generation": "1"
   },
   "32": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidoran♂"
+    "name": "Nidoran♂",
+    "generation": "1"
   },
   "33": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nidorino"
+    "name": "Nidorino",
+    "generation": "1"
   },
   "34": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Nidoking"
+    "name": "Nidoking",
+    "generation": "1"
   },
   "35": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Clefairy"
+    "name": "Clefairy",
+    "generation": "1"
   },
   "36": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Clefable"
+    "name": "Clefable",
+    "generation": "1"
   },
   "37": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Vulpix"
+    "name": "Vulpix",
+    "generation": "1"
   },
   "38": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Ninetales"
+    "name": "Ninetales",
+    "generation": "1"
   },
   "39": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Jigglypuff"
+    "name": "Jigglypuff",
+    "generation": "1"
   },
   "40": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Wigglytuff"
+    "name": "Wigglytuff",
+    "generation": "1"
   },
   "41": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Zubat"
+    "name": "Zubat",
+    "generation": "1"
   },
   "42": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Golbat"
+    "name": "Golbat",
+    "generation": "1"
   },
   "43": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Oddish"
+    "name": "Oddish",
+    "generation": "1"
   },
   "44": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gloom"
+    "name": "Gloom",
+    "generation": "1"
   },
   "45": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Vileplume"
+    "name": "Vileplume",
+    "generation": "1"
   },
   "46": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Paras"
+    "name": "Paras",
+    "generation": "1"
   },
   "47": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Parasect"
+    "name": "Parasect",
+    "generation": "1"
   },
   "48": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venonat"
+    "name": "Venonat",
+    "generation": "1"
   },
   "49": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venomoth"
+    "name": "Venomoth",
+    "generation": "1"
   },
   "50": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Diglett"
+    "name": "Diglett",
+    "generation": "1"
   },
   "51": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Dugtrio"
+    "name": "Dugtrio",
+    "generation": "1"
   },
   "52": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Meowth"
+    "name": "Meowth",
+    "generation": "1"
   },
   "53": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Persian"
+    "name": "Persian",
+    "generation": "1"
   },
   "54": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Psyduck"
+    "name": "Psyduck",
+    "generation": "1"
   },
   "55": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Golduck"
+    "name": "Golduck",
+    "generation": "1"
   },
   "56": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Mankey"
+    "name": "Mankey",
+    "generation": "1"
   },
   "57": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Primeape"
+    "name": "Primeape",
+    "generation": "1"
   },
   "58": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Growlithe"
+    "name": "Growlithe",
+    "generation": "1"
   },
   "59": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Arcanine"
+    "name": "Arcanine",
+    "generation": "1"
   },
   "60": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Poliwag"
+    "name": "Poliwag",
+    "generation": "1"
   },
   "61": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Poliwhirl"
+    "name": "Poliwhirl",
+    "generation": "1"
   },
   "62": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Poliwrath"
+    "name": "Poliwrath",
+    "generation": "1"
   },
   "63": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Abra"
+    "name": "Abra",
+    "generation": "1"
   },
   "64": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Kadabra"
+    "name": "Kadabra",
+    "generation": "1"
   },
   "65": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Alakazam"
+    "name": "Alakazam",
+    "generation": "1"
   },
   "66": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Machop"
+    "name": "Machop",
+    "generation": "1"
   },
   "67": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Machoke"
+    "name": "Machoke",
+    "generation": "1"
   },
   "68": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Machamp"
+    "name": "Machamp",
+    "generation": "1"
   },
   "69": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Bellsprout"
+    "name": "Bellsprout",
+    "generation": "1"
   },
   "70": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Weepinbell"
+    "name": "Weepinbell",
+    "generation": "1"
   },
   "71": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Victreebel"
+    "name": "Victreebel",
+    "generation": "1"
   },
   "72": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Tentacool"
+    "name": "Tentacool",
+    "generation": "1"
   },
   "73": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Tentacruel"
+    "name": "Tentacruel",
+    "generation": "1"
   },
   "74": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Geodude"
+    "name": "Geodude",
+    "generation": "1"
   },
   "75": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Graveler"
+    "name": "Graveler",
+    "generation": "1"
   },
   "76": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Golem"
+    "name": "Golem",
+    "generation": "1"
   },
   "77": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Ponyta"
+    "name": "Ponyta",
+    "generation": "1"
   },
   "78": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Rapidash"
+    "name": "Rapidash",
+    "generation": "1"
   },
   "79": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Slowpoke"
+    "name": "Slowpoke",
+    "generation": "1"
   },
   "80": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Slowbro"
+    "name": "Slowbro",
+    "generation": "1"
   },
   "81": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Magnemite"
+    "name": "Magnemite",
+    "generation": "1"
   },
   "82": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Magneton"
+    "name": "Magneton",
+    "generation": "1"
   },
   "83": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Farfetch'd"
+    "name": "Farfetch'd",
+    "generation": "1"
   },
   "84": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Doduo"
+    "name": "Doduo",
+    "generation": "1"
   },
   "85": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Dodrio"
+    "name": "Dodrio",
+    "generation": "1"
   },
   "86": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Seel"
+    "name": "Seel",
+    "generation": "1"
   },
   "87": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Dewgong"
+    "name": "Dewgong",
+    "generation": "1"
   },
   "88": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Grimer"
+    "name": "Grimer",
+    "generation": "1"
   },
   "89": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Muk"
+    "name": "Muk",
+    "generation": "1"
   },
   "90": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Shellder"
+    "name": "Shellder",
+    "generation": "1"
   },
   "91": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Cloyster"
+    "name": "Cloyster",
+    "generation": "1"
   },
   "92": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gastly"
+    "name": "Gastly",
+    "generation": "1"
   },
   "93": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Haunter"
+    "name": "Haunter",
+    "generation": "1"
   },
   "94": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gengar"
+    "name": "Gengar",
+    "generation": "1"
   },
   "95": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Onix"
+    "name": "Onix",
+    "generation": "1"
   },
   "96": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Drowzee"
+    "name": "Drowzee",
+    "generation": "1"
   },
   "97": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Hypno"
+    "name": "Hypno",
+    "generation": "1"
   },
   "98": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Krabby"
+    "name": "Krabby",
+    "generation": "1"
   },
   "99": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kingler"
+    "name": "Kingler",
+    "generation": "1"
   },
   "100": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Voltorb"
+    "name": "Voltorb",
+    "generation": "1"
   },
   "101": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electrode"
+    "name": "Electrode",
+    "generation": "1"
   },
   "102": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Exeggcute"
+    "name": "Exeggcute",
+    "generation": "1"
   },
   "103": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Exeggutor"
+    "name": "Exeggutor",
+    "generation": "1"
   },
   "104": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Cubone"
+    "name": "Cubone",
+    "generation": "1"
   },
   "105": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Marowak"
+    "name": "Marowak",
+    "generation": "1"
   },
   "106": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hitmonlee"
+    "name": "Hitmonlee",
+    "generation": "1"
   },
   "107": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hitmonchan"
+    "name": "Hitmonchan",
+    "generation": "1"
   },
   "108": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lickitung"
+    "name": "Lickitung",
+    "generation": "1"
   },
   "109": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Koffing"
+    "name": "Koffing",
+    "generation": "1"
   },
   "110": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Weezing"
+    "name": "Weezing",
+    "generation": "1"
   },
   "111": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rhyhorn"
+    "name": "Rhyhorn",
+    "generation": "1"
   },
   "112": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rhydon"
+    "name": "Rhydon",
+    "generation": "1"
   },
   "113": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Chansey"
+    "name": "Chansey",
+    "generation": "1"
   },
   "114": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Tangela"
+    "name": "Tangela",
+    "generation": "1"
   },
   "115": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Kangaskhan"
+    "name": "Kangaskhan",
+    "generation": "1"
   },
   "116": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Horsea"
+    "name": "Horsea",
+    "generation": "1"
   },
   "117": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Seadra"
+    "name": "Seadra",
+    "generation": "1"
   },
   "118": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Goldeen"
+    "name": "Goldeen",
+    "generation": "1"
   },
   "119": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Seaking"
+    "name": "Seaking",
+    "generation": "1"
   },
   "120": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Staryu"
+    "name": "Staryu",
+    "generation": "1"
   },
   "121": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Starmie"
+    "name": "Starmie",
+    "generation": "1"
   },
   "122": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mr. Mime"
+    "name": "Mr. Mime",
+    "generation": "1"
   },
   "123": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Scyther"
+    "name": "Scyther",
+    "generation": "1"
   },
   "124": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Jynx"
+    "name": "Jynx",
+    "generation": "1"
   },
   "125": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electabuzz"
+    "name": "Electabuzz",
+    "generation": "1"
   },
   "126": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Magmar"
+    "name": "Magmar",
+    "generation": "1"
   },
   "127": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Pinsir"
+    "name": "Pinsir",
+    "generation": "1"
   },
   "128": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Tauros"
+    "name": "Tauros",
+    "generation": "1"
   },
   "129": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Magikarp"
+    "name": "Magikarp",
+    "generation": "1"
   },
   "130": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Gyarados"
+    "name": "Gyarados",
+    "generation": "1"
   },
   "131": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Lapras"
+    "name": "Lapras",
+    "generation": "1"
   },
   "132": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Ditto"
+    "name": "Ditto",
+    "generation": "1"
   },
   "133": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Eevee"
+    "name": "Eevee",
+    "generation": "1"
   },
   "134": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Vaporeon"
+    "name": "Vaporeon",
+    "generation": "1"
   },
   "135": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Jolteon"
+    "name": "Jolteon",
+    "generation": "1"
   },
   "136": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Flareon"
+    "name": "Flareon",
+    "generation": "1"
   },
   "137": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Porygon"
+    "name": "Porygon",
+    "generation": "1"
   },
   "138": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Omanyte"
+    "name": "Omanyte",
+    "generation": "1"
   },
   "139": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Omastar"
+    "name": "Omastar",
+    "generation": "1"
   },
   "140": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kabuto"
+    "name": "Kabuto",
+    "generation": "1"
   },
   "141": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kabutops"
+    "name": "Kabutops",
+    "generation": "1"
   },
   "142": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Aerodactyl"
+    "name": "Aerodactyl",
+    "generation": "1"
   },
   "143": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Snorlax"
+    "name": "Snorlax",
+    "generation": "1"
   },
   "144": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Articuno"
+    "name": "Articuno",
+    "generation": "1"
   },
   "145": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Zapdos"
+    "name": "Zapdos",
+    "generation": "1"
   },
   "146": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Moltres"
+    "name": "Moltres",
+    "generation": "1"
   },
   "147": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dratini"
+    "name": "Dratini",
+    "generation": "1"
   },
   "148": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dragonair"
+    "name": "Dragonair",
+    "generation": "1"
   },
   "149": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Dragonite"
+    "name": "Dragonite",
+    "generation": "1"
   },
   "150": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Mewtwo"
+    "name": "Mewtwo",
+    "generation": "1"
   },
   "151": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Mew"
+    "name": "Mew",
+    "generation": "1"
   },
   "152": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Chikorita"
+    "name": "Chikorita",
+    "generation": "2"
   },
   "153": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Bayleef"
+    "name": "Bayleef",
+    "generation": "2"
   },
   "154": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Meganium"
+    "name": "Meganium",
+    "generation": "2"
   },
   "155": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Cyndaquil"
+    "name": "Cyndaquil",
+    "generation": "2"
   },
   "156": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Quilava"
+    "name": "Quilava",
+    "generation": "2"
   },
   "157": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Typhlosion"
+    "name": "Typhlosion",
+    "generation": "2"
   },
   "158": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Totodile"
+    "name": "Totodile",
+    "generation": "2"
   },
   "159": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Croconaw"
+    "name": "Croconaw",
+    "generation": "2"
   },
   "160": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Feraligatr"
+    "name": "Feraligatr",
+    "generation": "2"
   },
   "161": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Sentret"
+    "name": "Sentret",
+    "generation": "2"
   },
   "162": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Furret"
+    "name": "Furret",
+    "generation": "2"
   },
   "163": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Hoothoot"
+    "name": "Hoothoot",
+    "generation": "2"
   },
   "164": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Noctowl"
+    "name": "Noctowl",
+    "generation": "2"
   },
   "165": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ledyba"
+    "name": "Ledyba",
+    "generation": "2"
   },
   "166": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ledian"
+    "name": "Ledian",
+    "generation": "2"
   },
   "167": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Spinarak"
+    "name": "Spinarak",
+    "generation": "2"
   },
   "168": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Ariados"
+    "name": "Ariados",
+    "generation": "2"
   },
   "169": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Crobat"
+    "name": "Crobat",
+    "generation": "2"
   },
   "170": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Chinchou"
+    "name": "Chinchou",
+    "generation": "2"
   },
   "171": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Lanturn"
+    "name": "Lanturn",
+    "generation": "2"
   },
   "172": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Pichu"
+    "name": "Pichu",
+    "generation": "2"
   },
   "173": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Cleffa"
+    "name": "Cleffa",
+    "generation": "2"
   },
   "174": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Igglybuff"
+    "name": "Igglybuff",
+    "generation": "2"
   },
   "175": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Togepi"
+    "name": "Togepi",
+    "generation": "2"
   },
   "176": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Togetic"
+    "name": "Togetic",
+    "generation": "2"
   },
   "177": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Natu"
+    "name": "Natu",
+    "generation": "2"
   },
   "178": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Xatu"
+    "name": "Xatu",
+    "generation": "2"
   },
   "179": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Mareep"
+    "name": "Mareep",
+    "generation": "2"
   },
   "180": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Flaaffy"
+    "name": "Flaaffy",
+    "generation": "2"
   },
   "181": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Ampharos"
+    "name": "Ampharos",
+    "generation": "2"
   },
   "182": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Bellossom"
+    "name": "Bellossom",
+    "generation": "2"
   },
   "183": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Marill"
+    "name": "Marill",
+    "generation": "2"
   },
   "184": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Azumarill"
+    "name": "Azumarill",
+    "generation": "2"
   },
   "185": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Sudowoodo"
+    "name": "Sudowoodo",
+    "generation": "2"
   },
   "186": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Politoed"
+    "name": "Politoed",
+    "generation": "2"
   },
   "187": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Hoppip"
+    "name": "Hoppip",
+    "generation": "2"
   },
   "188": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Skiploom"
+    "name": "Skiploom",
+    "generation": "2"
   },
   "189": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Jumpluff"
+    "name": "Jumpluff",
+    "generation": "2"
   },
   "190": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Aipom"
+    "name": "Aipom",
+    "generation": "2"
   },
   "191": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sunkern"
+    "name": "Sunkern",
+    "generation": "2"
   },
   "192": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sunflora"
+    "name": "Sunflora",
+    "generation": "2"
   },
   "193": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Yanma"
+    "name": "Yanma",
+    "generation": "2"
   },
   "194": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Wooper"
+    "name": "Wooper",
+    "generation": "2"
   },
   "195": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Quagsire"
+    "name": "Quagsire",
+    "generation": "2"
   },
   "196": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Espeon"
+    "name": "Espeon",
+    "generation": "2"
   },
   "197": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Umbreon"
+    "name": "Umbreon",
+    "generation": "2"
   },
   "198": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Murkrow"
+    "name": "Murkrow",
+    "generation": "2"
   },
   "199": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Slowking"
+    "name": "Slowking",
+    "generation": "2"
   },
   "200": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Misdreavus"
+    "name": "Misdreavus",
+    "generation": "2"
   },
   "201": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Unown"
+    "name": "Unown",
+    "generation": "2"
   },
   "202": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Wobbuffet"
+    "name": "Wobbuffet",
+    "generation": "2"
   },
   "203": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Girafarig"
+    "name": "Girafarig",
+    "generation": "2"
   },
   "204": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Pineco"
+    "name": "Pineco",
+    "generation": "2"
   },
   "205": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Forretress"
+    "name": "Forretress",
+    "generation": "2"
   },
   "206": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Dunsparce"
+    "name": "Dunsparce",
+    "generation": "2"
   },
   "207": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Gligar"
+    "name": "Gligar",
+    "generation": "2"
   },
   "208": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Steelix"
+    "name": "Steelix",
+    "generation": "2"
   },
   "209": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Snubbull"
+    "name": "Snubbull",
+    "generation": "2"
   },
   "210": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Granbull"
+    "name": "Granbull",
+    "generation": "2"
   },
   "211": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Qwilfish"
+    "name": "Qwilfish",
+    "generation": "2"
   },
   "212": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Scizor"
+    "name": "Scizor",
+    "generation": "2"
   },
   "213": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Shuckle"
+    "name": "Shuckle",
+    "generation": "2"
   },
   "214": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Heracross"
+    "name": "Heracross",
+    "generation": "2"
   },
   "215": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Sneasel"
+    "name": "Sneasel",
+    "generation": "2"
   },
   "216": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Teddiursa"
+    "name": "Teddiursa",
+    "generation": "2"
   },
   "217": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Ursaring"
+    "name": "Ursaring",
+    "generation": "2"
   },
   "218": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Slugma"
+    "name": "Slugma",
+    "generation": "2"
   },
   "219": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Magcargo"
+    "name": "Magcargo",
+    "generation": "2"
   },
   "220": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Swinub"
+    "name": "Swinub",
+    "generation": "2"
   },
   "221": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Piloswine"
+    "name": "Piloswine",
+    "generation": "2"
   },
   "222": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Corsola"
+    "name": "Corsola",
+    "generation": "2"
   },
   "223": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Remoraid"
+    "name": "Remoraid",
+    "generation": "2"
   },
   "224": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Octillery"
+    "name": "Octillery",
+    "generation": "2"
   },
   "225": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Delibird"
+    "name": "Delibird",
+    "generation": "2"
   },
   "226": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mantine"
+    "name": "Mantine",
+    "generation": "2"
   },
   "227": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Skarmory"
+    "name": "Skarmory",
+    "generation": "2"
   },
   "228": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Houndour"
+    "name": "Houndour",
+    "generation": "2"
   },
   "229": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Houndoom"
+    "name": "Houndoom",
+    "generation": "2"
   },
   "230": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Kingdra"
+    "name": "Kingdra",
+    "generation": "2"
   },
   "231": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Phanpy"
+    "name": "Phanpy",
+    "generation": "2"
   },
   "232": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Donphan"
+    "name": "Donphan",
+    "generation": "2"
   },
   "233": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Porygon2"
+    "name": "Porygon2",
+    "generation": "2"
   },
   "234": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Stantler"
+    "name": "Stantler",
+    "generation": "2"
   },
   "235": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Smeargle"
+    "name": "Smeargle",
+    "generation": "2"
   },
   "236": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Tyrogue"
+    "name": "Tyrogue",
+    "generation": "2"
   },
   "237": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hitmontop"
+    "name": "Hitmontop",
+    "generation": "2"
   },
   "238": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Smoochum"
+    "name": "Smoochum",
+    "generation": "2"
   },
   "239": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Elekid"
+    "name": "Elekid",
+    "generation": "2"
   },
   "240": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Magby"
+    "name": "Magby",
+    "generation": "2"
   },
   "241": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Miltank"
+    "name": "Miltank",
+    "generation": "2"
   },
   "242": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Blissey"
+    "name": "Blissey",
+    "generation": "2"
   },
   "243": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Raikou"
+    "name": "Raikou",
+    "generation": "2"
   },
   "244": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Entei"
+    "name": "Entei",
+    "generation": "2"
   },
   "245": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Suicune"
+    "name": "Suicune",
+    "generation": "2"
   },
   "246": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Larvitar"
+    "name": "Larvitar",
+    "generation": "2"
   },
   "247": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Pupitar"
+    "name": "Pupitar",
+    "generation": "2"
   },
   "248": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Tyranitar"
+    "name": "Tyranitar",
+    "generation": "2"
   },
   "249": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Lugia"
+    "name": "Lugia",
+    "generation": "2"
   },
   "250": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ho-Oh"
+    "name": "Ho-Oh",
+    "generation": "2"
   },
   "251": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Celebi"
+    "name": "Celebi",
+    "generation": "2"
   },
   "252": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Treecko"
+    "name": "Treecko",
+    "generation": "3"
   },
   "253": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Grovyle"
+    "name": "Grovyle",
+    "generation": "3"
   },
   "254": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sceptile"
+    "name": "Sceptile",
+    "generation": "3"
   },
   "255": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Torchic"
+    "name": "Torchic",
+    "generation": "3"
   },
   "256": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Combusken"
+    "name": "Combusken",
+    "generation": "3"
   },
   "257": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Blaziken"
+    "name": "Blaziken",
+    "generation": "3"
   },
   "258": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Mudkip"
+    "name": "Mudkip",
+    "generation": "3"
   },
   "259": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Marshtomp"
+    "name": "Marshtomp",
+    "generation": "3"
   },
   "260": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Swampert"
+    "name": "Swampert",
+    "generation": "3"
   },
   "261": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Poochyena"
+    "name": "Poochyena",
+    "generation": "3"
   },
   "262": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Mightyena"
+    "name": "Mightyena",
+    "generation": "3"
   },
   "263": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Zigzagoon"
+    "name": "Zigzagoon",
+    "generation": "3"
   },
   "264": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Linoone"
+    "name": "Linoone",
+    "generation": "3"
   },
   "265": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Wurmple"
+    "name": "Wurmple",
+    "generation": "3"
   },
   "266": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Silcoon"
+    "name": "Silcoon",
+    "generation": "3"
   },
   "267": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Beautifly"
+    "name": "Beautifly",
+    "generation": "3"
   },
   "268": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Cascoon"
+    "name": "Cascoon",
+    "generation": "3"
   },
   "269": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Dustox"
+    "name": "Dustox",
+    "generation": "3"
   },
   "270": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lotad"
+    "name": "Lotad",
+    "generation": "3"
   },
   "271": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lombre"
+    "name": "Lombre",
+    "generation": "3"
   },
   "272": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Ludicolo"
+    "name": "Ludicolo",
+    "generation": "3"
   },
   "273": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Seedot"
+    "name": "Seedot",
+    "generation": "3"
   },
   "274": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Nuzleaf"
+    "name": "Nuzleaf",
+    "generation": "3"
   },
   "275": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Shiftry"
+    "name": "Shiftry",
+    "generation": "3"
   },
   "276": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Taillow"
+    "name": "Taillow",
+    "generation": "3"
   },
   "277": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swellow"
+    "name": "Swellow",
+    "generation": "3"
   },
   "278": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Wingull"
+    "name": "Wingull",
+    "generation": "3"
   },
   "279": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pelipper"
+    "name": "Pelipper",
+    "generation": "3"
   },
   "280": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Ralts"
+    "name": "Ralts",
+    "generation": "3"
   },
   "281": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Kirlia"
+    "name": "Kirlia",
+    "generation": "3"
   },
   "282": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Gardevoir"
+    "name": "Gardevoir",
+    "generation": "3"
   },
   "283": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Surskit"
+    "name": "Surskit",
+    "generation": "3"
   },
   "284": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Masquerain"
+    "name": "Masquerain",
+    "generation": "3"
   },
   "285": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Shroomish"
+    "name": "Shroomish",
+    "generation": "3"
   },
   "286": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Breloom"
+    "name": "Breloom",
+    "generation": "3"
   },
   "287": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Slakoth"
+    "name": "Slakoth",
+    "generation": "3"
   },
   "288": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Vigoroth"
+    "name": "Vigoroth",
+    "generation": "3"
   },
   "289": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Slaking"
+    "name": "Slaking",
+    "generation": "3"
   },
   "290": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Nincada"
+    "name": "Nincada",
+    "generation": "3"
   },
   "291": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ninjask"
+    "name": "Ninjask",
+    "generation": "3"
   },
   "292": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Shedinja"
+    "name": "Shedinja",
+    "generation": "3"
   },
   "293": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Whismur"
+    "name": "Whismur",
+    "generation": "3"
   },
   "294": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Loudred"
+    "name": "Loudred",
+    "generation": "3"
   },
   "295": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Exploud"
+    "name": "Exploud",
+    "generation": "3"
   },
   "296": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Makuhita"
+    "name": "Makuhita",
+    "generation": "3"
   },
   "297": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hariyama"
+    "name": "Hariyama",
+    "generation": "3"
   },
   "298": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Azurill"
+    "name": "Azurill",
+    "generation": "3"
   },
   "299": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Nosepass"
+    "name": "Nosepass",
+    "generation": "3"
   },
   "300": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Skitty"
+    "name": "Skitty",
+    "generation": "3"
   },
   "301": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Delcatty"
+    "name": "Delcatty",
+    "generation": "3"
   },
   "302": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Sableye"
+    "name": "Sableye",
+    "generation": "3"
   },
   "303": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mawile"
+    "name": "Mawile",
+    "generation": "3"
   },
   "304": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Aron"
+    "name": "Aron",
+    "generation": "3"
   },
   "305": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Lairon"
+    "name": "Lairon",
+    "generation": "3"
   },
   "306": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Aggron"
+    "name": "Aggron",
+    "generation": "3"
   },
   "307": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Meditite"
+    "name": "Meditite",
+    "generation": "3"
   },
   "308": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Medicham"
+    "name": "Medicham",
+    "generation": "3"
   },
   "309": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electrike"
+    "name": "Electrike",
+    "generation": "3"
   },
   "310": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Manectric"
+    "name": "Manectric",
+    "generation": "3"
   },
   "311": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Plusle"
+    "name": "Plusle",
+    "generation": "3"
   },
   "312": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Minun"
+    "name": "Minun",
+    "generation": "3"
   },
   "313": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Volbeat"
+    "name": "Volbeat",
+    "generation": "3"
   },
   "314": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Illumise"
+    "name": "Illumise",
+    "generation": "3"
   },
   "315": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Roselia"
+    "name": "Roselia",
+    "generation": "3"
   },
   "316": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Gulpin"
+    "name": "Gulpin",
+    "generation": "3"
   },
   "317": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Swalot"
+    "name": "Swalot",
+    "generation": "3"
   },
   "318": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Carvanha"
+    "name": "Carvanha",
+    "generation": "3"
   },
   "319": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Sharpedo"
+    "name": "Sharpedo",
+    "generation": "3"
   },
   "320": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wailmer"
+    "name": "Wailmer",
+    "generation": "3"
   },
   "321": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wailord"
+    "name": "Wailord",
+    "generation": "3"
   },
   "322": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Numel"
+    "name": "Numel",
+    "generation": "3"
   },
   "323": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Camerupt"
+    "name": "Camerupt",
+    "generation": "3"
   },
   "324": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Torkoal"
+    "name": "Torkoal",
+    "generation": "3"
   },
   "325": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Spoink"
+    "name": "Spoink",
+    "generation": "3"
   },
   "326": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Grumpig"
+    "name": "Grumpig",
+    "generation": "3"
   },
   "327": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Spinda"
+    "name": "Spinda",
+    "generation": "3"
   },
   "328": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Trapinch"
+    "name": "Trapinch",
+    "generation": "3"
   },
   "329": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Vibrava"
+    "name": "Vibrava",
+    "generation": "3"
   },
   "330": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Flygon"
+    "name": "Flygon",
+    "generation": "3"
   },
   "331": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cacnea"
+    "name": "Cacnea",
+    "generation": "3"
   },
   "332": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Cacturne"
+    "name": "Cacturne",
+    "generation": "3"
   },
   "333": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swablu"
+    "name": "Swablu",
+    "generation": "3"
   },
   "334": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Altaria"
+    "name": "Altaria",
+    "generation": "3"
   },
   "335": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Zangoose"
+    "name": "Zangoose",
+    "generation": "3"
   },
   "336": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Seviper"
+    "name": "Seviper",
+    "generation": "3"
   },
   "337": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Lunatone"
+    "name": "Lunatone",
+    "generation": "3"
   },
   "338": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Solrock"
+    "name": "Solrock",
+    "generation": "3"
   },
   "339": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Barboach"
+    "name": "Barboach",
+    "generation": "3"
   },
   "340": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Whiscash"
+    "name": "Whiscash",
+    "generation": "3"
   },
   "341": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Corphish"
+    "name": "Corphish",
+    "generation": "3"
   },
   "342": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Crawdaunt"
+    "name": "Crawdaunt",
+    "generation": "3"
   },
   "343": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Baltoy"
+    "name": "Baltoy",
+    "generation": "3"
   },
   "344": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Claydol"
+    "name": "Claydol",
+    "generation": "3"
   },
   "345": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lileep"
+    "name": "Lileep",
+    "generation": "3"
   },
   "346": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cradily"
+    "name": "Cradily",
+    "generation": "3"
   },
   "347": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Anorith"
+    "name": "Anorith",
+    "generation": "3"
   },
   "348": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Armaldo"
+    "name": "Armaldo",
+    "generation": "3"
   },
   "349": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Feebas"
+    "name": "Feebas",
+    "generation": "3"
   },
   "350": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Milotic"
+    "name": "Milotic",
+    "generation": "3"
   },
   "351": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Castform"
+    "name": "Castform",
+    "generation": "3"
   },
   "352": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Kecleon"
+    "name": "Kecleon",
+    "generation": "3"
   },
   "353": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Shuppet"
+    "name": "Shuppet",
+    "generation": "3"
   },
   "354": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Banette"
+    "name": "Banette",
+    "generation": "3"
   },
   "355": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Duskull"
+    "name": "Duskull",
+    "generation": "3"
   },
   "356": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Dusclops"
+    "name": "Dusclops",
+    "generation": "3"
   },
   "357": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Tropius"
+    "name": "Tropius",
+    "generation": "3"
   },
   "358": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Chimecho"
+    "name": "Chimecho",
+    "generation": "3"
   },
   "359": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Absol"
+    "name": "Absol",
+    "generation": "3"
   },
   "360": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Wynaut"
+    "name": "Wynaut",
+    "generation": "3"
   },
   "361": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Snorunt"
+    "name": "Snorunt",
+    "generation": "3"
   },
   "362": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Glalie"
+    "name": "Glalie",
+    "generation": "3"
   },
   "363": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Spheal"
+    "name": "Spheal",
+    "generation": "3"
   },
   "364": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Sealeo"
+    "name": "Sealeo",
+    "generation": "3"
   },
   "365": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Walrein"
+    "name": "Walrein",
+    "generation": "3"
   },
   "366": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Clamperl"
+    "name": "Clamperl",
+    "generation": "3"
   },
   "367": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Huntail"
+    "name": "Huntail",
+    "generation": "3"
   },
   "368": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Gorebyss"
+    "name": "Gorebyss",
+    "generation": "3"
   },
   "369": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Relicanth"
+    "name": "Relicanth",
+    "generation": "3"
   },
   "370": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Luvdisc"
+    "name": "Luvdisc",
+    "generation": "3"
   },
   "371": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Bagon"
+    "name": "Bagon",
+    "generation": "3"
   },
   "372": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Shelgon"
+    "name": "Shelgon",
+    "generation": "3"
   },
   "373": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Salamence"
+    "name": "Salamence",
+    "generation": "3"
   },
   "374": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Beldum"
+    "name": "Beldum",
+    "generation": "3"
   },
   "375": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Metang"
+    "name": "Metang",
+    "generation": "3"
   },
   "376": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Metagross"
+    "name": "Metagross",
+    "generation": "3"
   },
   "377": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Regirock"
+    "name": "Regirock",
+    "generation": "3"
   },
   "378": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Regice"
+    "name": "Regice",
+    "generation": "3"
   },
   "379": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Registeel"
+    "name": "Registeel",
+    "generation": "3"
   },
   "380": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Latias"
+    "name": "Latias",
+    "generation": "3"
   },
   "381": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Latios"
+    "name": "Latios",
+    "generation": "3"
   },
   "382": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Kyogre"
+    "name": "Kyogre",
+    "generation": "3"
   },
   "383": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Groudon"
+    "name": "Groudon",
+    "generation": "3"
   },
   "384": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Rayquaza"
+    "name": "Rayquaza",
+    "generation": "3"
   },
   "385": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Jirachi"
+    "name": "Jirachi",
+    "generation": "3"
   },
   "386": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Deoxys"
+    "name": "Deoxys",
+    "generation": "3"
   },
   "387": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Turtwig"
+    "name": "Turtwig",
+    "generation": "4"
   },
   "388": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Grotle"
+    "name": "Grotle",
+    "generation": "4"
   },
   "389": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Torterra"
+    "name": "Torterra",
+    "generation": "4"
   },
   "390": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Chimchar"
+    "name": "Chimchar",
+    "generation": "4"
   },
   "391": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Monferno"
+    "name": "Monferno",
+    "generation": "4"
   },
   "392": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Infernape"
+    "name": "Infernape",
+    "generation": "4"
   },
   "393": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Piplup"
+    "name": "Piplup",
+    "generation": "4"
   },
   "394": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Prinplup"
+    "name": "Prinplup",
+    "generation": "4"
   },
   "395": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Empoleon"
+    "name": "Empoleon",
+    "generation": "4"
   },
   "396": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Starly"
+    "name": "Starly",
+    "generation": "4"
   },
   "397": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Staravia"
+    "name": "Staravia",
+    "generation": "4"
   },
   "398": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Staraptor"
+    "name": "Staraptor",
+    "generation": "4"
   },
   "399": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Bidoof"
+    "name": "Bidoof",
+    "generation": "4"
   },
   "400": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Bibarel"
+    "name": "Bibarel",
+    "generation": "4"
   },
   "401": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Kricketot"
+    "name": "Kricketot",
+    "generation": "4"
   },
   "402": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Kricketune"
+    "name": "Kricketune",
+    "generation": "4"
   },
   "403": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Shinx"
+    "name": "Shinx",
+    "generation": "4"
   },
   "404": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Luxio"
+    "name": "Luxio",
+    "generation": "4"
   },
   "405": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Luxray"
+    "name": "Luxray",
+    "generation": "4"
   },
   "406": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Budew"
+    "name": "Budew",
+    "generation": "4"
   },
   "407": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Roserade"
+    "name": "Roserade",
+    "generation": "4"
   },
   "408": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Cranidos"
+    "name": "Cranidos",
+    "generation": "4"
   },
   "409": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rampardos"
+    "name": "Rampardos",
+    "generation": "4"
   },
   "410": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Shieldon"
+    "name": "Shieldon",
+    "generation": "4"
   },
   "411": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Bastiodon"
+    "name": "Bastiodon",
+    "generation": "4"
   },
   "412": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Burmy"
+    "name": "Burmy",
+    "generation": "4"
   },
   "414": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mothim"
+    "name": "Mothim",
+    "generation": "4"
   },
   "415": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Combee"
+    "name": "Combee",
+    "generation": "4"
   },
   "416": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Vespiquen"
+    "name": "Vespiquen",
+    "generation": "4"
   },
   "417": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Pachirisu"
+    "name": "Pachirisu",
+    "generation": "4"
   },
   "418": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Buizel"
+    "name": "Buizel",
+    "generation": "4"
   },
   "419": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Floatzel"
+    "name": "Floatzel",
+    "generation": "4"
   },
   "420": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cherubi"
+    "name": "Cherubi",
+    "generation": "4"
   },
   "421": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Cherrim"
+    "name": "Cherrim",
+    "generation": "4"
   },
   "422": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Shellos"
+    "name": "Shellos",
+    "generation": "4"
   },
   "423": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Gastrodon"
+    "name": "Gastrodon",
+    "generation": "4"
   },
   "424": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Ambipom"
+    "name": "Ambipom",
+    "generation": "4"
   },
   "425": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Drifloon"
+    "name": "Drifloon",
+    "generation": "4"
   },
   "426": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Drifblim"
+    "name": "Drifblim",
+    "generation": "4"
   },
   "427": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Buneary"
+    "name": "Buneary",
+    "generation": "4"
   },
   "428": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lopunny"
+    "name": "Lopunny",
+    "generation": "4"
   },
   "429": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Mismagius"
+    "name": "Mismagius",
+    "generation": "4"
   },
   "430": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Honchkrow"
+    "name": "Honchkrow",
+    "generation": "4"
   },
   "431": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Glameow"
+    "name": "Glameow",
+    "generation": "4"
   },
   "432": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Purugly"
+    "name": "Purugly",
+    "generation": "4"
   },
   "433": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Chingling"
+    "name": "Chingling",
+    "generation": "4"
   },
   "434": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Stunky"
+    "name": "Stunky",
+    "generation": "4"
   },
   "435": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Skuntank"
+    "name": "Skuntank",
+    "generation": "4"
   },
   "436": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Bronzor"
+    "name": "Bronzor",
+    "generation": "4"
   },
   "437": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Bronzong"
+    "name": "Bronzong",
+    "generation": "4"
   },
   "438": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Bonsly"
+    "name": "Bonsly",
+    "generation": "4"
   },
   "439": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mime Jr."
+    "name": "Mime Jr.",
+    "generation": "4"
   },
   "440": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Happiny"
+    "name": "Happiny",
+    "generation": "4"
   },
   "441": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Chatot"
+    "name": "Chatot",
+    "generation": "4"
   },
   "442": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Spiritomb"
+    "name": "Spiritomb",
+    "generation": "4"
   },
   "443": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Gible"
+    "name": "Gible",
+    "generation": "4"
   },
   "444": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Gabite"
+    "name": "Gabite",
+    "generation": "4"
   },
   "445": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Garchomp"
+    "name": "Garchomp",
+    "generation": "4"
   },
   "446": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Munchlax"
+    "name": "Munchlax",
+    "generation": "4"
   },
   "447": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Riolu"
+    "name": "Riolu",
+    "generation": "4"
   },
   "448": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Lucario"
+    "name": "Lucario",
+    "generation": "4"
   },
   "449": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Hippopotas"
+    "name": "Hippopotas",
+    "generation": "4"
   },
   "450": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Hippowdon"
+    "name": "Hippowdon",
+    "generation": "4"
   },
   "451": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Skorupi"
+    "name": "Skorupi",
+    "generation": "4"
   },
   "452": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Drapion"
+    "name": "Drapion",
+    "generation": "4"
   },
   "453": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Croagunk"
+    "name": "Croagunk",
+    "generation": "4"
   },
   "454": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Toxicroak"
+    "name": "Toxicroak",
+    "generation": "4"
   },
   "455": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Carnivine"
+    "name": "Carnivine",
+    "generation": "4"
   },
   "456": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Finneon"
+    "name": "Finneon",
+    "generation": "4"
   },
   "457": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Lumineon"
+    "name": "Lumineon",
+    "generation": "4"
   },
   "458": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mantyke"
+    "name": "Mantyke",
+    "generation": "4"
   },
   "459": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Snover"
+    "name": "Snover",
+    "generation": "4"
   },
   "460": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Abomasnow"
+    "name": "Abomasnow",
+    "generation": "4"
   },
   "461": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Weavile"
+    "name": "Weavile",
+    "generation": "4"
   },
   "462": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Magnezone"
+    "name": "Magnezone",
+    "generation": "4"
   },
   "463": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lickilicky"
+    "name": "Lickilicky",
+    "generation": "4"
   },
   "464": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rhyperior"
+    "name": "Rhyperior",
+    "generation": "4"
   },
   "465": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Tangrowth"
+    "name": "Tangrowth",
+    "generation": "4"
   },
   "466": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Electivire"
+    "name": "Electivire",
+    "generation": "4"
   },
   "467": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Magmortar"
+    "name": "Magmortar",
+    "generation": "4"
   },
   "468": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Togekiss"
+    "name": "Togekiss",
+    "generation": "4"
   },
   "469": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Yanmega"
+    "name": "Yanmega",
+    "generation": "4"
   },
   "470": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Leafeon"
+    "name": "Leafeon",
+    "generation": "4"
   },
   "471": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Glaceon"
+    "name": "Glaceon",
+    "generation": "4"
   },
   "472": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Gliscor"
+    "name": "Gliscor",
+    "generation": "4"
   },
   "473": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Mamoswine"
+    "name": "Mamoswine",
+    "generation": "4"
   },
   "474": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Porygon-Z"
+    "name": "Porygon-Z",
+    "generation": "4"
   },
   "475": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Gallade"
+    "name": "Gallade",
+    "generation": "4"
   },
   "476": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Probopass"
+    "name": "Probopass",
+    "generation": "4"
   },
   "477": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Dusknoir"
+    "name": "Dusknoir",
+    "generation": "4"
   },
   "478": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Froslass"
+    "name": "Froslass",
+    "generation": "4"
   },
   "479": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Rotom"
+    "name": "Rotom",
+    "generation": "4"
   },
   "480": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Uxie"
+    "name": "Uxie",
+    "generation": "4"
   },
   "481": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Mesprit"
+    "name": "Mesprit",
+    "generation": "4"
   },
   "482": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Azelf"
+    "name": "Azelf",
+    "generation": "4"
   },
   "483": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dialga"
+    "name": "Dialga",
+    "generation": "4"
   },
   "484": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Palkia"
+    "name": "Palkia",
+    "generation": "4"
   },
   "485": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Heatran"
+    "name": "Heatran",
+    "generation": "4"
   },
   "486": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Regigigas"
+    "name": "Regigigas",
+    "generation": "4"
   },
   "488": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Cresselia"
+    "name": "Cresselia",
+    "generation": "4"
   },
   "489": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Phione"
+    "name": "Phione",
+    "generation": "4"
   },
   "490": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Manaphy"
+    "name": "Manaphy",
+    "generation": "4"
   },
   "491": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Darkrai"
+    "name": "Darkrai",
+    "generation": "4"
   },
   "493": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Arceus"
+    "name": "Arceus",
+    "generation": "4"
   },
   "494": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Victini"
+    "name": "Victini",
+    "generation": "5"
   },
   "495": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Snivy"
+    "name": "Snivy",
+    "generation": "5"
   },
   "496": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Servine"
+    "name": "Servine",
+    "generation": "5"
   },
   "497": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Serperior"
+    "name": "Serperior",
+    "generation": "5"
   },
   "498": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Tepig"
+    "name": "Tepig",
+    "generation": "5"
   },
   "499": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Pignite"
+    "name": "Pignite",
+    "generation": "5"
   },
   "500": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Emboar"
+    "name": "Emboar",
+    "generation": "5"
   },
   "501": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Oshawott"
+    "name": "Oshawott",
+    "generation": "5"
   },
   "502": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Dewott"
+    "name": "Dewott",
+    "generation": "5"
   },
   "503": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Samurott"
+    "name": "Samurott",
+    "generation": "5"
   },
   "504": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Patrat"
+    "name": "Patrat",
+    "generation": "5"
   },
   "505": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Watchog"
+    "name": "Watchog",
+    "generation": "5"
   },
   "506": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Lillipup"
+    "name": "Lillipup",
+    "generation": "5"
   },
   "507": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Herdier"
+    "name": "Herdier",
+    "generation": "5"
   },
   "508": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Stoutland"
+    "name": "Stoutland",
+    "generation": "5"
   },
   "509": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Purrloin"
+    "name": "Purrloin",
+    "generation": "5"
   },
   "510": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Liepard"
+    "name": "Liepard",
+    "generation": "5"
   },
   "511": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Pansage"
+    "name": "Pansage",
+    "generation": "5"
   },
   "512": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Simisage"
+    "name": "Simisage",
+    "generation": "5"
   },
   "513": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Pansear"
+    "name": "Pansear",
+    "generation": "5"
   },
   "514": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Simisear"
+    "name": "Simisear",
+    "generation": "5"
   },
   "515": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Panpour"
+    "name": "Panpour",
+    "generation": "5"
   },
   "516": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Simipour"
+    "name": "Simipour",
+    "generation": "5"
   },
   "517": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Munna"
+    "name": "Munna",
+    "generation": "5"
   },
   "518": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Musharna"
+    "name": "Musharna",
+    "generation": "5"
   },
   "519": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pidove"
+    "name": "Pidove",
+    "generation": "5"
   },
   "520": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Tranquill"
+    "name": "Tranquill",
+    "generation": "5"
   },
   "521": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Unfezant"
+    "name": "Unfezant",
+    "generation": "5"
   },
   "522": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Blitzle"
+    "name": "Blitzle",
+    "generation": "5"
   },
   "523": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Zebstrika"
+    "name": "Zebstrika",
+    "generation": "5"
   },
   "524": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Roggenrola"
+    "name": "Roggenrola",
+    "generation": "5"
   },
   "525": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Boldore"
+    "name": "Boldore",
+    "generation": "5"
   },
   "526": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Gigalith"
+    "name": "Gigalith",
+    "generation": "5"
   },
   "527": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Woobat"
+    "name": "Woobat",
+    "generation": "5"
   },
   "528": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swoobat"
+    "name": "Swoobat",
+    "generation": "5"
   },
   "529": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Drilbur"
+    "name": "Drilbur",
+    "generation": "5"
   },
   "530": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Excadrill"
+    "name": "Excadrill",
+    "generation": "5"
   },
   "531": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Audino"
+    "name": "Audino",
+    "generation": "5"
   },
   "532": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Timburr"
+    "name": "Timburr",
+    "generation": "5"
   },
   "533": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Gurdurr"
+    "name": "Gurdurr",
+    "generation": "5"
   },
   "534": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Conkeldurr"
+    "name": "Conkeldurr",
+    "generation": "5"
   },
   "535": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Tympole"
+    "name": "Tympole",
+    "generation": "5"
   },
   "536": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Palpitoad"
+    "name": "Palpitoad",
+    "generation": "5"
   },
   "537": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Seismitoad"
+    "name": "Seismitoad",
+    "generation": "5"
   },
   "538": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Throh"
+    "name": "Throh",
+    "generation": "5"
   },
   "539": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Sawk"
+    "name": "Sawk",
+    "generation": "5"
   },
   "540": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sewaddle"
+    "name": "Sewaddle",
+    "generation": "5"
   },
   "541": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Swadloon"
+    "name": "Swadloon",
+    "generation": "5"
   },
   "542": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Leavanny"
+    "name": "Leavanny",
+    "generation": "5"
   },
   "543": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Venipede"
+    "name": "Venipede",
+    "generation": "5"
   },
   "544": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Whirlipede"
+    "name": "Whirlipede",
+    "generation": "5"
   },
   "545": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Scolipede"
+    "name": "Scolipede",
+    "generation": "5"
   },
   "546": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Cottonee"
+    "name": "Cottonee",
+    "generation": "5"
   },
   "547": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Whimsicott"
+    "name": "Whimsicott",
+    "generation": "5"
   },
   "548": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Petilil"
+    "name": "Petilil",
+    "generation": "5"
   },
   "549": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lilligant"
+    "name": "Lilligant",
+    "generation": "5"
   },
   "550": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Basculin"
+    "name": "Basculin",
+    "generation": "5"
   },
   "551": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Sandile"
+    "name": "Sandile",
+    "generation": "5"
   },
   "552": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Krokorok"
+    "name": "Krokorok",
+    "generation": "5"
   },
   "553": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Krookodile"
+    "name": "Krookodile",
+    "generation": "5"
   },
   "554": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Darumaka"
+    "name": "Darumaka",
+    "generation": "5"
   },
   "555": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Darmanitan"
+    "name": "Darmanitan",
+    "generation": "5"
   },
   "556": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Maractus"
+    "name": "Maractus",
+    "generation": "5"
   },
   "557": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Dwebble"
+    "name": "Dwebble",
+    "generation": "5"
   },
   "558": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Crustle"
+    "name": "Crustle",
+    "generation": "5"
   },
   "559": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Scraggy"
+    "name": "Scraggy",
+    "generation": "5"
   },
   "560": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Scrafty"
+    "name": "Scrafty",
+    "generation": "5"
   },
   "561": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Sigilyph"
+    "name": "Sigilyph",
+    "generation": "5"
   },
   "562": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Yamask"
+    "name": "Yamask",
+    "generation": "5"
   },
   "563": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Cohagrigus"
+    "name": "Cohagrigus",
+    "generation": "5"
   },
   "564": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Tirtouga"
+    "name": "Tirtouga",
+    "generation": "5"
   },
   "565": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Carracosta"
+    "name": "Carracosta",
+    "generation": "5"
   },
   "566": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Archen"
+    "name": "Archen",
+    "generation": "5"
   },
   "567": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Archeops"
+    "name": "Archeops",
+    "generation": "5"
   },
   "568": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Trubbish"
+    "name": "Trubbish",
+    "generation": "5"
   },
   "569": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Garbodor"
+    "name": "Garbodor",
+    "generation": "5"
   },
   "570": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Zorua"
+    "name": "Zorua",
+    "generation": "5"
   },
   "571": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Zoroark"
+    "name": "Zoroark",
+    "generation": "5"
   },
   "572": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Minccino"
+    "name": "Minccino",
+    "generation": "5"
   },
   "573": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Cinccino"
+    "name": "Cinccino",
+    "generation": "5"
   },
   "574": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Gothita"
+    "name": "Gothita",
+    "generation": "5"
   },
   "575": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Gothorita"
+    "name": "Gothorita",
+    "generation": "5"
   },
   "576": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Gothitelle"
+    "name": "Gothitelle",
+    "generation": "5"
   },
   "577": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Solosis"
+    "name": "Solosis",
+    "generation": "5"
   },
   "578": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Duosion"
+    "name": "Duosion",
+    "generation": "5"
   },
   "579": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Reuniclus"
+    "name": "Reuniclus",
+    "generation": "5"
   },
   "580": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Ducklett"
+    "name": "Ducklett",
+    "generation": "5"
   },
   "581": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Swanna"
+    "name": "Swanna",
+    "generation": "5"
   },
   "582": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Vanillite"
+    "name": "Vanillite",
+    "generation": "5"
   },
   "583": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Vanillish"
+    "name": "Vanillish",
+    "generation": "5"
   },
   "584": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Vanilluxe"
+    "name": "Vanilluxe",
+    "generation": "5"
   },
   "585": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Deerling"
+    "name": "Deerling",
+    "generation": "5"
   },
   "586": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Sawsbuck"
+    "name": "Sawsbuck",
+    "generation": "5"
   },
   "587": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Emolga"
+    "name": "Emolga",
+    "generation": "5"
   },
   "588": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Karrablast"
+    "name": "Karrablast",
+    "generation": "5"
   },
   "589": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Escavalier"
+    "name": "Escavalier",
+    "generation": "5"
   },
   "590": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Foongus"
+    "name": "Foongus",
+    "generation": "5"
   },
   "591": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Amoonguss"
+    "name": "Amoonguss",
+    "generation": "5"
   },
   "592": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Frillish"
+    "name": "Frillish",
+    "generation": "5"
   },
   "593": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Jellicent"
+    "name": "Jellicent",
+    "generation": "5"
   },
   "594": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Alomomola"
+    "name": "Alomomola",
+    "generation": "5"
   },
   "595": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Joltik"
+    "name": "Joltik",
+    "generation": "5"
   },
   "596": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Galvantula"
+    "name": "Galvantula",
+    "generation": "5"
   },
   "597": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Ferroseed"
+    "name": "Ferroseed",
+    "generation": "5"
   },
   "598": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Ferrothorn"
+    "name": "Ferrothorn",
+    "generation": "5"
   },
   "599": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Klink"
+    "name": "Klink",
+    "generation": "5"
   },
   "600": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Klang"
+    "name": "Klang",
+    "generation": "5"
   },
   "601": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Klinklang"
+    "name": "Klinklang",
+    "generation": "5"
   },
   "602": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Tynamo"
+    "name": "Tynamo",
+    "generation": "5"
   },
   "603": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Eelektrik"
+    "name": "Eelektrik",
+    "generation": "5"
   },
   "604": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Eelektross"
+    "name": "Eelektross",
+    "generation": "5"
   },
   "605": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Elgyem"
+    "name": "Elgyem",
+    "generation": "5"
   },
   "606": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Beheeyem"
+    "name": "Beheeyem",
+    "generation": "5"
   },
   "607": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Litwick"
+    "name": "Litwick",
+    "generation": "5"
   },
   "608": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Lampent"
+    "name": "Lampent",
+    "generation": "5"
   },
   "609": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Chandelure"
+    "name": "Chandelure",
+    "generation": "5"
   },
   "610": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Axew"
+    "name": "Axew",
+    "generation": "5"
   },
   "611": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Fraxure"
+    "name": "Fraxure",
+    "generation": "5"
   },
   "612": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Haxorus"
+    "name": "Haxorus",
+    "generation": "5"
   },
   "613": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Cubchoo"
+    "name": "Cubchoo",
+    "generation": "5"
   },
   "614": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Beartic"
+    "name": "Beartic",
+    "generation": "5"
   },
   "615": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Cryogonal"
+    "name": "Cryogonal",
+    "generation": "5"
   },
   "616": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Shelmet"
+    "name": "Shelmet",
+    "generation": "5"
   },
   "617": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Accelgor"
+    "name": "Accelgor",
+    "generation": "5"
   },
   "618": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Stunfisk"
+    "name": "Stunfisk",
+    "generation": "5"
   },
   "619": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Mienfoo"
+    "name": "Mienfoo",
+    "generation": "5"
   },
   "620": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Mienshao"
+    "name": "Mienshao",
+    "generation": "5"
   },
   "621": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Druddigon"
+    "name": "Druddigon",
+    "generation": "5"
   },
   "622": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Golett"
+    "name": "Golett",
+    "generation": "5"
   },
   "623": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Golurk"
+    "name": "Golurk",
+    "generation": "5"
   },
   "624": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Pawniard"
+    "name": "Pawniard",
+    "generation": "5"
   },
   "625": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Bisharp"
+    "name": "Bisharp",
+    "generation": "5"
   },
   "626": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Bouffalant"
+    "name": "Bouffalant",
+    "generation": "5"
   },
   "627": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Rufflet"
+    "name": "Rufflet",
+    "generation": "5"
   },
   "628": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Braviary"
+    "name": "Braviary",
+    "generation": "5"
   },
   "629": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Vullaby"
+    "name": "Vullaby",
+    "generation": "5"
   },
   "630": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Mandibuzz"
+    "name": "Mandibuzz",
+    "generation": "5"
   },
   "631": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Heatmor"
+    "name": "Heatmor",
+    "generation": "5"
   },
   "632": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Durant"
+    "name": "Durant",
+    "generation": "5"
   },
   "633": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Deino"
+    "name": "Deino",
+    "generation": "5"
   },
   "634": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Zweilous"
+    "name": "Zweilous",
+    "generation": "5"
   },
   "635": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Hydreigon"
+    "name": "Hydreigon",
+    "generation": "5"
   },
   "636": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Larvesta"
+    "name": "Larvesta",
+    "generation": "5"
   },
   "637": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Volcarona"
+    "name": "Volcarona",
+    "generation": "5"
   },
   "638": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Cobalion"
+    "name": "Cobalion",
+    "generation": "5"
   },
   "639": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Terrakion"
+    "name": "Terrakion",
+    "generation": "5"
   },
   "640": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Virizion"
+    "name": "Virizion",
+    "generation": "5"
   },
   "643": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Reshiram"
+    "name": "Reshiram",
+    "generation": "5"
   },
   "644": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Zekrom"
+    "name": "Zekrom",
+    "generation": "5"
   },
   "646": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Kyurem"
+    "name": "Kyurem",
+    "generation": "5"
   },
   "647": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Keldeo"
+    "name": "Keldeo",
+    "generation": "5"
   },
   "649": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Genesect"
+    "name": "Genesect",
+    "generation": "5"
   },
   "650": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Chespin"
+    "name": "Chespin",
+    "generation": "6"
   },
   "651": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Quilladin"
+    "name": "Quilladin",
+    "generation": "6"
   },
   "652": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Chesnaught"
+    "name": "Chesnaught",
+    "generation": "6"
   },
   "653": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Fennekin"
+    "name": "Fennekin",
+    "generation": "6"
   },
   "654": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Braixen"
+    "name": "Braixen",
+    "generation": "6"
   },
   "655": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Delphox"
+    "name": "Delphox",
+    "generation": "6"
   },
   "656": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Froakie"
+    "name": "Froakie",
+    "generation": "6"
   },
   "657": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Frogadier"
+    "name": "Frogadier",
+    "generation": "6"
   },
   "658": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Greninja"
+    "name": "Greninja",
+    "generation": "6"
   },
   "659": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Bunnelby"
+    "name": "Bunnelby",
+    "generation": "6"
   },
   "660": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Diggersby"
+    "name": "Diggersby",
+    "generation": "6"
   },
   "661": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Fletchling"
+    "name": "Fletchling",
+    "generation": "6"
   },
   "662": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Fletchinder"
+    "name": "Fletchinder",
+    "generation": "6"
   },
   "663": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Talonflame"
+    "name": "Talonflame",
+    "generation": "6"
   },
   "664": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Scatterbug"
+    "name": "Scatterbug",
+    "generation": "6"
   },
   "665": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Spewpa"
+    "name": "Spewpa",
+    "generation": "6"
   },
   "666": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Vivillon"
+    "name": "Vivillon",
+    "generation": "6"
   },
   "667": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Litleo"
+    "name": "Litleo",
+    "generation": "6"
   },
   "668": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Pyroar"
+    "name": "Pyroar",
+    "generation": "6"
   },
   "669": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Flabébé"
+    "name": "Flabébé",
+    "generation": "6"
   },
   "670": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Floette"
+    "name": "Floette",
+    "generation": "6"
   },
   "671": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Florges"
+    "name": "Florges",
+    "generation": "6"
   },
   "672": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Skiddo"
+    "name": "Skiddo",
+    "generation": "6"
   },
   "673": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Gogoat"
+    "name": "Gogoat",
+    "generation": "6"
   },
   "674": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Pancham"
+    "name": "Pancham",
+    "generation": "6"
   },
   "675": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Pangoro"
+    "name": "Pangoro",
+    "generation": "6"
   },
   "676": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Furfrou"
+    "name": "Furfrou",
+    "generation": "6"
   },
   "677": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Espurr"
+    "name": "Espurr",
+    "generation": "6"
   },
   "678": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Meowstic"
+    "name": "Meowstic",
+    "generation": "6"
   },
   "679": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Honedge"
+    "name": "Honedge",
+    "generation": "6"
   },
   "680": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Doublade"
+    "name": "Doublade",
+    "generation": "6"
   },
   "682": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Spritzee"
+    "name": "Spritzee",
+    "generation": "6"
   },
   "683": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Aromatisse"
+    "name": "Aromatisse",
+    "generation": "6"
   },
   "684": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Swirlix"
+    "name": "Swirlix",
+    "generation": "6"
   },
   "685": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Slurpuff"
+    "name": "Slurpuff",
+    "generation": "6"
   },
   "686": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Inkay"
+    "name": "Inkay",
+    "generation": "6"
   },
   "687": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Malamar"
+    "name": "Malamar",
+    "generation": "6"
   },
   "688": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Binacle"
+    "name": "Binacle",
+    "generation": "6"
   },
   "689": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Barbaracle"
+    "name": "Barbaracle",
+    "generation": "6"
   },
   "690": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Skrelp"
+    "name": "Skrelp",
+    "generation": "6"
   },
   "691": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Dragalge"
+    "name": "Dragalge",
+    "generation": "6"
   },
   "692": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Clauncher"
+    "name": "Clauncher",
+    "generation": "6"
   },
   "693": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Clawitzer"
+    "name": "Clawitzer",
+    "generation": "6"
   },
   "694": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Helioptile"
+    "name": "Helioptile",
+    "generation": "6"
   },
   "695": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Heliolisk"
+    "name": "Heliolisk",
+    "generation": "6"
   },
   "696": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Tyrunt"
+    "name": "Tyrunt",
+    "generation": "6"
   },
   "697": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Tyrantrum"
+    "name": "Tyrantrum",
+    "generation": "6"
   },
   "698": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Amaura"
+    "name": "Amaura",
+    "generation": "6"
   },
   "699": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Aurorus"
+    "name": "Aurorus",
+    "generation": "6"
   },
   "700": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Sylveon"
+    "name": "Sylveon",
+    "generation": "6"
   },
   "701": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Hawlucha"
+    "name": "Hawlucha",
+    "generation": "6"
   },
   "702": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Dedenne"
+    "name": "Dedenne",
+    "generation": "6"
   },
   "703": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Carbink"
+    "name": "Carbink",
+    "generation": "6"
   },
   "704": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Goomy"
+    "name": "Goomy",
+    "generation": "6"
   },
   "705": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Sliggoo"
+    "name": "Sliggoo",
+    "generation": "6"
   },
   "706": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Goodra"
+    "name": "Goodra",
+    "generation": "6"
   },
   "707": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Klefki"
+    "name": "Klefki",
+    "generation": "6"
   },
   "708": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Phantump"
+    "name": "Phantump",
+    "generation": "6"
   },
   "709": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Trevenant"
+    "name": "Trevenant",
+    "generation": "6"
   },
   "710": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Pumpkaboo"
+    "name": "Pumpkaboo",
+    "generation": "6"
   },
   "711": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Gourgeist"
+    "name": "Gourgeist",
+    "generation": "6"
   },
   "712": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Bergmite"
+    "name": "Bergmite",
+    "generation": "6"
   },
   "713": {
     "types": [
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Avalugg"
+    "name": "Avalugg",
+    "generation": "6"
   },
   "714": {
     "types": [
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Noibat"
+    "name": "Noibat",
+    "generation": "6"
   },
   "715": {
     "types": [
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Noivern"
+    "name": "Noivern",
+    "generation": "6"
   },
   "716": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Xerneas"
+    "name": "Xerneas",
+    "generation": "6"
   },
   "717": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Yveltal"
+    "name": "Yveltal",
+    "generation": "6"
   },
   "718": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Zygarde"
+    "name": "Zygarde",
+    "generation": "6"
   },
   "719": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Diancie"
+    "name": "Diancie",
+    "generation": "6"
   },
   "721": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Volcanion"
+    "name": "Volcanion",
+    "generation": "6"
   },
   "722": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Rowlet"
+    "name": "Rowlet",
+    "generation": "7"
   },
   "723": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Dartrix"
+    "name": "Dartrix",
+    "generation": "7"
   },
   "724": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Decidueye"
+    "name": "Decidueye",
+    "generation": "7"
   },
   "725": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Litten"
+    "name": "Litten",
+    "generation": "7"
   },
   "726": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Torracat"
+    "name": "Torracat",
+    "generation": "7"
   },
   "727": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       }
     ],
-    "name": "Incineroar"
+    "name": "Incineroar",
+    "generation": "7"
   },
   "728": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Popplio"
+    "name": "Popplio",
+    "generation": "7"
   },
   "729": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Brionne"
+    "name": "Brionne",
+    "generation": "7"
   },
   "730": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Primarina"
+    "name": "Primarina",
+    "generation": "7"
   },
   "731": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Pikipek"
+    "name": "Pikipek",
+    "generation": "7"
   },
   "732": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Trumbeak"
+    "name": "Trumbeak",
+    "generation": "7"
   },
   "733": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Toucannon"
+    "name": "Toucannon",
+    "generation": "7"
   },
   "734": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Yungoos"
+    "name": "Yungoos",
+    "generation": "7"
   },
   "735": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Gumshoos"
+    "name": "Gumshoos",
+    "generation": "7"
   },
   "736": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Grubbin"
+    "name": "Grubbin",
+    "generation": "7"
   },
   "737": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Charjabug"
+    "name": "Charjabug",
+    "generation": "7"
   },
   "738": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Vikavolt"
+    "name": "Vikavolt",
+    "generation": "7"
   },
   "739": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Crabrawler"
+    "name": "Crabrawler",
+    "generation": "7"
   },
   "740": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Ice",
-      "color": "#98d8d8"
+        "type": "Ice",
+        "color": "#98d8d8"
       }
     ],
-    "name": "Crabominable"
+    "name": "Crabominable",
+    "generation": "7"
   },
   "741": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Oricorio"
+    "name": "Oricorio",
+    "generation": "7"
   },
   "742": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Cutiefly"
+    "name": "Cutiefly",
+    "generation": "7"
   },
   "743": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Ribombee"
+    "name": "Ribombee",
+    "generation": "7"
   },
   "744": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Rockruff"
+    "name": "Rockruff",
+    "generation": "7"
   },
   "745": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       }
     ],
-    "name": "Lycanroc"
+    "name": "Lycanroc",
+    "generation": "7"
   },
   "746": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wishiwashi"
+    "name": "Wishiwashi",
+    "generation": "7"
   },
   "747": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Mareanie"
+    "name": "Mareanie",
+    "generation": "7"
   },
   "748": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Toxapex"
+    "name": "Toxapex",
+    "generation": "7"
   },
   "749": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Mudbray"
+    "name": "Mudbray",
+    "generation": "7"
   },
   "750": {
     "types": [
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Mudsdale"
+    "name": "Mudsdale",
+    "generation": "7"
   },
   "751": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Dewpider"
+    "name": "Dewpider",
+    "generation": "7"
   },
   "752": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       }
     ],
-    "name": "Araquanid"
+    "name": "Araquanid",
+    "generation": "7"
   },
   "753": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Fomantis"
+    "name": "Fomantis",
+    "generation": "7"
   },
   "754": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Lurantis"
+    "name": "Lurantis",
+    "generation": "7"
   },
   "755": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Morelull"
+    "name": "Morelull",
+    "generation": "7"
   },
   "756": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Shiinotic"
+    "name": "Shiinotic",
+    "generation": "7"
   },
   "757": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Salandit"
+    "name": "Salandit",
+    "generation": "7"
   },
   "758": {
     "types": [
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       },
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       }
     ],
-    "name": "Salazzle"
+    "name": "Salazzle",
+    "generation": "7"
   },
   "759": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Stufful"
+    "name": "Stufful",
+    "generation": "7"
   },
   "760": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Bewear"
+    "name": "Bewear",
+    "generation": "7"
   },
   "761": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Bounsweet"
+    "name": "Bounsweet",
+    "generation": "7"
   },
   "762": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Steenee"
+    "name": "Steenee",
+    "generation": "7"
   },
   "763": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Tsareena"
+    "name": "Tsareena",
+    "generation": "7"
   },
   "764": {
     "types": [
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Comfey"
+    "name": "Comfey",
+    "generation": "7"
   },
   "765": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Oranguru"
+    "name": "Oranguru",
+    "generation": "7"
   },
   "766": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Passimian"
+    "name": "Passimian",
+    "generation": "7"
   },
   "767": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Wimpod"
+    "name": "Wimpod",
+    "generation": "7"
   },
   "768": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Golisopod"
+    "name": "Golisopod",
+    "generation": "7"
   },
   "769": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Sandygast"
+    "name": "Sandygast",
+    "generation": "7"
   },
   "770": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Ground",
-      "color": "#e0c068"
+        "type": "Ground",
+        "color": "#e0c068"
       }
     ],
-    "name": "Palossand"
+    "name": "Palossand",
+    "generation": "7"
   },
   "771": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       }
     ],
-    "name": "Pyukumuku"
+    "name": "Pyukumuku",
+    "generation": "7"
   },
   "772": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Type: Null"
+    "name": "Type: Null",
+    "generation": "7"
   },
   "773": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Silvally"
+    "name": "Silvally",
+    "generation": "7"
   },
   "774": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Minior (Core)"
+    "name": "Minior (Core)",
+    "generation": "7"
   },
   "775": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       }
     ],
-    "name": "Komala"
+    "name": "Komala",
+    "generation": "7"
   },
   "776": {
     "types": [
       {
-      "type": "Fire",
-      "color": "#f08030"
+        "type": "Fire",
+        "color": "#f08030"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Turtonator"
+    "name": "Turtonator",
+    "generation": "7"
   },
   "777": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Togedemaru"
+    "name": "Togedemaru",
+    "generation": "7"
   },
   "778": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Mimikyu"
+    "name": "Mimikyu",
+    "generation": "7"
   },
   "779": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Bruxish"
+    "name": "Bruxish",
+    "generation": "7"
   },
   "780": {
     "types": [
       {
-      "type": "Normal",
-      "color": "#8a8a59"
+        "type": "Normal",
+        "color": "#8a8a59"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Drampa"
+    "name": "Drampa",
+    "generation": "7"
   },
   "781": {
     "types": [
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       },
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       }
     ],
-    "name": "Dhelmise"
+    "name": "Dhelmise",
+    "generation": "7"
   },
   "782": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Jangmo-o"
+    "name": "Jangmo-o",
+    "generation": "7"
   },
   "783": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Hakamo-o"
+    "name": "Hakamo-o",
+    "generation": "7"
   },
   "784": {
     "types": [
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Kommo-o"
+    "name": "Kommo-o",
+    "generation": "7"
   },
   "785": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Tapu Koko"
+    "name": "Tapu Koko",
+    "generation": "7"
   },
   "786": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Tapu Lele"
+    "name": "Tapu Lele",
+    "generation": "7"
   },
   "787": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Tapu Bulu"
+    "name": "Tapu Bulu",
+    "generation": "7"
   },
   "788": {
     "types": [
       {
-      "type": "Water",
-      "color": "#6890f0"
+        "type": "Water",
+        "color": "#6890f0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Tapu Fini"
+    "name": "Tapu Fini",
+    "generation": "7"
   },
   "789": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Cosmog"
+    "name": "Cosmog",
+    "generation": "7"
   },
   "790": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Cosmoem"
+    "name": "Cosmoem",
+    "generation": "7"
   },
   "791": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Solgaleo"
+    "name": "Solgaleo",
+    "generation": "7"
   },
   "792": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Lunala"
+    "name": "Lunala",
+    "generation": "7"
   },
   "793": {
     "types": [
       {
-      "type": "Rock",
-      "color": "#b8a038"
+        "type": "Rock",
+        "color": "#b8a038"
       },
       {
-      "type": "Poison",
-      "color": "#a040a0"
+        "type": "Poison",
+        "color": "#a040a0"
       }
     ],
-    "name": "Nihilego"
+    "name": "Nihilego",
+    "generation": "7"
   },
   "794": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Buzzwole"
+    "name": "Buzzwole",
+    "generation": "7"
   },
   "795": {
     "types": [
       {
-      "type": "Bug",
-      "color": "#a8b820"
+        "type": "Bug",
+        "color": "#a8b820"
       },
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       }
     ],
-    "name": "Pheromosa"
+    "name": "Pheromosa",
+    "generation": "7"
   },
   "796": {
     "types": [
       {
-      "type": "Electric",
-      "color": "#f8d030"
+        "type": "Electric",
+        "color": "#f8d030"
       }
     ],
-    "name": "Xurkitree"
+    "name": "Xurkitree",
+    "generation": "7"
   },
   "797": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Flying",
-      "color": "#a890f0"
+        "type": "Flying",
+        "color": "#a890f0"
       }
     ],
-    "name": "Celesteela"
+    "name": "Celesteela",
+    "generation": "7"
   },
   "798": {
     "types": [
       {
-      "type": "Grass",
-      "color": "#78c850"
+        "type": "Grass",
+        "color": "#78c850"
       },
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       }
     ],
-    "name": "Kartana"
+    "name": "Kartana",
+    "generation": "7"
   },
   "799": {
     "types": [
       {
-      "type": "Dark",
-      "color": "#707070"
+        "type": "Dark",
+        "color": "#707070"
       },
       {
-      "type": "Dragon",
-      "color": "#7038f8"
+        "type": "Dragon",
+        "color": "#7038f8"
       }
     ],
-    "name": "Guzzlord"
+    "name": "Guzzlord",
+    "generation": "7"
   },
   "800": {
     "types": [
       {
-      "type": "Psychic",
-      "color": "#f85888"
+        "type": "Psychic",
+        "color": "#f85888"
       }
     ],
-    "name": "Necrozma"
+    "name": "Necrozma",
+    "generation": "7"
   },
   "801": {
     "types": [
       {
-      "type": "Steel",
-      "color": "#b8b8d0"
+        "type": "Steel",
+        "color": "#b8b8d0"
       },
       {
-      "type": "Fairy",
-      "color": "#e898e8"
+        "type": "Fairy",
+        "color": "#e898e8"
       }
     ],
-    "name": "Magearna"
+    "name": "Magearna",
+    "generation": "7"
   },
   "802": {
     "types": [
       {
-      "type": "Fighting",
-      "color": "#c03028"
+        "type": "Fighting",
+        "color": "#c03028"
       },
       {
-      "type": "Ghost",
-      "color": "#705898"
+        "type": "Ghost",
+        "color": "#705898"
       }
     ],
-    "name": "Marshadow"
+    "name": "Marshadow",
+    "generation": "7"
   }
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -533,6 +533,7 @@ function pokemonLabel(item) {
     const pokemonRarity = getPokemonRarity(item['pokemon_id'])
 
     var name = item['pokemon_name']
+    var generation = item['pokemon_gen']
     var rarityDisplay = pokemonRarity ? '(' + pokemonRarity + ')' : ''
     var types = item['pokemon_types']
     var typesDisplay = ''
@@ -584,7 +585,7 @@ function pokemonLabel(item) {
             <div class='pokemon container content-left'>
               <div>
                 <img class='pokemon sprite' src='static/icons/${id}.png'>
-                <span class='pokemon'>Level: </span><span class='pokemon'>${pokemonLevel}</span>
+                <span class='pokemon'>Gen: </span><span class='pokemon'>${generation}</span><br>
                 <span class='pokemon links exclude'><a href='javascript:excludePokemon(${id})'>Exclude</a></span>
                 <span class='pokemon links notify'><a href='javascript:notifyAboutPokemon(${id})'>Notify</a></span>
                 <span class='pokemon links remove'><a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a></span>
@@ -596,7 +597,10 @@ function pokemonLabel(item) {
                 <span class='label-countdown' disappears-at='${disappearTime}'>00m00s</span> left (${moment(disappearTime).format('HH:mm')})
               </div>
               <div class='pokemon'>
-                CP: <span class='pokemon encounter'>${cp}/${iv.toFixed(1)}%</span> (A${atk}/D${def}/S${sta})
+                CP: <span class='pokemon encounter'>${cp} | IV: ${iv.toFixed(1)}%</span> (A${atk}/D${def}/S${sta})
+              </div>
+              <div class='pokemon'>
+                Level: <span class='pokemon'>${pokemonLevel}</span>
               </div>
               <div class='pokemon'>
                 Moveset: <span class='pokemon encounter'>${pMove1}/${pMove2}</span>
@@ -616,7 +620,7 @@ function pokemonLabel(item) {
         <div class='pokemon container content-left'>
           <div>
             <img class='pokemon sprite' src='static/icons/${id}.png'>
-            <span class='pokemon'>Level: </span><span class='pokemon no-encounter'>n/a</span>
+            <span class='pokemon'>Gen: </span><span class='pokemon'>${generation}</span><br>
             <span class='pokemon links exclude'><a href='javascript:excludePokemon(${id})'>Exclude</a></span>
             <span class='pokemon links notify'><a href='javascript:notifyAboutPokemon(${id})'>Notify</a></span>
             <span class='pokemon links remove'><a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a></span>
@@ -629,6 +633,9 @@ function pokemonLabel(item) {
           </div>
           <div class='pokemon'>
             CP: <span class='pokemon no-encounter'>No information</span>
+          </div>
+          <div class='pokemon'>
+            Level: <span class='pokemon no-encounter'>No information</span>
           </div>
           <div class='pokemon'>
             Moveset: <span class='pokemon no-encounter'>No information</span>

--- a/static/sass/layout/_pokemon.scss
+++ b/static/sass/layout/_pokemon.scss
@@ -84,7 +84,7 @@
       content: '\f018';
       display: inline-block;
       font-family: FontAwesome;
-      margin: 6px 3px 0px 0px;
+      margin: 1px 3px 0px 0px;
       height: 16px;
       width: 16px;
       -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This adds generation info to RM and adds a small label to the pokemon label window

## Motivation and Context
This PR is a precursor to things like "exclude by gen" and "generation % on stats page"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![gitgen](https://user-images.githubusercontent.com/8204684/35700728-b609e2b8-078b-11e8-95a1-9915a182ff77.PNG)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
