### PR TITLE
Allow custom hashing service + higher key values.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -3328,7 +3328,7 @@ def database_migrate(db, old_ver):
             # drop trainer from gympokemon
             migrator.drop_column('gympokemon', 'trainer_name')
         )
-    
+
     if old_ver < 30:
         db.execute_sql(
             'ALTER TABLE `hashkeys` '

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -40,7 +40,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 29
+db_schema_version = 30
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -1788,9 +1788,9 @@ class Token(BaseModel):
 
 class HashKeys(BaseModel):
     key = Utf8mb4CharField(primary_key=True, max_length=20)
-    maximum = SmallIntegerField(default=0)
-    remaining = SmallIntegerField(default=0)
-    peak = SmallIntegerField(default=0)
+    maximum = IntegerField(default=0)
+    remaining = IntegerField(default=0)
+    peak = IntegerField(default=0)
     expires = DateTimeField(null=True)
     last_updated = DateTimeField(default=datetime.utcnow)
 
@@ -3327,6 +3327,14 @@ def database_migrate(db, old_ver):
         migrate(
             # drop trainer from gympokemon
             migrator.drop_column('gympokemon', 'trainer_name')
+        )
+    
+    if old_ver < 30:
+        db.execute_sql(
+            'ALTER TABLE `hashkeys` '
+            'MODIFY COLUMN `maximum` INTEGER,'
+            'MODIFY COLUMN `remaining` INTEGER,'
+            'MODIFY COLUMN `peak` INTEGER;'
         )
 
     # Always log that we're done.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -486,8 +486,9 @@ def get_args():
     parser.add_argument('-hk', '--hash-key', default=None, action='append',
                         help='Key for hash server.')
     parser.add_argument('-hs', '--hash-service', default='bossland', type=str,
-                        help=('Hash service name. Supports BossLand and'
-                              ' devkat hashing.'))
+                        help=('Hash service name. Supports bossland and'
+                              ' devkat hashing.'),
+                        choices=['bossland', 'devkat'])
     parser.add_argument('-novc', '--no-version-check', action='store_true',
                         help='Disable API version check.',
                         default=False)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -484,7 +484,10 @@ def get_args():
                         help=('Enable status page database update using ' +
                               'STATUS_NAME as main worker name.'))
     parser.add_argument('-hk', '--hash-key', default=None, action='append',
-                        help='Key for hash server')
+                        help='Key for hash server.')
+    parser.add_argument('-hs', '--hash-service', default='bossland', type=str,
+                        help=('Hash service name. Supports BossLand and'
+                              ' devkat hashing.'))
     parser.add_argument('-novc', '--no-version-check', action='store_true',
                         help='Disable API version check.',
                         default=False)

--- a/runserver.py
+++ b/runserver.py
@@ -288,9 +288,10 @@ def main():
         'devkat': 'https://hashing.devkat.org'
     }
 
-    endpoint = legal_endpoints.get(args.hash_service, False)
+    hash_service = args.hash_service.lower()
+    endpoint = legal_endpoints.get(hash_service, False)
     if endpoint:
-        log.info('Using hash service: %s.', args.hash_service)
+        log.info('Using hash service: %s.', hash_service)
         HashServer.endpoint = endpoint
 
     # Make sure they are warned.

--- a/runserver.py
+++ b/runserver.py
@@ -67,6 +67,7 @@ log.addHandler(stderr_hdlr)
 try:
     import pgoapi
     from pgoapi import PGoApi, utilities as util
+    from pgoapi.hash_server import HashServer
 except ImportError:
     log.critical(
         "It seems `pgoapi` is not installed. Try running " +
@@ -281,6 +282,18 @@ def main():
     if not args.no_server and not validate_assets(args):
         sys.exit(1)
 
+    # Set hashing endpoint. 'bossland' doesn't need to be added here, it's
+    # the default in the API.
+    legal_endpoints = {
+        'devkat': 'https://hashing.devkat.org'
+    }
+
+    endpoint = legal_endpoints.get(args.hash_service, False)
+    if endpoint:
+        log.info('Using hash service: %s.', args.hash_service)
+        HashServer.endpoint = endpoint
+
+    # Make sure they are warned.
     if args.no_version_check and not args.only_server:
         log.warning('You are running RocketMap in No Version Check mode. '
                     "If you don't know what you're doing, this mode "


### PR DESCRIPTION
## Description
* Allow legal (in terms of law) hashing API service alternatives.
* Allow higher HashKey values. RocketMap currently assumes the values always mean RPM, and SmallInteger limits it to only 32767.

## Motivation and Context
Allow for devkat hashing.

## How Has This Been Tested?
Untested.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
