### PR TITLE
Support -hs in level-up tool.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -25,6 +25,8 @@ from pprint import pformat
 from time import strftime
 from timeit import default_timer
 
+from pgoapi.hash_server import HashServer
+
 log = logging.getLogger(__name__)
 
 
@@ -847,6 +849,19 @@ def get_args():
 
     args.locales_dir = 'static/dist/locales'
     args.data_dir = 'static/dist/data'
+
+    # Set hashing endpoint. 'bossland' doesn't need to be added here, it's
+    # the default in the API.
+    legal_endpoints = {
+        'devkat': 'https://hashing.devkat.org'
+    }
+
+    hash_service = args.hash_service.lower()
+    endpoint = legal_endpoints.get(hash_service, False)
+    if endpoint:
+        log.info('Using hash service: %s.', hash_service)
+        HashServer.endpoint = endpoint
+
     return args
 
 

--- a/runserver.py
+++ b/runserver.py
@@ -67,7 +67,6 @@ log.addHandler(stderr_hdlr)
 try:
     import pgoapi
     from pgoapi import PGoApi, utilities as util
-    from pgoapi.hash_server import HashServer
 except ImportError:
     log.critical(
         "It seems `pgoapi` is not installed. Try running " +
@@ -281,18 +280,6 @@ def main():
     # Let's not forget to run Grunt / Only needed when running with webserver.
     if not args.no_server and not validate_assets(args):
         sys.exit(1)
-
-    # Set hashing endpoint. 'bossland' doesn't need to be added here, it's
-    # the default in the API.
-    legal_endpoints = {
-        'devkat': 'https://hashing.devkat.org'
-    }
-
-    hash_service = args.hash_service.lower()
-    endpoint = legal_endpoints.get(hash_service, False)
-    if endpoint:
-        log.info('Using hash service: %s.', hash_service)
-        HashServer.endpoint = endpoint
 
     # Make sure they are warned.
     if args.no_version_check and not args.only_server:


### PR DESCRIPTION
## Description
Moves `-hs` from `runserver.py` to `get_args` in `utils.py`, so any script relying on it will support the different hashing services.

## Motivation and Context
Adds support for `-hs` to the level-up tool.

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
