### PR TITLE
Ability to make missed_count optional

### DIFF
--- a/docs/first-run/blinding.md
+++ b/docs/first-run/blinding.md
@@ -32,7 +32,8 @@ On high lvl accounts you can identify blinded accounts when the encounter fails 
 
 ### Spawnpoint Fix
 
-If your accounts are blinded and it starts disabling spawnpoints because it considers them "missed too often", you can run this query safely to re-enable those spawnpoints:
+If your accounts are blinded and it starts disabling spawnpoints because it considers them "missed too often", you can disable missed count by launching with `-mc 0` or `missed-count: 0` in your config.  
+To re-enable deactivated spawnpoints, you can safely run this query:
 ```sql
 UPDATE spawnpoint SET missed_count = 0;
 ```

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -42,7 +42,7 @@
                     [-vci VERSION_CHECK_INTERVAL] [-odt ON_DEMAND_TIMEOUT]
                     [--disable-blacklist] [-tp TRUSTED_PROXIES]
                     [--api-version API_VERSION] [--no-file-logs]
-                    [--log-path LOG_PATH] [--dump] [-exg]
+                    [--log-path LOG_PATH] [--dump] [-exg] [-mc MISSED_COUNT]
                     [-v | --verbosity VERBOSE] [-Rh RARITY_HOURS]
                     [-Rf RARITY_UPDATE_FREQUENCY]
 
@@ -396,13 +396,17 @@ environment variables which override config file values which override defaults.
       --dump                Dump censored debug info about the environment and
                             auto-upload to hastebin.com. [env var: POGOMAP_DUMP]
       -exg, --ex-gyms       Fetch OSM parks within geofence and flag gyms that are
-                            candidates for ex raids. Only required once per area.
+                            candidates for EX raids. Only required once per area.
                             [env var: POGOMAP_EX_GYMS]
+      -mc MISSED_COUNT, --missed-count MISSED_COUNT
+                            Amount of times spawnpoint is missed before before
+                            it's disabled (Default: 5). 0 to disable. [env var:
+                            POGOMAP_MISSED_COUNT]
       -v                    Show debug messages from RocketMap and pgoapi. Can be
                             repeated up to 3 times.
       --verbosity VERBOSE   Show debug messages from RocketMap and pgoapi. [env
                             var: POGOMAP_VERBOSITY]
-
+    
     Database:
       --db-name DB_NAME     Name of the database to be used. [env var:
                             POGOMAP_DB_NAME]
@@ -414,7 +418,7 @@ environment variables which override config file values which override defaults.
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
                             behind. [env var: POGOMAP_DB_THREADS]
-
+    
     Dynamic Rarity:
       -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
                             Number of hours of Pokemon data to use to calculate

--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -406,7 +406,7 @@ environment variables which override config file values which override defaults.
                             repeated up to 3 times.
       --verbosity VERBOSE   Show debug messages from RocketMap and pgoapi. [env
                             var: POGOMAP_VERBOSITY]
-    
+
     Database:
       --db-name DB_NAME     Name of the database to be used. [env var:
                             POGOMAP_DB_NAME]
@@ -418,7 +418,7 @@ environment variables which override config file values which override defaults.
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
                             behind. [env var: POGOMAP_DB_THREADS]
-    
+
     Dynamic Rarity:
       -Rh RARITY_HOURS, --rarity-hours RARITY_HOURS
                             Number of hours of Pokemon data to use to calculate

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1332,7 +1332,7 @@ class SpawnPoint(LatLongModel):
 
         for sp in linked_spawn_points:
 
-            if sp['missed_count'] > args.missed_count and args.missed_count:
+            if args.missed_count and sp['missed_count'] > args.missed_count:
                 continue
 
             endpoints = SpawnPoint.start_end(sp, scan_delay)
@@ -2277,7 +2277,7 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
     # Look for spawnpoints within scan_loc that are not here to see if we
     # can narrow down tth window.
     for sp in ScannedLocation.linked_spawn_points(scan_location['cellid']):
-        if sp['missed_count'] > args.missed_count and args.missed_count:
+        if args.missed_count and sp['missed_count'] > args.missed_count:
                 continue
 
         if sp['id'] in sp_id_list:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1332,7 +1332,7 @@ class SpawnPoint(LatLongModel):
 
         for sp in linked_spawn_points:
 
-            if sp['missed_count'] > 5:
+            if sp['missed_count'] > args.missed_count and args.missed_count:
                 continue
 
             endpoints = SpawnPoint.start_end(sp, scan_delay)
@@ -2277,7 +2277,7 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
     # Look for spawnpoints within scan_loc that are not here to see if we
     # can narrow down tth window.
     for sp in ScannedLocation.linked_spawn_points(scan_location['cellid']):
-        if sp['missed_count'] > 5:
+        if sp['missed_count'] > args.missed_count and args.missed_count:
                 continue
 
         if sp['id'] in sp_id_list:
@@ -2293,11 +2293,15 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                 spawn_points[sp['id']] = sp
             endpoints = SpawnPoint.start_end(sp, args.spawn_delay)
             if clock_between(endpoints[0], now_secs, endpoints[1]):
-                sp['missed_count'] += 1
                 spawn_points[sp['id']] = sp
-                log.warning('%s kind spawnpoint %s has no Pokemon %d times'
-                            ' in a row.',
-                            sp['kind'], sp['id'], sp['missed_count'])
+                if args.missed_count:
+                    sp['missed_count'] += 1
+                    log.warning('%s kind spawnpoint %s has no Pokemon %d times'
+                                ' in a row.',
+                                sp['kind'], sp['id'], sp['missed_count'])
+                else:
+                    log.warning('%s kind spawnpoint %s has no Pokemon',
+                                sp['kind'], sp['id'])
                 log.info('Possible causes: Still doing initial scan, super'
                          ' rare double spawnpoint during')
                 log.info('hidden period, or Niantic has removed '

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -768,8 +768,8 @@ class SpeedScan(HexSearch):
                 spawnpoints = SpawnPoint.select_in_hex_by_cellids(
                     self.scans.keys(), self.location_change_date)
                 for sp in spawnpoints:
-                    if (sp['missed_count'] > self.args.missed_count and
-                            self.args.missed_count):
+                    if (self.args.missed_count and
+                                sp['missed_count'] > self.args.missed_count):
                         continue
                     self.active_sp += 1
                     self.tth_found += (sp['earliest_unseen'] ==

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -768,7 +768,8 @@ class SpeedScan(HexSearch):
                 spawnpoints = SpawnPoint.select_in_hex_by_cellids(
                     self.scans.keys(), self.location_change_date)
                 for sp in spawnpoints:
-                    if sp['missed_count'] > 5:
+                    if (sp['missed_count'] > self.args.missed_count and
+                            self.args.missed_count):
                         continue
                     self.active_sp += 1
                     self.tth_found += (sp['earliest_unseen'] ==

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -769,8 +769,8 @@ class SpeedScan(HexSearch):
                     self.scans.keys(), self.location_change_date)
                 for sp in spawnpoints:
                     if (self.args.missed_count and
-                                sp['missed_count'] > self.args.missed_count):
-                        continue
+                            sp['missed_count'] > self.args.missed_count):
+                                continue
                     self.active_sp += 1
                     self.tth_found += (sp['earliest_unseen'] ==
                                        sp['latest_seen'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -502,8 +502,8 @@ def get_args():
                               'Only required once per area.'),
                         action='store_true', default=False)
     parser.add_argument('-mc', '--missed-count',
-                        help=('Amount of times spawnpoint is missed before ' +
-                              'before it\'s disabled (Default: 5). ' +
+                        help=('Number of times that a spawnpoint can be' +
+                              'missed before it gets disabled. (Default: 5).' +
                               '0 to disable.'),
                         type=int, default=5)
     verbose = parser.add_mutually_exclusive_group()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -502,7 +502,7 @@ def get_args():
                               'Only required once per area.'),
                         action='store_true', default=False)
     parser.add_argument('-mc', '--missed-count',
-                        help=('Number of times that a spawnpoint can be' +
+                        help=('Number of times that a spawnpoint can be ' +
                               'missed before it gets disabled. (Default: 5).' +
                               '0 to disable.'),
                         type=int, default=5)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -501,6 +501,11 @@ def get_args():
                               'gyms that are candidates for EX raids. ' +
                               'Only required once per area.'),
                         action='store_true', default=False)
+    parser.add_argument('-mc', '--missed-count',
+                        help=('Amount of times spawnpoint is missed before ' +
+                              'before it\'s disabled (Default: 5). ' +
+                              '0 to disable.'),
+                        type=int, default=5)
     verbose = parser.add_mutually_exclusive_group()
     verbose.add_argument('-v',
                          help=('Show debug messages from RocketMap ' +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR gives the ability to set a custom missed_count for a spawnpoint to be disabled.
Alternatively disable it entirely with `-mc 0` | `--missed-count 0`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When changing accounts after blinding, some spawnpoints have been missed over 5 times. 
Some regularly run sql to set missed_count to 0.
Doing less repedetive tasks helps with quality of life. with this pr, spawnpoint disabling can be disabled. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1 worker in Helsinki now, presumably results after blinded. 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
