### PR TITLE
[WIP] Frontend Work for #2528 Sponsor ID Field

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -40,7 +40,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 30
+db_schema_version = 31
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -435,6 +435,7 @@ class Gym(LatLongModel):
     slots_available = SmallIntegerField()
     enabled = BooleanField()
     park = BooleanField(default=False)
+    sponsor = SmallIntegerField(null=True)
     latitude = DoubleField()
     longitude = DoubleField()
     total_cp = SmallIntegerField()
@@ -562,6 +563,7 @@ class Gym(LatLongModel):
                               Gym.slots_available,
                               Gym.latitude,
                               Gym.longitude,
+                              Gym.sponsor,
                               Gym.last_modified,
                               Gym.last_scanned,
                               Gym.total_cp)
@@ -2174,6 +2176,8 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                             f.owned_by_team,
                         'park':
                             park,
+                        'sponsor':
+                            f.sponsor,
                         'guard_pokemon_id':
                             f.guard_pokemon_id,
                         'slots_available':
@@ -2204,6 +2208,8 @@ def parse_map(args, map_dict, scan_coords, scan_location, db_update_queue,
                         f.owned_by_team,
                     'park':
                         park,
+                    'sponsor':
+                        f.sponsor,
                     'guard_pokemon_id':
                         f.guard_pokemon_id,
                     'slots_available':
@@ -3338,6 +3344,13 @@ def database_migrate(db, old_ver):
             'MODIFY COLUMN `maximum` INTEGER,'
             'MODIFY COLUMN `remaining` INTEGER,'
             'MODIFY COLUMN `peak` INTEGER;'
+        )
+
+    if old_ver < 31:
+        migrate(
+            # Add `sponsor` column to `gym`
+            migrator.add_column('gym', 'sponsor',
+                                SmallIntegerField(null=True))
         )
 
     # Always log that we're done.

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -878,8 +878,8 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
-    'showRaidSelector': {
-        default: 0,
+    'showRaidFilter': {
+        default: 1,
         type: StoreTypes.Number
     },
     'showRaidMinLevel': {
@@ -894,8 +894,8 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
-    'showGymSelector': {
-        default: 0,
+    'showGymFilter': {
+        default: 1,
         type: StoreTypes.Number
     },
     'useGymSidebar': {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -879,7 +879,7 @@ var StoreOptions = {
         type: StoreTypes.Boolean
     },
     'showRaidFilter': {
-        default: 1,
+        default: 0,
         type: StoreTypes.Number
     },
     'showRaidMinLevel': {
@@ -895,7 +895,7 @@ var StoreOptions = {
         type: StoreTypes.Boolean
     },
     'showGymFilter': {
-        default: 1,
+        default: 0,
         type: StoreTypes.Number
     },
     'useGymSidebar': {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -878,13 +878,9 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
-    'showParkRaidsOnly': {
-        default: false,
-        type: StoreTypes.Boolean
-    },
-    'showActiveRaidsOnly': {
-        default: false,
-        type: StoreTypes.Boolean
+    'showRaidSelector': {
+        default: 0,
+        type: StoreTypes.Number
     },
     'showRaidMinLevel': {
         default: 1,
@@ -898,15 +894,11 @@ var StoreOptions = {
         default: false,
         type: StoreTypes.Boolean
     },
+    'showGymSelector': {
+        default: 0,
+        type: StoreTypes.Number
+    },
     'useGymSidebar': {
-        default: false,
-        type: StoreTypes.Boolean
-    },
-    'showParkGymsOnly': {
-        default: false,
-        type: StoreTypes.Boolean
-    },
-    'showOpenGymsOnly': {
         default: false,
         type: StoreTypes.Boolean
     },

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -9,8 +9,8 @@ var $textPerfectionNotify
 var $textLevelNotify
 var $selectStyle
 var $selectIconSize
-var $selectGymSelector
-var $selectRaidSelector
+var $selectGymFilter
+var $selectRaidFilter
 var $switchRaidMinLevel
 var $switchRaidMaxLevel
 var $selectTeamGymsOnly
@@ -452,9 +452,9 @@ function initSidebar() {
     $('#gym-sidebar-switch').prop('checked', Store.get('useGymSidebar'))
     $('#gym-sidebar-wrapper').toggle(Store.get('showGyms') || Store.get('showRaids'))
     $('#gyms-filter-wrapper').toggle(Store.get('showGyms'))
-    $('#gym-selector-switch').val(Store.get('showGymSelector'))
+    $('#gym-filter-switch').val(Store.get('showGymFilter'))
     $('#team-gyms-only-switch').val(Store.get('showTeamGymsOnly'))
-    $('#raid-selector-switch').val(Store.get('showRaidSelector'))
+    $('#raid-filter-switch').val(Store.get('showRaidFilter'))
     $('#raid-min-level-only-switch').val(Store.get('showRaidMinLevel'))
     $('#raid-max-level-only-switch').val(Store.get('showRaidMaxLevel'))
     $('#raids-filter-wrapper').toggle(Store.get('showRaids'))
@@ -1203,7 +1203,7 @@ function updateGymMarker(item, marker) {
     let raidLevel = getRaidLevel(item.raid)
     const hasActiveRaid = item.raid && item.raid.end > Date.now()
     const raidLevelVisible = raidLevel >= Store.get('showRaidMinLevel') && raidLevel <= Store.get('showRaidMaxLevel')
-    const showRaidSetting = Store.get('showRaids') && !Store.get('showGymSelector')
+    const showRaidSetting = Store.get('showRaids') && Store.get('showGymFilter')
 
     if (item.raid && isOngoingRaid(item.raid) && Store.get('showRaids') && raidLevelVisible) {
         let markerImage = 'static/images/raid/' + gymTypes[item.team_id] + '_' + item.raid.level + '_unknown.png'
@@ -1801,29 +1801,29 @@ function processGym(i, item) {
         }
     }
 
-    if (Store.get('showGymSelector') === 1) {
+    if (Store.get('showGymFilter') === 1) {
         if (item['gym_id'] in mapData.gyms) {
             return true
         }
-    } else if (Store.get('showGymSelector') === 2) {
+    } else if (Store.get('showGymFilter') === 2) {
 		// showOpenGymsOnly
         if (item.slots_available === 0) {
             removeGymFromMap(item['gym_id'])
             return true
         }
-    } else if (Store.get('showGymSelector') === 3) {
+    } else if (Store.get('showGymFilter') === 3) {
 		// showParkGymsOnly
         if (!item.park) {
             removeGymFromMap(item['gym_id'])
             return true
         }
-    } else if (Store.get('showGymSelector') === 4) {
+    } else if (Store.get('showGymFilter') === 4) {
 		// showSponsorGymsOnly
         if (!item.sponsor) {
             removeGymFromMap(item['gym_id'])
             return true
         }
-    } else if (Store.get('showGymSelector') === 5) {
+    } else if (Store.get('showGymFilter') === 5) {
 		// showExGymsOnly
         if (!(item.sponsor | item.park)) {
             removeGymFromMap(item['gym_id'])
@@ -1837,31 +1837,31 @@ function processGym(i, item) {
             return true
         }
 
-        if (Store.get('showRaidSelector') === 1) {
+        if (Store.get('showRaidFilter') === 1) {
             // showAllRaids
             if (Store.get('showRaids') && !isValidRaid(item.raid)) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
-        } else if (Store.get('showRaidSelector') === 2) {
+        } else if (Store.get('showRaidFilter') === 2) {
             // showActiveRaidsOnly
             if (!isOngoingRaid(item.raid)) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
-        } else if (Store.get('showRaidSelector') === 3) {
+        } else if (Store.get('showRaidFilter') === 3) {
             // showParkRaidsOnly
             if (!item.park) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
-        } else if (Store.get('showRaidSelector') === 4) {
+        } else if (Store.get('showRaidFilter') === 4) {
             // showSponsorRaidsOnly
             if (!item.sponsor) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
-        } else if (Store.get('showRaidSelector') === 5) {
+        } else if (Store.get('showRaidFilter') === 5) {
             // showExRaidsOnly
             if (!(item.sponsor || item.park)) {
                 removeGymFromMap(item['gym_id'])
@@ -2574,15 +2574,15 @@ $(function () {
         markerCluster.repaint()
     })
 
-    $selectRaidSelector = $('#raid-selector-switch')
+    $selectRaidFilter = $('#raid-filter-switch')
 
-    $selectRaidSelector.select2({
+    $selectRaidFilter.select2({
         placeholder: 'Raid Views',
         minimumResultsForSearch: Infinity
     })
 
-    $selectRaidSelector.on('change', function () {
-        Store.set('showRaidSelector', this.value)
+    $selectRaidFilter.on('change', function () {
+        Store.set('showRaidFilter', this.value)
         lastgyms = false
         updateMap()
     })
@@ -2613,15 +2613,15 @@ $(function () {
         updateMap()
     })
 
-    $selectGymSelector = $('#gym-selector-switch')
+    $selectGymFilter = $('#gym-filter-switch')
 
-    $selectGymSelector.select2({
+    $selectGymFilter.select2({
         placeholder: 'Gym Views',
         minimumResultsForSearch: Infinity
     })
 
-    $selectGymSelector.on('change', function () {
-        Store.set('showGymSelector', this.value)
+    $selectGymFilter.on('change', function () {
+        Store.set('showGymFilter', this.value)
         lastgyms = false
         updateMap()
     })
@@ -2971,17 +2971,17 @@ $(function () {
     }
 
     function resetGymFilter() {
-        Store.set('showGymSelector', 0)
+        Store.set('showGymFilter', 0)
         Store.set('showTeamGymsOnly', 0)
         Store.set('minGymLevel', 0)
         Store.set('maxGymLevel', 6)
 
-        $('#gym-selector-switch').val(Store.get('showGymSelector'))
+        $('#gym-filter-switch').val(Store.get('showGymFilter'))
         $('#team-gyms-only-switch').val(Store.get('showTeamGymsOnly'))
         $('#min-level-gyms-filter-switch').val(Store.get('minGymLevel'))
         $('#max-level-gyms-filter-switch').val(Store.get('maxGymLevel'))
 
-        $('#gym-selector-switch').trigger('change')
+        $('#gym-filter-switch').trigger('change')
         $('#min-level-gyms-filter-switch').trigger('change')
         $('#max-level-gyms-filter-switch').trigger('change')
     }
@@ -2993,7 +2993,7 @@ $(function () {
         }
         resetGymFilter()
         var wrapperGyms = $('#gyms-filter-wrapper')
-        var switchRaids = $('#raid-selector-switch')
+        var switchRaids = $('#raid-filter-switch')
         var wrapperSidebar = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false
@@ -3013,7 +3013,7 @@ $(function () {
             'duration': 500
         }
         var wrapperRaids = $('#raids-filter-wrapper')
-        var switchGyms = $('#gym-selector-switch')
+        var switchGyms = $('#gym-filter-switch')
         var wrapperSidebar = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1802,30 +1802,30 @@ function processGym(i, item) {
     }
 
     switch (Store.get('showGymFilter')) {
-        case 1: // ShowAllGyms
+        case 1: // show all gyms
             if (item['gym_id'] in mapData.gyms) {
                 return true
             }
             break
-        case 2: // showOpenGymsOnly
+        case 2: // only show gyms with open slots
             if (item.slots_available === 0) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
             break
-        case 3: // showParkGymsOnly
+        case 3: // only show park gyms
             if (!item.park) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
             break
-        case 4: // showSponsorGymsOnly
+        case 4: // only show sponsored gyms
             if (!item.sponsor) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
             break
-        case 5: // showExGymsOnly
+        case 5: // only show ex-eligible gyms
             if (!(item.sponsor | item.park)) {
                 removeGymFromMap(item['gym_id'])
                 return true
@@ -1839,31 +1839,31 @@ function processGym(i, item) {
         }
 
         switch (Store.get('showRaidFilter')) {
-            case 1: // showAllRaids
+            case 1: // show all raids & eggs
                 if (!isValidRaid(item.raid)) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 2: // showActiveRaidsOnly
+            case 2: // only show active raids
                 if (!isOngoingRaid(item.raid)) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 3: // showParkRaidsOnly
+            case 3: // only only show raids and eggs at park gyms
                 if (!(item.park && isValidRaid(item.raid))) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 4: // showSponsorRaidsOnly
+            case 4: // only show raids and eggs at sponsored gyms
                 if (!(item.sponsor && isValidRaid(item.raid))) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 5: // showExRaidsOnly
+            case 5: // only show raids and eggs at ex-eligible gyms
                 if (!((item.sponsor || item.park) && isValidRaid(item.raid))) {
                     removeGymFromMap(item['gym_id'])
                     return true

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -2993,7 +2993,7 @@ $(function () {
         }
         resetGymFilter()
         var wrapperGyms = $('#gyms-filter-wrapper')
-        var switchRaids = $('#raids-switch')
+        var switchRaids = $('#raid-selector-switch')
         var wrapperSidebar = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false
@@ -3013,7 +3013,7 @@ $(function () {
             'duration': 500
         }
         var wrapperRaids = $('#raids-filter-wrapper')
-        var switchGyms = $('#gyms-switch')
+        var switchGyms = $('#gym-selector-switch')
         var wrapperSidebar = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1803,7 +1803,6 @@ function processGym(i, item) {
 
     if (Store.get('showGymSelector') === 1) {
         if (item['gym_id'] in mapData.gyms) {
-            item.marker = updateGymMarker(item, mapData.gyms[item['gym_id']].marker)
             return true
         }
     } else if (Store.get('showGymSelector') === 2) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1802,30 +1802,30 @@ function processGym(i, item) {
     }
 
     switch (Store.get('showGymFilter')) {
-        case 1: // show all gyms
+        case 0: // show all gyms
             if (item['gym_id'] in mapData.gyms) {
                 return true
             }
             break
-        case 2: // only show gyms with open slots
+        case 1: // only show gyms with open slots
             if (item.slots_available === 0) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
             break
-        case 3: // only show park gyms
+        case 2: // only show park gyms
             if (!item.park) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
             break
-        case 4: // only show sponsored gyms
+        case 3: // only show sponsored gyms
             if (!item.sponsor) {
                 removeGymFromMap(item['gym_id'])
                 return true
             }
             break
-        case 5: // only show ex-eligible gyms
+        case 4: // only show ex-eligible gyms
             if (!(item.sponsor | item.park)) {
                 removeGymFromMap(item['gym_id'])
                 return true
@@ -1839,32 +1839,32 @@ function processGym(i, item) {
         }
 
         switch (Store.get('showRaidFilter')) {
-            case 1: // show all raids & eggs
+            case 0: // show all raids & eggs
                 if (!isValidRaid(item.raid)) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 2: // only show active raids
+            case 1: // only show active raids
                 if (!isOngoingRaid(item.raid)) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 3: // only only show raids and eggs at park gyms
-                if (!(item.park && isValidRaid(item.raid))) {
+            case 2: // only only show raids and eggs at park gyms
+                if (!(isValidRaid(item.raid) && item.park)) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 4: // only show raids and eggs at sponsored gyms
-                if (!(item.sponsor && isValidRaid(item.raid))) {
+            case 3: // only show raids and eggs at sponsored gyms
+                if (!(isValidRaid(item.raid) && item.sponsor)) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
                 break
-            case 5: // only show raids and eggs at ex-eligible gyms
-                if (!((item.sponsor || item.park) && isValidRaid(item.raid))) {
+            case 4: // only show raids and eggs at ex-eligible gyms
+                if (!(isValidRaid(item.raid) && (item.sponsor || item.park))) {
                     removeGymFromMap(item['gym_id'])
                     return true
                 }
@@ -2972,7 +2972,7 @@ $(function () {
     }
 
     function resetGymFilter() {
-        Store.set('showGymFilter', 1)
+        Store.set('showGymFilter', 0)
         Store.set('showTeamGymsOnly', 0)
         Store.set('minGymLevel', 0)
         Store.set('maxGymLevel', 6)
@@ -2994,7 +2994,7 @@ $(function () {
         }
         resetGymFilter()
         var wrapperGyms = $('#gyms-filter-wrapper')
-        var switchRaids = $('#raid-filter-switch')
+        var switchRaids = $('#raids-switch')
         var wrapperSidebar = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false
@@ -3014,7 +3014,7 @@ $(function () {
             'duration': 500
         }
         var wrapperRaids = $('#raids-filter-wrapper')
-        var switchGyms = $('#gym-filter-switch')
+        var switchGyms = $('#gyms-switch')
         var wrapperSidebar = $('#gym-sidebar-wrapper')
         if (this.checked) {
             lastgyms = false

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1801,35 +1801,36 @@ function processGym(i, item) {
         }
     }
 
-    if (Store.get('showGymFilter') === 1) {
-        if (item['gym_id'] in mapData.gyms) {
-            return true
-        }
-    } else if (Store.get('showGymFilter') === 2) {
-		// showOpenGymsOnly
-        if (item.slots_available === 0) {
-            removeGymFromMap(item['gym_id'])
-            return true
-        }
-    } else if (Store.get('showGymFilter') === 3) {
-		// showParkGymsOnly
-        if (!item.park) {
-            removeGymFromMap(item['gym_id'])
-            return true
-        }
-    } else if (Store.get('showGymFilter') === 4) {
-		// showSponsorGymsOnly
-        if (!item.sponsor) {
-            removeGymFromMap(item['gym_id'])
-            return true
-        }
-    } else if (Store.get('showGymFilter') === 5) {
-		// showExGymsOnly
-        if (!(item.sponsor | item.park)) {
-            removeGymFromMap(item['gym_id'])
-            return true
-        }
-    } else { return false }
+    switch (Store.get('showGymFilter')) {
+        case 1: // ShowAllGyms
+            if (item['gym_id'] in mapData.gyms) {
+                return true
+            }
+            break
+        case 2: // showOpenGymsOnly
+            if (item.slots_available === 0) {
+                removeGymFromMap(item['gym_id'])
+                return true
+            }
+            break
+        case 3: // showParkGymsOnly
+            if (!item.park) {
+                removeGymFromMap(item['gym_id'])
+                return true
+            }
+            break
+        case 4: // showSponsorGymsOnly
+            if (!item.sponsor) {
+                removeGymFromMap(item['gym_id'])
+                return true
+            }
+            break
+        case 5: // showExGymsOnly
+            if (!(item.sponsor | item.park)) {
+                removeGymFromMap(item['gym_id'])
+                return true
+            }
+    }
 
     if (!Store.get('showGyms')) {
         if (Store.get('showRaids') && !isValidRaid(item.raid)) {
@@ -1837,37 +1838,37 @@ function processGym(i, item) {
             return true
         }
 
-        if (Store.get('showRaidFilter') === 1) {
-            // showAllRaids
-            if (Store.get('showRaids') && !isValidRaid(item.raid)) {
-                removeGymFromMap(item['gym_id'])
-                return true
-            }
-        } else if (Store.get('showRaidFilter') === 2) {
-            // showActiveRaidsOnly
-            if (!isOngoingRaid(item.raid)) {
-                removeGymFromMap(item['gym_id'])
-                return true
-            }
-        } else if (Store.get('showRaidFilter') === 3) {
-            // showParkRaidsOnly
-            if (!item.park) {
-                removeGymFromMap(item['gym_id'])
-                return true
-            }
-        } else if (Store.get('showRaidFilter') === 4) {
-            // showSponsorRaidsOnly
-            if (!item.sponsor) {
-                removeGymFromMap(item['gym_id'])
-                return true
-            }
-        } else if (Store.get('showRaidFilter') === 5) {
-            // showExRaidsOnly
-            if (!(item.sponsor || item.park)) {
-                removeGymFromMap(item['gym_id'])
-                return true
-            }
-        } else { return false }
+        switch (Store.get('showRaidFilter')) {
+            case 1: // showAllRaids
+                if (!isValidRaid(item.raid)) {
+                    removeGymFromMap(item['gym_id'])
+                    return true
+                }
+                break
+            case 2: // showActiveRaidsOnly
+                if (!isOngoingRaid(item.raid)) {
+                    removeGymFromMap(item['gym_id'])
+                    return true
+                }
+                break
+            case 3: // showParkRaidsOnly
+                if (!(item.park && isValidRaid(item.raid))) {
+                    removeGymFromMap(item['gym_id'])
+                    return true
+                }
+                break
+            case 4: // showSponsorRaidsOnly
+                if (!(item.sponsor && isValidRaid(item.raid))) {
+                    removeGymFromMap(item['gym_id'])
+                    return true
+                }
+                break
+            case 5: // showExRaidsOnly
+                if (!((item.sponsor || item.park) && isValidRaid(item.raid))) {
+                    removeGymFromMap(item['gym_id'])
+                    return true
+                }
+        }
 
         if (raidLevel > Store.get('showRaidMaxLevel') || raidLevel < Store.get('showRaidMinLevel')) {
             removeGymFromMap(item['gym_id'])
@@ -2577,7 +2578,7 @@ $(function () {
     $selectRaidFilter = $('#raid-filter-switch')
 
     $selectRaidFilter.select2({
-        placeholder: 'Raid Views',
+        placeholder: 'Filter Raids',
         minimumResultsForSearch: Infinity
     })
 
@@ -2616,7 +2617,7 @@ $(function () {
     $selectGymFilter = $('#gym-filter-switch')
 
     $selectGymFilter.select2({
-        placeholder: 'Gym Views',
+        placeholder: 'Filter Gyms',
         minimumResultsForSearch: Infinity
     })
 
@@ -2971,7 +2972,7 @@ $(function () {
     }
 
     function resetGymFilter() {
-        Store.set('showGymFilter', 0)
+        Store.set('showGymFilter', 1)
         Store.set('showTeamGymsOnly', 0)
         Store.set('minGymLevel', 0)
         Store.set('maxGymLevel', 6)

--- a/templates/map.html
+++ b/templates/map.html
@@ -84,7 +84,7 @@
                   <option value="2">Active Raids</option>
                   <option value="3">Park Raids</option>
                   <option value="4">Sponsored Raids</option>
-                  <option value="5">Ex-Gym Raids</option>
+                  <option value="5">EX Eligible Raids</option>
                 </select>
               </div>
               <div class="form-control switch-container" id="min-raid-level-only-wrapper">
@@ -140,7 +140,7 @@
                   <option value="2">Open Gyms</option>
                   <option value="3">Park Gyms</option>
                   <option value="4">Sponsored Gyms</option>
-                  <option value="5">Ex-Raid Gyms</option>
+                  <option value="5">EX Raid Gyms</option>
                 </select>
               </div>
               <div class="form-control switch-container" id="team-gyms-only-wrapper">

--- a/templates/map.html
+++ b/templates/map.html
@@ -77,25 +77,15 @@
               </div>
             </div>
             <div id="raids-filter-wrapper" style="display:none">
-              <div class="form-control switch-container" id="raid-active-gym-wrapper">
-                <h3>Show Active Raids only</h3>
-                <div class="onoffswitch">
-                  <input id="raid-active-gym-switch" type="checkbox" name="raid-active-gym-switch" class="onoffswitch-checkbox" checked>
-                  <label class="onoffswitch-label" for="raid-active-gym-switch">
-                  <span class="switch-label" data-on="On" data-off="Off"></span>
-                  <span class="switch-handle"></span>
-                  </label>
-                </div>
-              </div>
-              <div class="form-control switch-container" id="park-active-gym-wrapper">
-                <h3>Show Park Raids only</h3>
-                <div class="onoffswitch">
-                  <input id="raid-park-gym-switch" type="checkbox" name="raid-park-gym-switch" class="onoffswitch-checkbox" checked>
-                  <label class="onoffswitch-label" for="raid-park-gym-switch">
-                  <span class="switch-label" data-on="On" data-off="Off"></span>
-                  <span class="switch-handle"></span>
-                  </label>
-                </div>
+              <div class="form-control switch-container" id="raid-selector-wrapper">
+                <h3>Raid View</h3>
+                <select name="raid-selector-switch" id="raid-selector-switch">
+                  <option value="1">All Raids</option>
+                  <option value="2">Active Raids</option>
+                  <option value="3">Park Raids</option>
+                  <option value="4">Sponsor Raids</option>
+                  <option value="5">Ex-Gym Raids</option>
+                </select>
               </div>
               <div class="form-control switch-container" id="min-raid-level-only-wrapper">
                 <h3>Minimum Raid Level</h3>
@@ -143,6 +133,16 @@
             </div>
               {% endif %}
             <div id="gyms-filter-wrapper" style="display:none">
+              <div class="form-control switch-container" id="gym-selector-wrapper">
+                <h3>Gym View</h3>
+                <select name="gym-selector-switch" id="gym-selector-switch">
+                  <option value="1">All Gyms</option>
+                  <option value="2">Open Gyms</option>
+                  <option value="3">Park Gyms</option>
+                  <option value="4">Sponsor Gyms</option>
+                  <option value="5">Ex-Raid Gyms</option>
+                </select>
+              </div>
               <div class="form-control switch-container" id="team-gyms-only-wrapper">
                 <h3>Team</h3>
                 <select name="team-gyms-filter-switch" id="team-gyms-only-switch">
@@ -151,26 +151,6 @@
                   <option value="2">Valor</option>
                   <option value="3">Instinct</option>
                 </select>
-              </div>
-              <div class="form-control switch-container" id="open-gyms-only-wrapper">
-                <h3>Open Spot</h3>
-                <div class="onoffswitch">
-                  <input id="open-gyms-only-switch" type="checkbox" name="open-gyms-only-switch" class="onoffswitch-checkbox" checked>
-                  <label class="onoffswitch-label" for="open-gyms-only-switch">
-                  <span class="switch-label" data-on="On" data-off="Off"></span>
-                  <span class="switch-handle"></span>
-                  </label>
-                </div>
-              </div>
-              <div class="form-control switch-container" id="park-gyms-only-wrapper">
-                <h3>Park Gyms Only</h3>
-                <div class="onoffswitch">
-                  <input id="park-gyms-only-switch" type="checkbox" name="park-gyms-only-switch" class="onoffswitch-checkbox" checked>
-                  <label class="onoffswitch-label" for="park-gyms-only-switch">
-                  <span class="switch-label" data-on="On" data-off="Off"></span>
-                  <span class="switch-handle"></span>
-                  </label>
-                </div>
               </div>
               <div class="form-control switch-container" id="min-level-gyms-filter-wrapper">
                 <h3>Minimum Level</h3>

--- a/templates/map.html
+++ b/templates/map.html
@@ -80,11 +80,11 @@
               <div class="form-control switch-container" id="raid-filter-wrapper">
                 <h3>Filter Raids</h3>
                 <select name="raid-filter-switch" id="raid-filter-switch">
-                  <option value="1">All Raids</option>
-                  <option value="2">Active Raids</option>
-                  <option value="3">Park Raids</option>
-                  <option value="4">Sponsored Raids</option>
-                  <option value="5">EX-eligible Raids</option>
+                  <option value="0">All Raids</option>
+                  <option value="1">Active Raids</option>
+                  <option value="2">Park Raids</option>
+                  <option value="3">Sponsored Raids</option>
+                  <option value="4">EX-eligible Raids</option>
                 </select>
               </div>
               <div class="form-control switch-container" id="min-raid-level-only-wrapper">
@@ -136,11 +136,11 @@
               <div class="form-control switch-container" id="gym-filter-wrapper">
                 <h3>Filter Gyms</h3>
                 <select name="gym-filter-switch" id="gym-filter-switch">
-                  <option value="1">All Gyms</option>
-                  <option value="2">Open Gyms</option>
-                  <option value="3">Park Gyms</option>
-                  <option value="4">Sponsored Gyms</option>
-                  <option value="5">EX Raid Gyms</option>
+                  <option value="0">All Gyms</option>
+                  <option value="1">Open Gyms</option>
+                  <option value="2">Park Gyms</option>
+                  <option value="3">Sponsored Gyms</option>
+                  <option value="4">EX Raid Gyms</option>
                 </select>
               </div>
               <div class="form-control switch-container" id="team-gyms-only-wrapper">

--- a/templates/map.html
+++ b/templates/map.html
@@ -84,7 +84,7 @@
                   <option value="2">Active Raids</option>
                   <option value="3">Park Raids</option>
                   <option value="4">Sponsored Raids</option>
-                  <option value="5">EX Eligible Raids</option>
+                  <option value="5">EX-eligible Raids</option>
                 </select>
               </div>
               <div class="form-control switch-container" id="min-raid-level-only-wrapper">

--- a/templates/map.html
+++ b/templates/map.html
@@ -78,12 +78,12 @@
             </div>
             <div id="raids-filter-wrapper" style="display:none">
               <div class="form-control switch-container" id="raid-selector-wrapper">
-                <h3>Raid View</h3>
+                <h3>Filter Raids</h3>
                 <select name="raid-selector-switch" id="raid-selector-switch">
                   <option value="1">All Raids</option>
                   <option value="2">Active Raids</option>
                   <option value="3">Park Raids</option>
-                  <option value="4">Sponsor Raids</option>
+                  <option value="4">Sponsored Raids</option>
                   <option value="5">Ex-Gym Raids</option>
                 </select>
               </div>
@@ -134,12 +134,12 @@
               {% endif %}
             <div id="gyms-filter-wrapper" style="display:none">
               <div class="form-control switch-container" id="gym-selector-wrapper">
-                <h3>Gym View</h3>
+                <h3>Filter Gyms</h3>
                 <select name="gym-selector-switch" id="gym-selector-switch">
                   <option value="1">All Gyms</option>
                   <option value="2">Open Gyms</option>
                   <option value="3">Park Gyms</option>
-                  <option value="4">Sponsor Gyms</option>
+                  <option value="4">Sponsored Gyms</option>
                   <option value="5">Ex-Raid Gyms</option>
                 </select>
               </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -77,9 +77,9 @@
               </div>
             </div>
             <div id="raids-filter-wrapper" style="display:none">
-              <div class="form-control switch-container" id="raid-selector-wrapper">
+              <div class="form-control switch-container" id="raid-filter-wrapper">
                 <h3>Filter Raids</h3>
-                <select name="raid-selector-switch" id="raid-selector-switch">
+                <select name="raid-filter-switch" id="raid-filter-switch">
                   <option value="1">All Raids</option>
                   <option value="2">Active Raids</option>
                   <option value="3">Park Raids</option>
@@ -133,9 +133,9 @@
             </div>
               {% endif %}
             <div id="gyms-filter-wrapper" style="display:none">
-              <div class="form-control switch-container" id="gym-selector-wrapper">
+              <div class="form-control switch-container" id="gym-filter-wrapper">
                 <h3>Filter Gyms</h3>
-                <select name="gym-selector-switch" id="gym-selector-switch">
+                <select name="gym-filter-switch" id="gym-filter-switch">
                   <option value="1">All Gyms</option>
                   <option value="2">Open Gyms</option>
                   <option value="3">Park Gyms</option>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the front-end work necessary to complete the Sponsor ID field data gathered under #2528.  This PR needs a lot of work as it currently doesn't fully operate; however, some of that may be due to the way Gyms & Raids are selected as it has been proven that there is some disconnect in how the selection of Gyms vs Raids functions. 

## Motivation and Context
This completes Sponsor ID by allowing the user to select visible Gyms & Raids based on whether a gym is a sponsored gym.  This also combines Sponsored & Parks into a single "EX" gym selector. 

## How Has This Been Tested?
This has been tested locally on a dev environment

## Screenshots (if appropriate):
### With Sponsor Gyms Only On
![image](https://user-images.githubusercontent.com/3013565/37247583-5267c9e2-248b-11e8-8b25-58d4d16abd80.png)


### With All Gyms
![image](https://user-images.githubusercontent.com/3013565/37247579-3badef1a-248b-11e8-8b97-65c75c153c81.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
