### PR TITLE
Fix typo in -DCf docs.

### DIFF
--- a/docs/first-run/commandline.md
+++ b/docs/first-run/commandline.md
@@ -430,7 +430,7 @@ environment variables which override config file values which override defaults.
                             valid scan. Default: 720, 0 to disable.
                             [env var: POGOMAP_DB_CLEANUP_SPAWNPOINT]
       -DCf DB_CLEANUP_FORTS, --db-cleanup-forts DB_CLEANUP_FORTS
-                            Clear gyms and pokestops from database X days after
+                            Clear gyms and pokestops from database X hours after
                             last valid scan. Default: 0, 0 to disable.
                             [env var: POGOMAP_DB_CLEANUP_FORTS]
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -411,8 +411,8 @@ def get_args():
                              'Default: 720, 0 to disable.'),
                        type=int, default=720)
     group.add_argument('-DCf', '--db-cleanup-forts',
-                       help=('Clear gyms and pokestops from database X days ' +
-                             'after last valid scan. ' +
+                       help=('Clear gyms and pokestops from database X hours '
+                             'after last valid scan. '
                              'Default: 0, 0 to disable.'),
                        type=int, default=0)
     parser.add_argument(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is a small typo in the command line documentation file. Yesterday I woke up to a map without gyms and pokestops and found out that `-DCf X` clears gyms and stops after X hours instead of X days. :)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Documentation is wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
not

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
