### PR TITLE
Updating Webhook Field for Boosted Weather

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2072,7 +2072,8 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                         'seconds_until_despawn': seconds_until_despawn,
                         'spawn_start': start_end[0],
                         'spawn_end': start_end[1],
-                        'player_level': encounter_level
+                        'player_level': encounter_level,
+                        'boosted_weather': boosted
                     })
                     if wh_poke['cp_multiplier'] is not None:
                         wh_poke.update({


### PR DESCRIPTION
## Description
Re-present the webhook field for `weather_boosted_condition` as `boosted_weather` 

## Motivation and Context
PokeAlarm was updated in 3.6 to accept the boosted weather condition via webhooks using the `boosted_weather` field name.  This was to conform with multiple scanners who were already presenting this information in this way.  This PR simply conforms RM to also send this data in this manner, while also allowing it to be sent as `webhook_boosted_condition` to match the official field name. 

## How Has This Been Tested?
This was tested locally on a dev instance. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
