### PR TITLE
Adds buttons to the menu to export / import the settings

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -153,6 +153,32 @@ function createServiceWorkerReceiver() {
     })
 }
 
+function download(name, settings) {
+    var a = document.createElement('a')
+    a.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(settings))
+    a.setAttribute('download', name + '_' + moment().format('DD-MM-YYYY HH:mm'))
+    a.style.display = 'none'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+}
+function upload(e) {
+    var t = JSON.parse(JSON.parse(e))
+    Object.keys(t).forEach(function (e) {
+        localStorage.setItem(e, t[e])
+    })
+    window.location.reload()
+}
+function openFile(file) {
+    var t = file.target
+    var fr = new FileReader()
+    fr.onload = function () {
+        console.log(fr.result)
+        upload(fr.result)
+    }
+    fr.readAsText(t.files[0])
+}
+
 function initMap() { // eslint-disable-line no-unused-vars
     map = new google.maps.Map(document.getElementById('map'), {
         center: {

--- a/templates/map.html
+++ b/templates/map.html
@@ -461,6 +461,8 @@
           </div>
         </div>
       <div>
+        <center><button class="settings" onclick="download('RocketMap', JSON.stringify(JSON.stringify(localStorage)))"><i class="fa fa-upload fa-fw"></i>Export Settings</button></center>
+        <center><input id="fileInput" type="file" style="display:none;" onchange="openFile(event)"> <button class="settings" onclick="document.getElementById('fileInput').click()"><i class="fa fa-download fa-fw"></i>Import Settings</button></center>
         <center><button class="settings" onclick="confirm('Are you sure you want to reset settings to default values?') ? (localStorage.clear(), window.location.reload()) : false"><i class="fa fa-refresh fa-fw"></i>Reset Settings</button></center>
       </div>
       </nav>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds buttons to the menu to export / import the settings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because the settings are stored in "Local Storage", they can be lost. Not anymore!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I use it on my own server.

## Screenshots (if appropriate):
![export-import](https://user-images.githubusercontent.com/37586747/37683002-6a247eec-2c8b-11e8-8b54-51314b28ad2d.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
