### PR TITLE
add castform Form to pokemon label

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -77,6 +77,12 @@ const cryFileTypes = ['wav', 'mp3']
 
 const genderType = ['♂', '♀', '⚲']
 const unownForm = ['unset', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '!', '?']
+const castFormForm = {
+    '29': 'Normal',
+    '30': 'Sunny',
+    '31': 'Rainy',
+    '32': 'Snowy'
+}
 const pokemonWithImages = [
     2, 3, 5, 6, 8, 9, 11, 28, 31, 34, 38, 59, 62, 65, 68, 71, 73, 76, 82, 89, 91, 94, 103, 105, 110, 112, 123, 125, 126, 129, 131, 134, 135, 136, 137, 139, 143, 144, 145, 146, 150, 153, 156, 159, 243, 244, 245, 248, 249, 250, 302, 303, 306, 320, 359, 382, 383, 384
 ]
@@ -565,6 +571,8 @@ function pokemonLabel(item) {
 
     if (id === 201 && form !== null && form > 0) {
         formString += `(${unownForm[item['form']]})`
+    } else if (id === 351 && form !== null && form > 0) {
+        formString += `(${castFormForm[item['form']]})`
     }
 
     contentstring += `


### PR DESCRIPTION
Simply adds castform Form to the pokemon label 

## Motivation and Context
There is an extra bit to add where it replaces the icon to the correct form but due to not having any default icon for forms I left it for a later PR along with unknown and others

## How Has This Been Tested?
ran for over 24 hours does what it says on the tin.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/8204684/36067557-3169b438-0eb7-11e8-90d4-aa6ca6148ddc.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
