### PR TITLE
add new spawn group to fix issue #2470

### DIFF
--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1115,7 +1115,7 @@ function getPokemonRarity(pokemonId) {
         return pokemonRarities[pokemonId]
     }
 
-    return ''
+    return 'New Spawn'
 }
 
 function getGoogleSprite(index, sprite, displayHeight) {
@@ -1155,6 +1155,7 @@ function setupPokemonMarkerDetails(item, map, scaleByRarity = true, isNotifyPkmn
 
     if (scaleByRarity) {
         const rarityValues = {
+            'new spawn': 40,
             'very rare': 30,
             'ultra rare': 40,
             'legendary': 50

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2765,7 +2765,7 @@ $(function () {
         })
         $selectRarityNotify.select2({
             placeholder: i8ln('Select Rarity'),
-            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare')],
+            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare'), i8ln('New Spawn')]
             templateResult: formatState
         })
 


### PR DESCRIPTION
There is a current issue of a brand new pokemon spawn and it will not be set a rarity until the dynamic rarity filer is updated. 

We could set all new pokemon to ultra rare but for people who dont update rarity often this would mean things as common as pidgey would stay ultra rare until rarity file is next updated.

This way sets all new pokemon as a "New Spawn" and once the rarity file is updated it will be sorted properly. I added "New Spawn" to notify by rarity on the side bar and also included it in scale by rarity.

This will fix [Issue #2470](https://github.com/RocketMap/RocketMap/issues/2470)

## How Has This Been Tested?
Tested on a live map and simulated new spawns to test it

![image](https://user-images.githubusercontent.com/8204684/36032915-619950de-0da7-11e8-91a6-36ac3df103f3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
