### PR TITLE
Only spin stops with levelup script

### DIFF
--- a/tools/levelup.py
+++ b/tools/levelup.py
@@ -45,7 +45,8 @@ def get_location_forts(api, account, location):
     cells = response['responses']['GET_MAP_OBJECTS'].map_cells
     forts = []
     for i, cell in enumerate(cells):
-        forts += cell.forts
+        if fort.type == 1:
+            forts += cell.forts
     if not forts:
         return (ErrorType.no_stops, None)
     return (None, forts)

--- a/tools/levelup.py
+++ b/tools/levelup.py
@@ -45,8 +45,10 @@ def get_location_forts(api, account, location):
     cells = response['responses']['GET_MAP_OBJECTS'].map_cells
     forts = []
     for i, cell in enumerate(cells):
-        if fort.type == 1:
-            forts += cell.forts
+        for fort in cell.forts:
+            # Only use stops.
+            if fort.type == 1:
+                forts += cell.forts
     if not forts:
         return (ErrorType.no_stops, None)
     return (None, forts)

--- a/tools/levelup.py
+++ b/tools/levelup.py
@@ -48,7 +48,7 @@ def get_location_forts(api, account, location):
         for fort in cell.forts:
             # Only use stops.
             if fort.type == 1:
-                forts += cell.forts
+                forts.append(fort)
     if not forts:
         return (ErrorType.no_stops, None)
     return (None, forts)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Filter forts to only spin stops

## Motivation and Context
Levelup as pointed by @fosJoddie was spinning both stops and gyms but it was using the stops method to spin gyms (calling a get_fort_info) that is not correct and never intended, we should filter to only spin stops.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested I don't have map or key anymore.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
