### PR TITLE
Fixed race condition

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -153,7 +153,7 @@ function createServiceWorkerReceiver() {
     })
 }
 
-function initMap() { // eslint-disable-line no-unused-vars
+function _initMap() { // eslint-disable-line
     map = new google.maps.Map(document.getElementById('map'), {
         center: {
             lat: Number(getParameterByName('lat')) || centerLat,
@@ -308,6 +308,12 @@ function initMap() { // eslint-disable-line no-unused-vars
     if (Push._agents.chrome.isSupported()) {
         createServiceWorkerReceiver()
     }
+}
+
+// wrapper function for real initMap (_initMap) to
+// avoid race conditions with custom.js
+function initMap() { // eslint-disable-line no-unused-vars
+    setTimeout(_initMap, 100)
 }
 
 function updateLocationMarker(style) {


### PR DESCRIPTION
Fixed a race condition when loading map for the first time.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Although custom.js is listed above map.js in map.html it's not being executed prior to map.js since the settings inside custom.js are set on page load - which is fine as they depend on Store which is defined in map.js. 
The issue is that the google maps script is also going to be executed on page load (=> `defer` attribute) which results in a race condition between custom.js and google maps script calling `initMap()` and sometimes results in custom settings being ignored and default settings being used.

To reproduce this just disable clustering in custom.js and load the map in a private tab: You'll see that clustering sometimes happens and sometimes it doesn't.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Race conditions should always be addressed and fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
