### PR TITLE
Exit script if no cells are in the geofenced area.

### DIFF
--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -49,6 +49,8 @@ import logging
 import math
 import time
 import sys
+import os
+
 from timeit import default_timer
 from threading import Lock
 from copy import deepcopy
@@ -57,6 +59,7 @@ from collections import Counter
 from queue import Empty
 from operator import itemgetter
 from datetime import datetime, timedelta
+
 from .transform import get_new_coords
 from .models import (hex_bounds, SpawnPoint, ScannedLocation,
                      ScanSpawnPoint, HashKeys)
@@ -278,7 +281,7 @@ class HexSearch(BaseScheduler):
             if not results:
                 log.error('No cells regarded as valid for desired scan area. '
                           'Check your provided geofences. Aborting.')
-                sys.exit()
+                os._exit(1)
 
         # Add the required appear and disappear times.
         locationsZeroed = []
@@ -401,7 +404,7 @@ class SpawnScan(BaseScheduler):
             if not self.locations:
                 log.error('No cells regarded as valid for desired scan area. '
                           'Check your provided geofences. Aborting.')
-                sys.exit()
+                os._exit(1)
 
         # Well shit...
         if not self.locations:
@@ -613,7 +616,7 @@ class SpeedScan(HexSearch):
             if not results:
                 log.error('No cells regarded as valid for desired scan area. '
                           'Check your provided geofences. Aborting.')
-                sys.exit()
+                os._exit(1)
 
         generated_locations = []
         for step, location in enumerate(results):


### PR DESCRIPTION
## Description
Force exits the script when no cells are in the geofenced area.

## Motivation and Context
`sys.exit()` only exits the Thread it's running in, not the entire script.

People in #help got confused that "RM got stuck":
```
2018-03-06 02:56:40,035 [  account-recycler][        search][    INFO] Account recycler running. Checking status of 0 accounts.
2018-03-06 02:57:40,040 [  account-recycler][        search][    INFO] Account recycler running. Checking status of 0 accounts.
2018-03-06 02:58:40,040 [  account-recycler][        search][    INFO] Account recycler running. Checking status of 0 accounts.
2018-03-06 02:59:40,043 [  account-recycler][        search][    INFO] Account recycler running. Checking status of 0 accounts.
```

Note: `os._exit()` doesn't wait until all `finally` clauses are executed, but until we rewrite the thread handling, this behavior is similar to the old (intended) one except that it actually exits the script. At these points the scanning hasn't started yet, so no negative consequences.

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
