### PR TITLE
Optionally rely on BossLand headers.

### DIFF
--- a/pogom/pgorequestwrapper.py
+++ b/pogom/pgorequestwrapper.py
@@ -55,19 +55,22 @@ class PGoRequestWrapper:
                 log.debug('Sending wrapped API request.')
                 return self.request.call(*args, **kwargs)
             except HashingQuotaExceededException:
+                # Default = sleep for a little bit, then retry.
+                random_sleep_secs = random.uniform(0.75, 1.5)
+                secs_to_sleep = random_sleep_secs
+
                 # Sleep until the RPM reset to free some RPM and don't use
                 # one of our retries, just retry until we have RPM left.
                 # If RPM reset was in the past, we'll still sleep for a
                 # little bit to introduce variation.
-                now = int(time.time())
-                rpm_reset = HashServer.status.get('period', now)
-                secs_till_reset = rpm_reset - now
-                random_sleep_secs = random.uniform(0.75, 1.5)
-                secs_to_sleep = random_sleep_secs
+                if self.args.hash_header_sleep:
+                    now = int(time.time())
+                    rpm_reset = HashServer.status.get('period', now)
+                    secs_till_reset = rpm_reset - now
 
-                # Could be outdated key header, or already passed.
-                if secs_till_reset > 0:
-                    secs_to_sleep = secs_till_reset + random_sleep_secs
+                    # Could be outdated key header, or already passed.
+                    if secs_till_reset > 0:
+                        secs_to_sleep = secs_till_reset + random_sleep_secs
 
                 # Don't be too enthusiastic about sleeping. Failsafe against a
                 # bugged header, timezone problems, ...

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -491,6 +491,11 @@ def get_args():
                         help=('Hash service name. Supports bossland and'
                               ' devkat hashing.'),
                         choices=['bossland', 'devkat'])
+    parser.add_argument('--hash-header-sleep',
+                        help=('Use the BossLand headers to determine how long'
+                              ' a worker should sleep if it exceeds the'
+                              ' hashing quota. Default: False.'),
+                        action='store_true', default=False)
     parser.add_argument('-novc', '--no-version-check', action='store_true',
                         help='Disable API version check.',
                         default=False)


### PR DESCRIPTION
## Description
* Optionally rely on BossLand headers to determine how long a worker should sleep if it exceeds the hashing quota.
* Disabled by default.

## Motivation and Context
devkat patrons have noticed that BossLand headers are unreliable, causing some weird behavior, and not following the exact RPM reset time their headers sends us. This leads to workers sleeping for too long and scans being delayed.

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
