### PR TITLE
Update pgoapi: Pin protobuf to 3.5.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/pogodevorg/pgoapi.git@3b8c0953de33b727a205ec89879b8c74aebf9b1e#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git@8d18543279676302601eba9b1c120d5ab0108dfc#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
## Description
Pin protobuf to 3.5.1.

```
pip uninstall pgoapi
pip uninstall protobuf
pip install -r requirements.txt
```

## Motivation and Context
https://github.com/pogodevorg/pgoapi/pull/224

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
